### PR TITLE
feat: Implement Sheet Input for Name and Skills.

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ export default tseslint.config(
             'rollup.config.js',
             'commitlint.config.js',
             'lint-staged-config.mjs',
+            'scripts/',
         ],
     },
     eslint.configs.recommended,
@@ -26,6 +27,7 @@ export default tseslint.config(
             parserOptions: {
                 projectService: true,
                 tsconfigRootDir: import.meta.dirname,
+                allowDefaultProject: ['*.js'],
             },
         },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,4 +48,31 @@ Hooks.once('init', () => {
     // @league-of-foundry-developers/foundry-vtt-types/src/foundry/client-esm/dice/terms/term.d.mts
     // @ts-expect-error see note
     CONFIG.Dice.rolls.push(dice.D20Roll);
+
+    //HandleBars Helper Registration
+    Handlebars.registerHelper(
+        'times',
+        (count: unknown, options: Handlebars.HelperOptions): string =>
+            [...Array(Number(count) || 0).keys()]
+                .map((i) =>
+                    options.fn(i, {
+                        data: options.data as unknown,
+                        blockParams: [i],
+                    }),
+                )
+                .join(''),
+    );
+
+    Handlebars.registerHelper('add', function (thing1, thing2): number {
+        return thing1 + thing2;
+    });
+    Handlebars.registerHelper('sub', function (thing1, thing2): number {
+        return thing1 - thing2;
+    });
+    Handlebars.registerHelper('multi', function (thing1, thing2): number {
+        return thing1 * thing2;
+    });
+    Handlebars.registerHelper('divide', function (thing1, thing2): number {
+        return thing1 / thing2;
+    });
 });

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -112,6 +112,8 @@
                 "Investiture": "Investiture"
             },
             "Skill": {
+                "label": "Skill",
+                "label_p": "Skills",
                 "Agility": "Agility",
                 "Athletics": "Athletics",
                 "HeavyWeapons": "Heavy Weapons",

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -27,3 +27,15 @@
 .rollable {
     cursor: pointer;
 }
+
+a.skill-pips {
+    display: flex;
+    flex-direction: row;
+    gap: var(--space-2);
+
+    .pips {
+        display: flex;
+        gap: var(--space-1);
+        justify-content: center;
+    }
+}

--- a/src/system/applications/actor/base-sheet.ts
+++ b/src/system/applications/actor/base-sheet.ts
@@ -30,10 +30,41 @@ export class BaseSheet extends ActorSheet {
                 'click',
                 this.onRollSkillTest.bind(this),
             );
+
+            html.find('a[data-action=adjust-skill-rank]').on(
+                'click',
+                this.onAdjustSkillRank.bind(this),
+            );
+
+            html.find('a[data-action=adjust-skill-rank]').on(
+                'contextmenu',
+                this.onAdjustSkillRank.bind(this),
+            );
+
+            html.find('.attribute .value').on(
+                'change',
+                this.onAttrUpdate.bind(this),
+            );
         }
     }
 
     /* --- Internal functions --- */
+
+    private onAdjustSkillRank(event: Event) {
+        event.preventDefault();
+
+        const incrementBool: boolean = event.type === 'click' ? true : false;
+
+        const skillId = $(event.currentTarget!)
+            .closest('[data-id]')
+            .data('id') as Skill;
+        void this.actor.modifySkillRank(skillId, incrementBool);
+    }
+
+    private onAttrUpdate(event: Event) {
+        event.preventDefault();
+        // TODO: Implement Derived Data Updating
+    }
 
     private onRollSkillTest(event: Event) {
         event.preventDefault();

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -191,13 +191,16 @@ const COSMERE: CosmereRPGConfig = {
 
     resources: {
         [Resource.Health]: {
+            key: Resource.Health,
             label: 'COSMERE.Actor.Resource.Health',
             deflect: true,
         },
         [Resource.Focus]: {
+            key: Resource.Health,
             label: 'COSMERE.Actor.Resource.Focus',
         },
         [Resource.Investiture]: {
+            key: Resource.Health,
             label: 'COSMERE.Actor.Resource.Investiture',
         },
     },

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -127,16 +127,19 @@ const COSMERE: CosmereRPGConfig = {
 
     attributeGroups: {
         [AttributeGroup.Physical]: {
+            key: AttributeGroup.Physical,
             label: 'COSMERE.AttributeGroup.Physical.long',
             attributes: [Attribute.Strength, Attribute.Speed],
             resource: Resource.Health,
         },
         [AttributeGroup.Cognitive]: {
+            key: AttributeGroup.Cognitive,
             label: 'COSMERE.AttributeGroup.Cognitive.long',
             attributes: [Attribute.Intellect, Attribute.Willpower],
             resource: Resource.Focus,
         },
         [AttributeGroup.Spiritual]: {
+            key: AttributeGroup.Spiritual,
             label: 'COSMERE.AttributeGroup.Spiritual.long',
             attributes: [Attribute.Awareness, Attribute.Presence],
             resource: Resource.Investiture,
@@ -145,10 +148,12 @@ const COSMERE: CosmereRPGConfig = {
 
     attributes: {
         [Attribute.Strength]: {
+            key: Attribute.Strength,
             label: 'COSMERE.Actor.Attribute.Strength.long',
             skills: [Skill.Athletics, Skill.HeavyWeapons],
         },
         [Attribute.Speed]: {
+            key: Attribute.Speed,
             label: 'COSMERE.Actor.Attribute.Speed.long',
             skills: [
                 Skill.Agility,
@@ -158,6 +163,7 @@ const COSMERE: CosmereRPGConfig = {
             ],
         },
         [Attribute.Intellect]: {
+            key: Attribute.Intellect,
             label: 'COSMERE.Actor.Attribute.Intellect.long',
             skills: [
                 Skill.Crafting,
@@ -167,14 +173,17 @@ const COSMERE: CosmereRPGConfig = {
             ],
         },
         [Attribute.Willpower]: {
+            key: Attribute.Willpower,
             label: 'COSMERE.Actor.Attribute.Willpower.long',
             skills: [Skill.Discipline, Skill.Intimidation],
         },
         [Attribute.Awareness]: {
+            key: Attribute.Awareness,
             label: 'COSMERE.Actor.Attribute.Awareness.long',
             skills: [Skill.Insight, Skill.Perception, Skill.Survival],
         },
         [Attribute.Presence]: {
+            key: Attribute.Presence,
             label: 'COSMERE.Actor.Attribute.Presence.long',
             skills: [Skill.Deception, Skill.Leadership, Skill.Persuasion],
         },
@@ -195,93 +204,111 @@ const COSMERE: CosmereRPGConfig = {
 
     skills: {
         [Skill.Agility]: {
+            key: Skill.Agility,
             label: 'COSMERE.Actor.Skill.Agility',
             attribute: Attribute.Speed,
             attrLabel: 'COSMERE.Actor.Attribute.Speed.short',
         },
         [Skill.Athletics]: {
+            key: Skill.Athletics,
             label: 'COSMERE.Actor.Skill.Athletics',
             attribute: Attribute.Strength,
             attrLabel: 'COSMERE.Actor.Attribute.Strength.short',
         },
         [Skill.HeavyWeapons]: {
+            key: Skill.HeavyWeapons,
             label: 'COSMERE.Actor.Skill.HeavyWeapons',
             attribute: Attribute.Strength,
             attrLabel: 'COSMERE.Actor.Attribute.Strength.short',
         },
         [Skill.LightWeapons]: {
+            key: Skill.LightWeapons,
             label: 'COSMERE.Actor.Skill.LightWeapons',
             attribute: Attribute.Speed,
             attrLabel: 'COSMERE.Actor.Attribute.Speed.short',
         },
         [Skill.Stealth]: {
+            key: Skill.Stealth,
             label: 'COSMERE.Actor.Skill.Stealth',
             attribute: Attribute.Speed,
             attrLabel: 'COSMERE.Actor.Attribute.Speed.short',
         },
         [Skill.Thievery]: {
+            key: Skill.Thievery,
             label: 'COSMERE.Actor.Skill.Thievery',
             attribute: Attribute.Speed,
             attrLabel: 'COSMERE.Actor.Attribute.Speed.short',
         },
 
         [Skill.Crafting]: {
+            key: Skill.Crafting,
             label: 'COSMERE.Actor.Skill.Crafting',
             attribute: Attribute.Intellect,
             attrLabel: 'COSMERE.Actor.Attribute.Intellect.short',
         },
         [Skill.Deduction]: {
+            key: Skill.Deduction,
             label: 'COSMERE.Actor.Skill.Deduction',
             attribute: Attribute.Intellect,
             attrLabel: 'COSMERE.Actor.Attribute.Intellect.short',
         },
         [Skill.Discipline]: {
+            key: Skill.Discipline,
             label: 'COSMERE.Actor.Skill.Discipline',
             attribute: Attribute.Willpower,
             attrLabel: 'COSMERE.Actor.Attribute.Willpower.short',
         },
         [Skill.Intimidation]: {
+            key: Skill.Intimidation,
             label: 'COSMERE.Actor.Skill.Intimidation',
             attribute: Attribute.Willpower,
             attrLabel: 'COSMERE.Actor.Attribute.Willpower.short',
         },
         [Skill.Lore]: {
+            key: Skill.Lore,
             label: 'COSMERE.Actor.Skill.Lore',
             attribute: Attribute.Intellect,
             attrLabel: 'COSMERE.Actor.Attribute.Intellect.short',
         },
         [Skill.Medicine]: {
+            key: Skill.Medicine,
             label: 'COSMERE.Actor.Skill.Medicine',
             attribute: Attribute.Intellect,
             attrLabel: 'COSMERE.Actor.Attribute.Intellect.short',
         },
 
         [Skill.Deception]: {
+            key: Skill.Deception,
             label: 'COSMERE.Actor.Skill.Deception',
             attribute: Attribute.Presence,
             attrLabel: 'COSMERE.Actor.Attribute.Presence.short',
         },
         [Skill.Insight]: {
+            key: Skill.Insight,
             label: 'COSMERE.Actor.Skill.Insight',
             attribute: Attribute.Awareness,
             attrLabel: 'COSMERE.Actor.Attribute.Awareness.short',
         },
         [Skill.Leadership]: {
+            key: Skill.Leadership,
             label: 'COSMERE.Actor.Skill.Leadership',
             attribute: Attribute.Presence,
             attrLabel: 'COSMERE.Actor.Attribute.Presence.short',
         },
         [Skill.Perception]: {
+            key: Skill.Perception,
             label: 'COSMERE.Actor.Skill.Perception',
             attribute: Attribute.Awareness,
             attrLabel: 'COSMERE.Actor.Attribute.Awareness.short',
         },
         [Skill.Persuasion]: {
+            key: Skill.Persuasion,
             label: 'COSMERE.Actor.Skill.Persuasion',
             attribute: Attribute.Presence,
             attrLabel: 'COSMERE.Actor.Attribute.Presence.short',
         },
         [Skill.Survival]: {
+            key: Skill.Survival,
             label: 'COSMERE.Actor.Skill.Survival',
             attribute: Attribute.Awareness,
             attrLabel: 'COSMERE.Actor.Attribute.Awareness.short',
@@ -292,7 +319,7 @@ const COSMERE: CosmereRPGConfig = {
         activation: {
             types: {
                 [ActivationType.SkillTest]: {
-                    label: 'COSMERE.GENERIC.SkillTest',
+                    label: 'GENERIC.SkillTest',
                 },
             },
             consumeTypes: {

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -93,6 +93,19 @@ export class CosmereActor<
     }
 
     /**
+     *  Utility function to increment/decrement a skill value
+     */
+    public modifySkillRank(skillId: Skill, incrementBool = true) {
+        const skillpath = `system.skills.${skillId}.rank`;
+        const skill = this.system.skills[skillId];
+        if (incrementBool) {
+            this.update({ [skillpath]: Math.clamp(skill.rank + 1, 0, 5) });
+        } else {
+            this.update({ [skillpath]: Math.clamp(skill.rank - 1, 0, 5) });
+        }
+    }
+
+    /**
      * Utility function to use an item for this actor
      */
     public async useItem(

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -99,9 +99,9 @@ export class CosmereActor<
         const skillpath = `system.skills.${skillId}.rank`;
         const skill = this.system.skills[skillId];
         if (incrementBool) {
-            this.update({ [skillpath]: Math.clamp(skill.rank + 1, 0, 5) });
+            void this.update({ [skillpath]: Math.clamp(skill.rank + 1, 0, 5) });
         } else {
-            this.update({ [skillpath]: Math.clamp(skill.rank - 1, 0, 5) });
+            void this.update({ [skillpath]: Math.clamp(skill.rank - 1, 0, 5) });
         }
     }
 

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -42,17 +42,20 @@ export interface InjuryConfig {
 }
 
 export interface AttributeGroupConfig {
+    key: string;
     label: string;
     attributes: [Attribute, Attribute];
     resource: Resource;
 }
 
 export interface AttributeConfig {
+    key: string;
     label: string;
     skills: Skill[];
 }
 
 export interface SkillConfig {
+    key: string;
     label: string;
     attribute: Attribute;
     attrLabel: string;

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -63,6 +63,7 @@ export interface SkillConfig {
 }
 
 export interface ResourceConfig {
+    key: string;
     label: string;
     deflect?: boolean;
 }

--- a/src/templates/actors/character-sheet.hbs
+++ b/src/templates/actors/character-sheet.hbs
@@ -1,17 +1,25 @@
 <form class="sheet actor character" autocomplete="off">
+    {{log actor}}
     <header class="sheet-header">
         <img class="profile" src="{{actor.img}}" data-tooltip="{{actor.name}}" data-edit="img" />
         <section class="header-details flexcol">
-            <h1 class="document-name">{{actor.name}}</h1>
+            <h1 class="document-name">
+                <input class="document-name" name="name" value="{{actor.name}}" />
+            </h1>
             <section>
-                <span class="ancestry">{{ localize ancestryLabel }}</span>
-                <span class="paths">{{ localize pathsLabel }}</span>
+                <span class="ancestry">
+                    {{ localize ancestryLabel }}
+                </span>
+                <span class="paths">
+                    {{ localize pathsLabel }}
+                </span>
             </section>
         </section>
     </header>
-
+    <hr />
     <section class="sheet-body">
         <section class="attribute-groups flexrow">
+
             {{#each attributeGroups as |attrGroup|}}
 
             <section class="attribute-group" data-id="{{attrGroup.id}}">
@@ -22,8 +30,17 @@
                 <section class="attributes flexrow">
                     {{#with attrGroup.attributes.[0] as |attribute|}}
                     <div class="attribute flexcol" data-id="{{attribute.id}}">
-                        <span class="box-title">{{ localize attribute.config.label }}</span>
-                        <span class="value">{{attribute.value}}</span>
+                        <span class="box-title">
+                            {{ localize attribute.config.label }}
+                        </span>
+                        <span class="value">
+                            <input 
+                                class="value" 
+                                size="2" 
+                                name="system.attributes.{{attribute.config.key}}.value" 
+                                value="{{attribute.value}}" 
+                            />
+                        </span>
                     </div>
                     {{/with}}
 
@@ -31,15 +48,24 @@
                     <div class="defense">
                         <span class="box-title">{{ localize "COSMERE.Actor.Statistics.Defense"}}</span>
                         <div class="defense-box">
-                            <span class="value">{{derived defense.value }}</span>
+                            <span class="value">{{ derived defense.value }}</span>
                         </div>
                     </div>
                     {{/with}}
 
                     {{#with attrGroup.attributes.[1] as |attribute|}}
                     <div class="attribute flexcol" data-id="{{attribute.id}}">
-                        <span class="box-title">{{ localize attribute.config.label }}</span>
-                        <span class="value">{{attribute.value}}</span>
+                        <span class="box-title">
+                            {{ localize attribute.config.label }}
+                        </span>
+                        <span class="value">
+                            <input 
+                                class="value" 
+                                size="2" 
+                                name="system.attributes.{{attribute.config.key}}.value" 
+                                value="{{attribute.value}}" 
+                            />
+                        </span>
                     </div>
                     {{/with}}
                 </section>
@@ -59,47 +85,34 @@
                         </div>
                         {{/if}}
                     </div>
-                    {{/with}}
+                    {{/with}} 
                 </section>
 
                 {{!-- Skills --}}
                 <section class="skills">
                     <ul class="skill-list">
                         {{#each attrGroup.skills as |skill|}}
+                            {{#if skill.active}}
+                                <li class="skill" data-id="{{skill.id}}">
+                                    <div class="mod-box rollable">
+                                        <span class="mod">+{{derived skill.mod }}</span>
+                                    </div>
 
-                        {{#if skill.active}}
-
-                        <li class="skill" data-id="{{skill.id}}">
-                            <div class="mod-box rollable">
-                                <span class="mod">+{{derived skill.mod }}</span>
-                            </div>
-
-                            <div class="label rollable">
-                                <span>{{ localize skill.config.label }}</span>
-                                <span style="text-transform: uppercase">({{ localize skill.config.attrLabel }})</span>
-                            </div>
-
-                            <ul class="ranks flexrow">
-                                <li>
-                                    <input type="checkbox" onclick="return false;" {{#if (greaterThan skill.rank 1 true)}}checked{{/if}}>
+                                    <div class="label rollable">
+                                        <span>{{ localize skill.config.label }}</span>
+                                        <span style="text-transform: uppercase">({{ localize skill.config.attrLabel }})</span>
+                                    </div>
+                                    <div class="skill-pips ranks">
+                                        <ul class="pip-skills">
+                                            <a data-action="adjust-skill-rank" data-id="{{skill.id}}" data-tooltip="Left Click to increase {{localize skill.config.label}}'s Rank<br>Right Click to decrease {{localize skill.config.label}}'s Rank">
+                                                {{#times skill.rank}}<li class="fa-solid fa-dot-circle"></li>{{/times}}
+                                                {{#times (sub 5 skill.rank)}}<li class="fa-regular fa-circle"></li>{{/times}}
+                                            </a>
+                                        </ul>
+                                    </div>
                                 </li>
-                                <li>
-                                    <input type="checkbox" onclick="return false;" {{#if (greaterThan skill.rank 2 true)}}checked{{/if}}>
-                                </li>
-                                <li>
-                                    <input type="checkbox" onclick="return false;" {{#if (greaterThan skill.rank 3 true)}}checked{{/if}}>
-                                </li>
-                                <li>
-                                    <input type="checkbox" onclick="return false;" {{#if (greaterThan skill.rank 4 true)}}checked{{/if}}>
-                                </li>
-                                <li>
-                                    <input type="checkbox" onclick="return false;" {{#if (greaterThan skill.rank 5 true)}}checked{{/if}}>
-                                </li>
-                            </ul>
-                        </li>
 
-                        {{/if}}
-
+                            {{/if}}
                         {{/each}}
                     </ul>
                 </section>

--- a/src/templates/actors/character-sheet.hbs
+++ b/src/templates/actors/character-sheet.hbs
@@ -8,7 +8,7 @@
                     ROLEPLAYING GAME<br />
                 </section>
                 <section>
-                    <input name="system.character.player" value="" placeholder="Player Name(WIP)" />
+                    <input name="system.character.player" value="" placeholder="Player Name(WIP)" disabled/>
                 </section>
             </section>
             <section class="header-details flexcol grid-span2">
@@ -18,15 +18,15 @@
                             <input class="document-name value" name="name" value="{{actor.name}}" />
                         </span>
                         <span>
-                           <input class="value" name="system.level" value="{{level}}" placeholder="Level(WIP)" /> 
+                           <input class="value" name="system.level" value="{{level}}" placeholder="Level(WIP)" disabled/> 
                         </span>
                     </section>
                     <section class="flexrow">
                         <span class="ancestry">
-                            <input class="value"  name="system.character.ancestry" value="{{ localize ancestryLabel }}" placeholder="Ancestry (WIP)" />
+                            <input class="value"  name="system.character.ancestry" value="{{ localize ancestryLabel }}" placeholder="Ancestry (WIP)" disabled/>
                         </span>
                         <span class="paths">
-                            <input class="value" name="system.character.paths" value="{{ localize pathsLabel }}" placeholder="Ancestry (WIP)" />
+                            <input class="value" name="system.character.paths" value="{{ localize pathsLabel }}" placeholder="Ancestry (WIP)" disabled/>
                         </span>
                     </section>
                     
@@ -53,8 +53,11 @@
                             </span>
                             <span class="value">
                                 <input 
+                                    type="number"
                                     class="value" 
-                                    size="2" 
+                                    min="0"
+                                    max="5"
+                                    step="1"
                                     name="system.attributes.{{attribute.config.key}}.value" 
                                     value="{{attribute.value}}" 
                                 />
@@ -78,8 +81,11 @@
                             </span>
                             <span class="value">
                                 <input 
+                                    type="number"
                                     class="value" 
-                                    size="2" 
+                                    min="0"
+                                    max="5"
+                                    step="1"
                                     name="system.attributes.{{attribute.config.key}}.value" 
                                     value="{{attribute.value}}" 
                                 />
@@ -97,16 +103,21 @@
         <div class="skills flexcol" data-group="primary" data-tab="skills">
             <section class="attribute-groups flexrow">
                 {{#each attributeGroups as |attrGroup|}}
-                    {{!-- Resource --}}
+                    
                     <section class="attribute-groups flexcol">
                    
-                        {{!-- Skills --}}
+                        
                         <section class="skills flexcol">
+                            {{!-- Resource --}}
                             {{#with attrGroup.resource as |resource|}}
                                 <div class="resource flexrow" data-id="{{resource.id}}">
                                     <div class="flexcol">
-                                        <span class="label">{{ localize resource.config.label}}</span>
-                                        <span class="value">{{resource.value}} / {{resource.max.value}}</span>
+                                        <span class="label">
+                                            {{ localize resource.config.label}}
+                                        </span>
+                                        <span class="value">
+                                            {{resource.value}} / {{resource.max.value}}
+                                        </span>
                                     </div>
                                     {{#if resource.deflect includeZero=true}}
                                         <div class="deflect flexcol">
@@ -116,6 +127,7 @@
                                     {{/if}}
                                 </div>
                             {{/with}} 
+                            {{!-- Skills --}}
                             <ul class="skill-list">
                                 {{#each attrGroup.skills as |skill|}}
                                     {{#if skill.active}}

--- a/src/templates/actors/character-sheet.hbs
+++ b/src/templates/actors/character-sheet.hbs
@@ -1,160 +1,154 @@
 <form class="sheet actor character" autocomplete="off">
     {{log actor}}
-    <header class="sheet-header">
-        <img class="profile" src="{{actor.img}}" data-tooltip="{{actor.name}}" data-edit="img" />
-        <section class="header-details flexcol">
-            <h1 class="document-name">
-                <input class="document-name" name="name" value="{{actor.name}}" />
-            </h1>
-            <section>
-                <span class="ancestry">
-                    {{ localize ancestryLabel }}
-                </span>
-                <span class="paths">
-                    {{ localize pathsLabel }}
-                </span>
+    <header class="sheet-header flexrow">
+        <section class="flexrow">
+            <section class="header-details flexcol">
+                <section class="flex-group-left">
+                    COSMERE <br />
+                    ROLEPLAYING GAME<br />
+                </section>
+                <section>
+                    <input name="system.character.player" value="" placeholder="Player Name(WIP)" />
+                </section>
+            </section>
+            <section class="header-details flexcol grid-span2">
+                <h1 class="document-name flexcol">
+                    <section class="flexrow">
+                        <span>
+                            <input class="document-name value" name="name" value="{{actor.name}}" />
+                        </span>
+                        <span>
+                           <input class="value" name="system.level" value="{{level}}" placeholder="Level(WIP)" /> 
+                        </span>
+                    </section>
+                    <section class="flexrow">
+                        <span class="ancestry">
+                            <input class="value"  name="system.character.ancestry" value="{{ localize ancestryLabel }}" placeholder="Ancestry (WIP)" />
+                        </span>
+                        <span class="paths">
+                            <input class="value" name="system.character.paths" value="{{ localize pathsLabel }}" placeholder="Ancestry (WIP)" />
+                        </span>
+                    </section>
+                    
+                </h1>
             </section>
         </section>
     </header>
+
     <hr />
-    <section class="sheet-body">
-        <section class="attribute-groups flexrow">
-
-            {{#each attributeGroups as |attrGroup|}}
-
+    <section class="attribute-groups flexrow">
+        {{#each attributeGroups as |attrGroup|}}
             <section class="attribute-group" data-id="{{attrGroup.id}}">
                 {{!-- Header --}}
-                <span class="label">{{ localize attrGroup.config.label }}</span>
+                <span class="label">
+                    {{ localize attrGroup.config.label }}
+                </span>
 
                 {{!-- Attributes and defense --}}
                 <section class="attributes flexrow">
                     {{#with attrGroup.attributes.[0] as |attribute|}}
-                    <div class="attribute flexcol" data-id="{{attribute.id}}">
-                        <span class="box-title">
-                            {{ localize attribute.config.label }}
-                        </span>
-                        <span class="value">
-                            <input 
-                                class="value" 
-                                size="2" 
-                                name="system.attributes.{{attribute.config.key}}.value" 
-                                value="{{attribute.value}}" 
-                            />
-                        </span>
-                    </div>
+                        <div class="attribute flexcol" data-id="{{attribute.id}}">
+                            <span class="box-title">
+                                {{ localize attribute.config.label }}
+                            </span>
+                            <span class="value">
+                                <input 
+                                    class="value" 
+                                    size="2" 
+                                    name="system.attributes.{{attribute.config.key}}.value" 
+                                    value="{{attribute.value}}" 
+                                />
+                            </span>
+                        </div>
                     {{/with}}
 
                     {{#with attrGroup.defense as |defense|}}
-                    <div class="defense">
-                        <span class="box-title">{{ localize "COSMERE.Actor.Statistics.Defense"}}</span>
-                        <div class="defense-box">
-                            <span class="value">{{ derived defense.value }}</span>
+                        <div class="defense">
+                            <span class="box-title">{{ localize "COSMERE.Actor.Statistics.Defense"}}</span>
+                            <div class="defense-box">
+                                <span class="value">{{ derived defense.value }}</span>
+                            </div>
                         </div>
-                    </div>
                     {{/with}}
 
                     {{#with attrGroup.attributes.[1] as |attribute|}}
-                    <div class="attribute flexcol" data-id="{{attribute.id}}">
-                        <span class="box-title">
-                            {{ localize attribute.config.label }}
-                        </span>
-                        <span class="value">
-                            <input 
-                                class="value" 
-                                size="2" 
-                                name="system.attributes.{{attribute.config.key}}.value" 
-                                value="{{attribute.value}}" 
-                            />
-                        </span>
-                    </div>
+                        <div class="attribute flexcol" data-id="{{attribute.id}}">
+                            <span class="box-title">
+                                {{ localize attribute.config.label }}
+                            </span>
+                            <span class="value">
+                                <input 
+                                    class="value" 
+                                    size="2" 
+                                    name="system.attributes.{{attribute.config.key}}.value" 
+                                    value="{{attribute.value}}" 
+                                />
+                            </span>
+                        </div>
                     {{/with}}
                 </section>
-
-                {{!-- Resource --}}
-                <section class="resources flexrow">
-                    {{#with attrGroup.resource as |resource|}}
-                    <div class="resource flexrow" data-id="{{resource.id}}">
-                        <div class="flexcol">
-                            <span class="label">{{ localize resource.config.label}}</span>
-                            <span class="value">{{resource.value}} / {{resource.max.value}}</span>
-                        </div>
-                        {{#if resource.deflect includeZero=true}}
-                        <div class="deflect flexcol">
-                            <span class="label">{{ localize "COSMERE.Actor.Statistics.Deflect"}}</span>
-                            <span class="value">{{ resource.deflect.value }}</span>
-                        </div>
-                        {{/if}}
-                    </div>
-                    {{/with}} 
-                </section>
-
-                {{!-- Skills --}}
-                <section class="skills">
-                    <ul class="skill-list">
-                        {{#each attrGroup.skills as |skill|}}
-                            {{#if skill.active}}
-                                <li class="skill" data-id="{{skill.id}}">
-                                    <div class="mod-box rollable">
-                                        <span class="mod">+{{derived skill.mod }}</span>
-                                    </div>
-
-                                    <div class="label rollable">
-                                        <span>{{ localize skill.config.label }}</span>
-                                        <span style="text-transform: uppercase">({{ localize skill.config.attrLabel }})</span>
-                                    </div>
-                                    <div class="skill-pips ranks">
-                                        <ul class="pip-skills">
-                                            <a data-action="adjust-skill-rank" data-id="{{skill.id}}" data-tooltip="Left Click to increase {{localize skill.config.label}}'s Rank<br>Right Click to decrease {{localize skill.config.label}}'s Rank">
-                                                {{#times skill.rank}}<li class="fa-solid fa-dot-circle"></li>{{/times}}
-                                                {{#times (sub 5 skill.rank)}}<li class="fa-regular fa-circle"></li>{{/times}}
-                                            </a>
-                                        </ul>
-                                    </div>
-                                </li>
-
-                            {{/if}}
-                        {{/each}}
-                    </ul>
-                </section>
-
-                {{#if (eq attrGroup.id 'phy')}}
-                {{!-- Remaining physical traits --}}
-                <section class="flexrow">
-                    <div class="derived-attribute flexcol">
-                        <span class="label">{{ localize "COSMERE.Actor.Statistics.MovementRate"}}</span>
-                        <span class="value">{{derived ../actor.system.movement.rate}} ft.</span>
-                    </div>
-                    <div class="derived-attribute flexcol">
-                        <span class="label">{{ localize "COSMERE.Actor.Statistics.RecoveryDie"}}</span>
-                        <span class="value">{{derived ../actor.system.recovery.die}}</span>
-                    </div>
-                    <div class="derived-attribute flexcol">
-                        <span class="label">{{ localize "COSMERE.Actor.Statistics.SensesRange"}}</span>
-                        <span class="value">
-                            {{#if (derived ../actor.system.senses.obscuredAffected)}}
-                                {{derived ../actor.system.senses.range}} ft.
-                            {{else}}
-                                {{ localize "COSMERE.Actor.Statistics.NoObscuredSense"}}
-                            {{/if}}
-                        </span>
-                    </div>
-                </section>
-                {{/if}}
-
-                {{#if (eq attrGroup.id 'spi')}}
-                {{!-- Expertises --}}
-                <section class="expertises flexcol">
-                    <span class="label">{{ localize "COSMERE.Actor.Character.Expertise.name"}}</span>
-                    <p class="list-value">
-                        {{expertisesList ../actor '-'}}
-                    </p>
-                </section>
-                {{/if}}
             </section>
+        {{/each}}
+    </section>
 
-            {{/each}}
-        </section>
 
+    <section class="sheet-body">
+        
+        <div class="skills flexcol" data-group="primary" data-tab="skills">
+            <section class="attribute-groups flexrow">
+                {{#each attributeGroups as |attrGroup|}}
+                    {{!-- Resource --}}
+                    <section class="attribute-groups flexcol">
+                   
+                        {{!-- Skills --}}
+                        <section class="skills flexcol">
+                            {{#with attrGroup.resource as |resource|}}
+                                <div class="resource flexrow" data-id="{{resource.id}}">
+                                    <div class="flexcol">
+                                        <span class="label">{{ localize resource.config.label}}</span>
+                                        <span class="value">{{resource.value}} / {{resource.max.value}}</span>
+                                    </div>
+                                    {{#if resource.deflect includeZero=true}}
+                                        <div class="deflect flexcol">
+                                            <span class="label">{{ localize "COSMERE.Actor.Statistics.Deflect"}}</span>
+                                            <span class="value">{{ resource.deflect.value }}</span>
+                                        </div>
+                                    {{/if}}
+                                </div>
+                            {{/with}} 
+                            <ul class="skill-list">
+                                {{#each attrGroup.skills as |skill|}}
+                                    {{#if skill.active}}
+                                        <li class="skill" data-id="{{skill.id}}">
+                                            <div class="mod-box rollable">
+                                                <span class="mod">+{{derived skill.mod }}</span>
+                                            </div>
 
+                                            <div class="label rollable">
+                                                <span>{{ localize skill.config.label }}</span>
+                                                <span style="text-transform: uppercase">({{ localize skill.config.attrLabel }})</span>
+                                            </div>
+                                            <div class="skill-pips ranks">
+                                                <ul class="pip-skills">
+                                                    <a data-action="adjust-skill-rank" data-id="{{skill.id}}" data-tooltip="Left Click to increase {{localize skill.config.label}}'s Rank<br>Right Click to decrease {{localize skill.config.label}}'s Rank">
+                                                        {{#times skill.rank}}<li class="fa-solid fa-dot-circle"></li>{{/times}}
+                                                        {{#times (sub 5 skill.rank)}}<li class="fa-regular fa-circle"></li>{{/times}}
+                                                    </a>
+                                                </ul>
+                                            </div>
+                                        </li>
+
+                                    {{/if}}
+                                {{/each}}
+                            </ul>
+                        </section>
+                    </section>
+                {{/each}}
+                <!--{{#each attributeGroups as |attrGroup|}}
+                {{/each}}-->
+            </section>
+        </div>
+
+        <div class="tab biography flexrow" data-group="primary" data-tab="biography"></div>
     </section>
 </form>


### PR DESCRIPTION
Partially addresses issue #4 

Implements editable areas for Name, Attributes, and Skill Ranks.

![image](https://github.com/user-attachments/assets/9930b910-8639-4cca-b35f-e95cb112b724)

TODO:
- Update Derived Data on Attribute Value Change
- CSS Changes to make text areas look not horrendous.
