### PR TITLE
feat(data): add injuries support to character data model

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -226,6 +226,18 @@
                     }
                 }
             },
+            "Injuries": {
+                "Name": {
+                    "placeholder": "[Injury Name]"
+                },
+                "Duration": {
+                    "FleshWound": "Flesh Wound",
+                    "ShallowInjury": "Shallow Injury",
+                    "ViciousInjury": "Vicious Injury",
+                    "PermanentInjury": "Permanent Injury",
+                    "Death": "Death"
+                }
+            },
             "DefaultFlavor": "[actor] uses their [item]"
         },
         "DamageTypes": {

--- a/src/system.json
+++ b/src/system.json
@@ -29,7 +29,9 @@
             "talent": {},
             "trait": {},
 
-            "action": {}
+            "action": {},
+
+            "injury": {}
         }
     },
     "languages": [

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -106,22 +106,22 @@ const COSMERE: CosmereRPGConfig = {
 
     injuries: {
         [InjuryDuration.FleshWound]: {
-            label: 'Flesh Wound',
+            label: 'COSMERE.Item.Injuries.Duration.FleshWound',
             durationFormula: '1',
         },
         [InjuryDuration.ShallowInjury]: {
-            label: 'Shallow Injury',
+            label: 'COSMERE.Item.Injuries.Duration.ShallowInjury',
             durationFormula: '1d6',
         },
         [InjuryDuration.ViciousInjury]: {
-            label: 'Vicious Injury',
+            label: 'COSMERE.Item.Injuries.Duration.ViciousInjury',
             durationFormula: '6d6',
         },
         [InjuryDuration.PermanentInjury]: {
-            label: 'Permanent Injury',
+            label: 'COSMERE.Item.Injuries.Duration.PermanentInjury',
         },
         [InjuryDuration.Death]: {
-            label: 'Death',
+            label: 'COSMERE.Item.Injuries.Duration.Death',
         },
     },
 

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -4,6 +4,7 @@ import {
     Size,
     CreatureType,
     Condition,
+    InjuryDuration,
     Attribute,
     AttributeGroup,
     Resource,
@@ -100,6 +101,27 @@ const COSMERE: CosmereRPGConfig = {
         },
         [Condition.Unconcious]: {
             label: 'COSMERE.Actor.Conditions.Unconscious',
+        },
+    },
+
+    injuries: {
+        [InjuryDuration.FleshWound]: {
+            label: 'Flesh Wound',
+            durationFormula: '1',
+        },
+        [InjuryDuration.ShallowInjury]: {
+            label: 'Shallow Injury',
+            durationFormula: '1d6',
+        },
+        [InjuryDuration.ViciousInjury]: {
+            label: 'Vicious Injury',
+            durationFormula: '6d6',
+        },
+        [InjuryDuration.PermanentInjury]: {
+            label: 'Permanent Injury',
+        },
+        [InjuryDuration.Death]: {
+            label: 'Death',
         },
     },
 

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -427,6 +427,11 @@ export class CommonActorDataModel<
             this.attributes.spd.value,
         );
 
+        // Injury count
+        this.injuries.value = this.parent.items.filter(
+            (item) => item.type === ItemType.Injury,
+        ).length;
+
         // Lifting & Carrying
         this.encumbrance.lift.value = strengthToLiftingCapacity(
             this.attributes.str.value,

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -51,6 +51,7 @@ export interface CommonActorData {
         Skill,
         { attribute: Attribute; rank: number; mod: Derived<number> }
     >;
+    injuries: Derived<number>;
     movement: {
         rate: Derived<number>;
     };
@@ -116,6 +117,15 @@ export class CommonActorDataModel<
                     }),
                 ),
             }),
+            injuries: new DerivedValueField(
+                new foundry.data.fields.NumberField({
+                    required: true,
+                    nullable: false,
+                    integer: true,
+                    min: 0,
+                    initial: 0,
+                }),
+            ),
             encumbrance: new foundry.data.fields.SchemaField({
                 lift: new DerivedValueField(
                     new foundry.data.fields.NumberField({

--- a/src/system/data/item/index.ts
+++ b/src/system/data/item/index.ts
@@ -12,6 +12,8 @@ import { TraitItemDataModel } from './trait';
 
 import { ActionItemDataModel } from './action';
 
+import { InjuryItemDataModel } from './injury';
+
 export const config: Record<
     ItemType,
     typeof foundry.abstract.TypeDataModel<
@@ -29,6 +31,8 @@ export const config: Record<
     [ItemType.Trait]: TraitItemDataModel,
 
     [ItemType.Action]: ActionItemDataModel,
+
+    [ItemType.Injury]: InjuryItemDataModel,
 };
 
 export * from './weapon';
@@ -38,3 +42,4 @@ export * from './ancestry';
 export * from './path';
 export * from './talent';
 export * from './action';
+export * from './injury';

--- a/src/system/data/item/injury.ts
+++ b/src/system/data/item/injury.ts
@@ -1,0 +1,49 @@
+// Mixins
+import { DataModelMixin } from '../mixins';
+import {
+    DescriptionItemMixin,
+    DescriptionItemData,
+} from './mixins/description';
+
+import { InjuryDuration } from '@system/types/cosmere';
+
+export interface InjuryItemData extends DescriptionItemData {
+    duration: {
+        type: string;
+        /*
+         * Initial: rolled duration, in days
+         * Remaining: time until the injury is healed, also in days
+         *
+         * These fields should be null for PermanentInjury or Death types
+         */
+        initial: number | null;
+        remaining: number | null;
+    };
+}
+
+export class InjuryItemDataModel extends DataModelMixin(
+    DescriptionItemMixin(),
+) {
+    static defineSchema() {
+        return foundry.utils.mergeObject(super.defineSchema(), {
+            // Default to flesh wound data as the least impactful injury type
+            duration: new foundry.data.fields.SchemaField({
+                type: new foundry.data.fields.StringField({
+                    required: true,
+                    nullable: false,
+                    initial: InjuryDuration.FleshWound,
+                }),
+                initial: new foundry.data.fields.NumberField({
+                    required: true,
+                    nullable: true,
+                    initial: 1,
+                }),
+                remaining: new foundry.data.fields.NumberField({
+                    required: true,
+                    nullable: true,
+                    initial: 1,
+                }),
+            }),
+        });
+    }
+}

--- a/src/system/data/item/injury.ts
+++ b/src/system/data/item/injury.ts
@@ -36,11 +36,15 @@ export class InjuryItemDataModel extends DataModelMixin(
                 initial: new foundry.data.fields.NumberField({
                     required: true,
                     nullable: true,
+                    integer: true,
+                    min: 0,
                     initial: 1,
                 }),
                 remaining: new foundry.data.fields.NumberField({
                     required: true,
                     nullable: true,
+                    integer: true,
+                    min: 0,
                     initial: 1,
                 }),
             }),

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -2,6 +2,7 @@ import {
     Size,
     CreatureType,
     Condition,
+    InjuryDuration,
     AttributeGroup,
     Attribute,
     Skill,
@@ -33,6 +34,11 @@ export interface CreatureTypeConfig {
 export interface ConditionConfig {
     label: string;
     reference?: string;
+}
+
+export interface InjuryConfig {
+    label: string;
+    durationFormula?: string;
 }
 
 export interface AttributeGroupConfig {
@@ -114,6 +120,7 @@ export interface CosmereRPGConfig {
     sizes: Record<Size, SizeConfig>;
     creatureTypes: Record<CreatureType, CreatureTypeConfig>;
     conditions: Record<Condition, ConditionConfig>;
+    injuries: Record<InjuryDuration, InjuryConfig>;
 
     attributeGroups: Record<AttributeGroup, AttributeGroupConfig>;
     attributes: Record<Attribute, AttributeConfig>;

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -35,6 +35,14 @@ export enum Condition {
     Unconcious = 'unconcious',
 }
 
+export enum InjuryDuration {
+    FleshWound = 'flesh_wound',
+    ShallowInjury = 'shallow_injury',
+    ViciousInjury = 'vicious_injury',
+    PermanentInjury = 'permanent_injury',
+    Death = 'death',
+}
+
 export enum AttributeGroup {
     Physical = 'phy',
     Cognitive = 'cog',
@@ -207,4 +215,6 @@ export enum ItemType {
     Trait = 'trait',
 
     Action = 'action',
+
+    Injury = 'injury',
 }


### PR DESCRIPTION
Partially addresses #5 

Adding injury support to the character data model. While injuries themselves (among other conditions) should be Items or some other kind of EmbeddedDocument that lives in a character, we also want easy access to the number of injuries one has among their other conditions. We'll want a derived field for quick access to the number of injuries for Injury Rolls, as well as particular support for Injury Items.

Done:
- Create derived `injuries` field in the common actor data model
- Implement `Injury` item type
  - create additional fields to model an injury (such as `duration`)
- Update Actor to derive `injuries` data from owned Injury items