### PR TITLE
feat(character sheet): add basic actions list

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,21 +27,10 @@ export default {
         copy({
             targets: [
                 { src: 'src/system.json', dest: 'build' },
-                { src: 'src/templates/*.hbs', dest: 'build/templates/' },
-                {
-                    src: 'src/templates/actors/*.hbs',
-                    dest: 'build/templates/actors/',
-                },
-                {
-                    src: 'src/templates/roll/*.hbs',
-                    dest: 'build/templates/roll/',
-                },
-                {
-                    src: 'src/templates/item/dialog/*.hbs',
-                    dest: 'build/templates/item/dialog/',
-                },
-                { src: 'src/lang/*.json', dest: 'build/lang/' }
+                { src: 'src/templates/**/*.hbs', dest: 'build/' },
+                { src: 'src/lang/*.json', dest: 'build/' }
             ],
+            flatten: false
         }),
     ],
 };

--- a/src/declarations/foundry/client/data/abstract/client-document.d.ts
+++ b/src/declarations/foundry/client/data/abstract/client-document.d.ts
@@ -1,15 +1,20 @@
-type Mixin<
+declare type Mixin<
     MixinClass extends new (...args: any[]) => any,
     BaseClass extends abstract new (...args: any[]) => any,
-> = MixinClass & BaseClass;
+> = BaseClass & MixinClass;
 
 declare function _ClientDocumentMixin<
     Schema extends foundry.abstract.DataModel = foundry.abstract.DataModel,
     Parent extends foundry.abstract.Document | null = null,
     BaseClass extends typeof foundry.abstract.Document<Schema, Parent>,
->(base: BaseClass): Mixin<ClientDocument, BaseClass>;
+>(base: BaseClass): Mixin<BaseClass, typeof _ClientDocument>;
 
-declare class ClientDocument {
+declare class _ClientDocument {
+    /**
+     * Lazily obtain a FormApplication instance used to configure this Document, or null if no sheet is available.
+     */
+    get sheet(): Application | foundry.applications.api.ApplicationV2 | null;
+
     /**
      * Apply transformations of derivations to the values of the source data object.
      * Compute data fields whose values are not stored to the database.

--- a/src/declarations/foundry/client/data/documents/actor.d.ts
+++ b/src/declarations/foundry/client/data/documents/actor.d.ts
@@ -6,7 +6,7 @@ declare class Actor<
     public readonly name: string;
     public readonly system: D;
 
-    get items(): I[];
+    get items(): Collection<I>;
 
     public getRollData(): object;
 }

--- a/src/declarations/foundry/common/abstract/data.d.ts
+++ b/src/declarations/foundry/common/abstract/data.d.ts
@@ -273,6 +273,8 @@ namespace foundry {
              */
             get uuid(): string;
 
+            get id(): string;
+
             /* --- Model permissions --- */
 
             /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import COSMERE from './system/config';
 
 import './style.scss';
 
-import './system/util/handlebars';
+import { preloadHandlebarsTemplates } from './system/util/handlebars';
 
 import * as applications from './system/applications';
 import * as dataModels from './system/data';
@@ -19,7 +19,7 @@ declare global {
     }
 }
 
-Hooks.once('init', () => {
+Hooks.once('init', async () => {
     CONFIG.COSMERE = COSMERE;
 
     CONFIG.Actor.dataModels = dataModels.actor.config;
@@ -48,4 +48,7 @@ Hooks.once('init', () => {
     // @league-of-foundry-developers/foundry-vtt-types/src/foundry/client-esm/dice/terms/term.d.mts
     // @ts-expect-error see note
     CONFIG.Dice.rolls.push(dice.D20Roll);
+
+    // Load templates
+    await preloadHandlebarsTemplates();
 });

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -265,17 +265,14 @@
                     "Utility": "Utility"
                 },
                 "ConsumeType": {
-                    "Resource": "Resource",
-                    "Charge": "Charge",
-                    "Item": "Item"
-                },
-                "Resources": {
-                    "Charge": {
-                        "Singular": "Charge",
-                        "Plural": "Charges",
-                        "Recharge": {
-                            "PerScene": "Per scene"
-                        }
+                    "ActorResource": {
+                        "Label": "Actor Resource"
+                    },
+                    "ItemResource": {
+                        "Label": "Item Resource"
+                    },
+                    "Item": {
+                        "Label": "Item"
                     }
                 }
             },
@@ -289,6 +286,19 @@
                     "ViciousInjury": "Vicious Injury",
                     "PermanentInjury": "Permanent Injury",
                     "Death": "Death"
+                }
+            },
+            "Resources": {
+                "Charge": {
+                    "Singular": "Charge",
+                    "Plural": "Charges"
+                },
+                "Use": {
+                    "Singular": "Use",
+                    "Plural": "Uses"
+                },
+                "Recharge": {
+                    "PerScene": "Per scene"
                 }
             },
             "DefaultFlavor": "[actor] uses [item]"

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -60,7 +60,8 @@
             "ActionCosts": {
                 "Action": "Action",
                 "Reaction": "Reaction",
-                "FreeAction": "Free Action"
+                "FreeAction": "Free Action",
+                "Special": "Special"
             },
             "Attribute": {
                 "name": "Attribute",
@@ -156,7 +157,11 @@
                     "label": "Actions"
                 },
                 "Inventory": {
-                    "label": "Inventory"
+                    "label": "Inventory",
+                    "Item": {
+                        "Quantity": "Quantity",
+                        "Weight": "Weight"
+                    }
                 }
             }
         },
@@ -301,6 +306,36 @@
                     "PerScene": "Per scene"
                 }
             },
+            "Equip": {
+                "Types": {
+                    "Wear": {
+                        "Label": "Worn"
+                    },
+                    "Hold": {
+                        "Label": "Held"
+                    }
+                },
+                "Hold": {
+                    "MainHand": {
+                        "Label": "Main Hand"
+                    },
+                    "OffHand": {
+                        "Label": "Off Hand"
+                    },
+                    "TwoHanded": {
+                        "Label": "Two Handed"
+                    }
+                },
+                "Equip": {
+                    "Label": "Equip"
+                },
+                "Unequip": {
+                    "Label": "Unequip"
+                },
+                "Unequipped": {
+                    "Label": "Unequipped"
+                }
+            },
             "DefaultFlavor": "[actor] uses [item]"
         },
         "Attack": {
@@ -329,6 +364,11 @@
             "None": "None",
             "Advantage": "Advantage",
             "Disadvantage": "Disadvantage"
+        },
+        "Damage": {
+            "Label": "Damage",
+            "Apply": "Apply",
+            "Graze": "Graze"
         }
     },
     "DIALOG": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -150,6 +150,14 @@
             "Type": {
                 "Humanoid": "Humanoid",
                 "Animal": "Animal"
+            },
+            "Sheet": {
+                "Actions": {
+                    "label": "Actions"
+                },
+                "Inventory": {
+                    "label": "Inventory"
+                }
             }
         },
         "AttributeGroup": {
@@ -168,13 +176,42 @@
         },
         "Item": {
             "Type": {
-                "Weapon": "Weapon",
-                "Armor": "Armor",
-                "Equipment": "Equipment",
-                "Ancestry": "Ancestry",
-                "Path": "Path",
-                "Talent": "Talent",
-                "Action": "Action"
+                "Weapon": {
+                    "label": "Weapon",
+                    "label_plural": "Weapons"
+                },
+                "Armor": {
+                    "label": "Armor",
+                    "label_plural": "Armor"
+                },
+                "Equipment": {
+                    "label": "Equipment",
+                    "label_plural": "Equipment"
+                },
+                "Ancestry": {
+                    "label": "Ancestry",
+                    "label_plural": "Ancestries"
+                },
+                "Path": {
+                    "label": "Path",
+                    "label_plural": "Paths"
+                },
+                "Talent": {
+                    "label": "Talent",
+                    "label_plural": "Talents"
+                },
+                "Action": {
+                    "label": "Action",
+                    "label_plural": "Actions"
+                },
+                "Trait": {
+                    "label": "Trait",
+                    "label_plural": "Traits"
+                },
+                "Injury": {
+                    "label": "Injury",
+                    "label_plural": "Injuries"
+                }
             },
             "Weapon": {
                 "Type": {
@@ -213,7 +250,20 @@
                     "Presentable": "Presentable"
                 }
             },
+            "Action": {
+                "Type": {
+                    "Basic": {
+                        "label": "Basic Action",
+                        "label_plural": "Basic Actions"
+                    }
+                }
+            },
             "Activation": {
+                "Type": {
+                    "Action": "Action",
+                    "SkillTest": "Skill Test",
+                    "Utility": "Utility"
+                },
                 "ConsumeType": {
                     "Resource": "Resource",
                     "Charge": "Charge",
@@ -222,7 +272,10 @@
                 "Resources": {
                     "Charge": {
                         "Singular": "Charge",
-                        "Plural": "Charges"
+                        "Plural": "Charges",
+                        "Recharge": {
+                            "PerScene": "Per scene"
+                        }
                     }
                 }
             },
@@ -238,14 +291,21 @@
                     "Death": "Death"
                 }
             },
-            "DefaultFlavor": "[actor] uses their [item]"
+            "DefaultFlavor": "[actor] uses [item]"
+        },
+        "Attack": {
+            "Type": {
+                "Melee": "Melee",
+                "Ranged": "Ranged"
+            }
         },
         "DamageTypes": {
             "Energy": "Energy",
             "Impact": "Impact",
             "Keen": "Keen",
             "Spirit": "Spirit",
-            "Vital": "Vital"
+            "Vital": "Vital",
+            "Healing": "Healing"
         }
     },
     "DICE": {
@@ -272,6 +332,7 @@
         "None": "None",
         "Formula": "Formula",
         "SkillTest": "Skill Test",
+        "Cost": "Cost",
         "DistanceUnit": "ft.",
         "Button": {
             "Roll": "Roll",

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,5 +1,5 @@
 @import './style/sheets/module.scss';
-@import './style/chat/module.scss';
+// @import './style/chat/module.scss';
 
 @font-face {
     font-family: 'cosmere-dingbats';

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,1 +1,12 @@
 @import './style/sheets/module.scss';
+@import './style/chat/module.scss';
+
+@font-face {
+    font-family: 'cosmere-dingbats';
+    src: url("https://dl.dropboxusercontent.com/scl/fi/9909gen4fd0oveyzfposx/CosmereDingbats-Regular.otf?rlkey=ig6odq9hxyo1st8kt3ujp1czz&st=72qrads3&raw=1")
+}
+
+i.cosmere-icon {
+    font-family: 'cosmere-dingbats';
+    font-style: normal;
+}

--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -123,3 +123,24 @@
         font-weight: normal;
     }
 }
+
+.documents {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+
+    .favorites {
+        width: 33%;
+    }
+
+    .tabs {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: unset;
+
+        .tab-body {
+            flex: 1;
+        }
+    }
+}

--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -113,7 +113,7 @@
     .label,
     p {
         text-align: center;
-        font-size: 10pt;
+        font-size: 8pt;
     }
 }
 

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -111,7 +111,8 @@
             .item-controls {
                 display: flex;
                 align-items: center;
-                justify-content: center;
+                justify-content: flex-end;
+                width: 2.5rem;
 
                 > a {
                     margin: .2rem;

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -30,6 +30,21 @@
 }
 
 .sheet {  
+    .tabs {
+        nav {
+            align-items: center;
+
+            a {
+                font-weight: bold;
+                text-align: center;
+
+                &.active {
+                    text-decoration: underline;
+                }
+            }
+        }
+    }
+
     .actions-list,
     .inventory-list {
         margin: 0;

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -43,6 +43,19 @@
                 }
             }
         }
+
+        .tab-body {
+            position: relative;
+
+            .scroll-container {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                right: 0;
+                overflow-y: scroll;
+            }
+        }
     }
 
     .actions-list,

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -6,6 +6,7 @@
 .sheet-body {
     display: flex;
     flex-direction: column;
+    flex: 1 !important;
 }
 
 .box-title {
@@ -26,4 +27,86 @@
 
 .rollable {
     cursor: pointer;
+}
+
+.sheet {  
+    .actions-list,
+    .inventory-list {
+        margin: 0;
+        padding: 0;
+
+        .item-image {
+            width: 2rem;
+            height: 2rem;
+        }
+
+        .item-header {
+            height: 2rem;
+            align-items: center;
+
+            &:not(:first-of-type) {
+                margin-top: 1rem;
+            }
+
+            .name {
+                font-weight: bold;
+                font-size: 13pt;
+            }
+        }
+        
+        .item {
+            display: flex;
+            flex-direction: row;
+            padding-right: 2rem;
+            margin-top: .2rem;
+
+            &:hover {
+                background: rgba(0, 0, 0, 0.15);
+            }
+        
+            .item-name {
+                flex: 1;
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+        
+                .name {
+                    display: flex;
+                    flex-direction: column;
+                    margin-left: .75rem;
+        
+                    .title {
+                        font-weight: bold;
+                    }
+        
+                    .subtitle {
+                        font-size: 8pt;
+                        opacity: .75;
+                    }   
+                }
+            }
+        
+            .skill-test, .damage, .consume, .charges {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                margin-right: 2rem;
+                width: 5rem;
+        
+                .val {
+                    font-weight: bold;
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
+                    justify-content: center;
+                    margin-top: .1rem;
+                }
+        
+                .sub {
+                    font-size: 8pt;
+                    opacity: .75;
+                }
+            }
+        }
+    }
 }

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -114,7 +114,7 @@
                 }
             }
         
-            .skill-test, .damage, .consume, .charges {
+            .skill-test, .damage, .consume, .resource {
                 display: flex;
                 flex-direction: column;
                 align-items: center;

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -69,6 +69,10 @@
         }
 
         .item-header {
+            display: flex;
+            flex-direction: row;
+            padding-right: 1rem;
+            margin-top: .2rem;
             height: 2rem;
             align-items: center;
 
@@ -80,6 +84,16 @@
                 font-weight: bold;
                 font-size: 13pt;
             }
+
+            .subtitle {
+                font-size: 8pt;
+                margin-bottom: 0.3rem;
+                opacity: .75;
+            }
+
+            .col {
+                font-size: 9pt;
+            }
         }
         
         .item {
@@ -88,63 +102,109 @@
             padding-right: 1rem;
             margin-top: .2rem;
 
+            .item-name {
+                .name {
+                    margin-left: .75rem;
+                }
+            }
+
             &:hover {
                 background: rgba(0, 0, 0, 0.15);
             }
-        
-            .item-name {
-                flex: 1;
+        }
+
+        .item-name {
+            flex: 1;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+    
+            .name {
+                display: flex;
+                flex-direction: column;
+    
+                .title {
+                    font-weight: bold;
+
+                    i {
+                        margin-left: .5rem;
+                    }
+                }
+    
+                .subtitle {
+                    font-size: 8pt;
+                    opacity: .75;
+                }   
+            }
+        }
+
+        .col {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            margin-right: 2rem;
+            width: 5rem;
+    
+            .val {
+                font-weight: bold;
                 display: flex;
                 flex-direction: row;
                 align-items: center;
-        
-                .name {
-                    display: flex;
-                    flex-direction: column;
-                    margin-left: .75rem;
-        
-                    .title {
-                        font-weight: bold;
+                justify-content: center;
+                margin-top: .1rem;
+            }
+    
+            .sub {
+                font-size: 8pt;
+                opacity: .75;
+            }
+
+            &.equip {
+                width: 1.5rem;
+                position: relative;
+
+                .value {
+                    font-size: 14pt;
+                    color: rgba(0, 0, 0, 0.3);
+
+                    &.equipped {
+                        color: #232323;
                     }
-        
-                    .subtitle {
-                        font-size: 8pt;
-                        opacity: .75;
-                    }   
                 }
             }
-        
-            .skill-test, .damage, .consume, .resource {
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-                margin-right: 2rem;
-                width: 5rem;
-        
-                .val {
-                    font-weight: bold;
-                    display: flex;
-                    flex-direction: row;
-                    align-items: center;
-                    justify-content: center;
-                    margin-top: .1rem;
-                }
-        
-                .sub {
-                    font-size: 8pt;
-                    opacity: .75;
-                }
+        }
+
+        .item-controls {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            width: 2.5rem;
+
+            > a {
+                margin: .2rem;
+            }
+        }
+
+        .dropdown {
+            display: none;
+            position: absolute;
+            top: 100%;
+            margin: 0;
+            background: #fffbf2;
+            list-style: none;
+            padding: 0.2rem;
+            font-size: 12pt;
+            z-index: 10;
+            box-shadow: 0 0.1rem 0.3rem 0 rgba(0, 0, 0, .3);
+            border: 1px solid gray;
+
+            &.active {
+                display: block;
             }
 
-            .item-controls {
-                display: flex;
-                align-items: center;
-                justify-content: flex-end;
-                width: 2.5rem;
-
-                > a {
-                    margin: .2rem;
-                }
+            .option-select:not(.selected) {
+                opacity: .5;
             }
         }
     }

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -57,7 +57,7 @@
         .item {
             display: flex;
             flex-direction: row;
-            padding-right: 2rem;
+            padding-right: 1rem;
             margin-top: .2rem;
 
             &:hover {
@@ -105,6 +105,16 @@
                 .sub {
                     font-size: 8pt;
                     opacity: .75;
+                }
+            }
+
+            .item-controls {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                > a {
+                    margin: .2rem;
                 }
             }
         }

--- a/src/system/applications/actor/base-sheet.ts
+++ b/src/system/applications/actor/base-sheet.ts
@@ -9,7 +9,11 @@ import { CosmereItem } from '@system/documents/item';
 
 import { ActionItemDataModel, ActionItemData } from '@system/data/item';
 
+type TabId = 'actions' | 'inventory';
+
 export class BaseSheet extends ActorSheet {
+    private currentTab: TabId = 'actions';
+
     get template() {
         return `systems/cosmere-rpg/templates/actors/${this.actor.type}-sheet.hbs`;
     }
@@ -27,6 +31,8 @@ export class BaseSheet extends ActorSheet {
             ).map(this.getDataForAttributeGroup.bind(this)),
 
             items: this.getItemData(),
+
+            tab: this.currentTab,
         };
     }
 
@@ -42,15 +48,35 @@ export class BaseSheet extends ActorSheet {
             );
 
             // Item listeners
-            // html.find('.item.rollable').on('click', this.onItemAction.bind(this));
             html.find('.item [data-action]').on(
                 'click',
                 this.onItemAction.bind(this),
             );
         }
+
+        html.find('nav a.tab-item[data-tab]').on(
+            'click',
+            this.onSelectTab.bind(this),
+        );
     }
 
     /* --- Internal functions --- */
+
+    private onSelectTab(event: Event) {
+        event.preventDefault();
+
+        // Get the tab id
+        const tabId = $(event.currentTarget!).data('tab') as TabId;
+
+        // Ensure tab was changed
+        if (tabId === this.currentTab) return;
+
+        // Change which tab is active
+        this.currentTab = tabId;
+
+        // Re-render
+        this.render(true);
+    }
 
     private onRollSkillTest(event: Event) {
         event.preventDefault();

--- a/src/system/applications/actor/base-sheet.ts
+++ b/src/system/applications/actor/base-sheet.ts
@@ -41,7 +41,12 @@ export class BaseSheet extends ActorSheet {
                 this.onRollSkillTest.bind(this),
             );
 
-            html.find('.item.rollable').on('click', this.onUseItem.bind(this));
+            // Item listeners
+            // html.find('.item.rollable').on('click', this.onItemAction.bind(this));
+            html.find('.item [data-action]').on(
+                'click',
+                this.onItemAction.bind(this),
+            );
         }
     }
 
@@ -56,9 +61,18 @@ export class BaseSheet extends ActorSheet {
         void this.actor.rollSkill(skillId);
     }
 
-    private onUseItem(event: Event) {
+    private onItemAction(event: Event) {
         event.preventDefault();
+        event.stopPropagation();
 
+        // Get the action
+        const action = $(event.currentTarget!)
+            .closest('[data-action]')
+            .data('action') as string;
+
+        console.log('action', action);
+
+        // Get the item id
         const itemId = $(event.currentTarget!)
             .closest('[data-item-id]')
             .data('item-id') as string;
@@ -67,8 +81,17 @@ export class BaseSheet extends ActorSheet {
         const item = this.actor.items.get(itemId);
         if (!item) return;
 
-        // Use the item
-        void this.actor.useItem(item);
+        switch (action) {
+            case 'use':
+                void this.actor.useItem(item);
+                break;
+            case 'view':
+            case 'edit':
+                item.sheet?.render(true);
+                break;
+            case 'delete':
+                void this.actor.deleteEmbeddedDocuments('Item', [item.id]);
+        }
     }
 
     /* ---------------------- */

--- a/src/system/applications/actor/base-sheet.ts
+++ b/src/system/applications/actor/base-sheet.ts
@@ -202,7 +202,12 @@ export class BaseSheet extends ActorSheet {
         // Get all activatable items
         const activatableItems = this.actor.items
             .filter((item) => item.hasActivation())
-            .filter((item) => !item.isEquippable() || item.system.equipped);
+            .filter(
+                (item) =>
+                    !item.isEquippable() ||
+                    item.system.equipped ||
+                    item.system.alwaysEquipped,
+            );
 
         // Get all items that are not actions (but are activatable, e.g. weapons)
         const nonActionItems = activatableItems.filter(

--- a/src/system/applications/actor/base-sheet.ts
+++ b/src/system/applications/actor/base-sheet.ts
@@ -230,6 +230,7 @@ export class BaseSheet extends ActorSheet {
                 .map((type) => ({
                     id: type,
                     label: CONFIG.COSMERE.action.types[type].labelPlural,
+                    subtitle: CONFIG.COSMERE.action.types[type].subtitle,
                     items: actionItems.filter(
                         (i) => (i.system.type as ActionType) === type,
                     ),

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -25,6 +25,8 @@ import {
     AttackType,
     ItemRechargeType,
     ItemResource,
+    EquipType,
+    HoldType,
 } from './types/cosmere';
 
 const COSMERE: CosmereRPGConfig = {
@@ -379,6 +381,32 @@ const COSMERE: CosmereRPGConfig = {
                 },
             },
         },
+        equip: {
+            types: {
+                [EquipType.Wear]: {
+                    label: 'COSMERE.Item.Equip.Types.Wear.Label',
+                    icon: '<i class="fa-solid fa-shirt"></i>',
+                },
+                [EquipType.Hold]: {
+                    label: 'COSMERE.Item.Equip.Types.Hold.Label',
+                    icon: '<i class="fa-solid fa-hand-fist"></i>',
+                },
+            },
+            hold: {
+                [HoldType.MainHand]: {
+                    label: 'COSMERE.Item.Equip.Hold.MainHand.Label',
+                    icon: '<i class="fa-solid fa-hand"></i>',
+                },
+                [HoldType.OffHand]: {
+                    label: 'COSMERE.Item.Equip.Hold.OffHand.Label',
+                    icon: '<i class="fa-regular fa-hand"></i>',
+                },
+                [HoldType.TwoHanded]: {
+                    label: 'COSMERE.Item.Equip.Hold.TwoHanded.Label',
+                    icon: '<i class="fa-solid fa-hands"></i>',
+                },
+            },
+        },
     },
 
     weaponTypes: {
@@ -525,6 +553,9 @@ const COSMERE: CosmereRPGConfig = {
             },
             [ActionCostType.FreeAction]: {
                 label: 'COSMERE.Actor.ActionCosts.FreeAction',
+            },
+            [ActionCostType.Special]: {
+                label: 'COSMERE.Actor.ActionCosts.Special',
             },
         },
     },

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -24,6 +24,7 @@ import {
     ItemType,
     AttackType,
     ItemRechargeType,
+    ItemResource,
 } from './types/cosmere';
 
 const COSMERE: CosmereRPGConfig = {
@@ -350,21 +351,31 @@ const COSMERE: CosmereRPGConfig = {
                 },
             },
             consumeTypes: {
-                [ItemConsumeType.Resource]: {
-                    label: 'COSMERE.Item.Activation.ConsumeType.Resource',
+                [ItemConsumeType.ActorResource]: {
+                    label: 'COSMERE.Item.Activation.ConsumeType.ActorResource.Label',
                 },
-                [ItemConsumeType.Charge]: {
-                    label: 'COSMERE.Item.Activation.ConsumeType.Charge',
+                [ItemConsumeType.ItemResource]: {
+                    label: 'COSMERE.Item.Activation.ConsumeType.ItemResource.Label',
                 },
                 [ItemConsumeType.Item]: {
-                    label: 'COSMERE.Item.Activation.ConsumeType.Item',
+                    label: 'COSMERE.Item.Activation.ConsumeType.Item.Label',
                 },
             },
-            charges: {
-                recharge: {
-                    [ItemRechargeType.PerScene]: {
-                        label: 'COSMERE.Item.Activation.Resources.Charge.Recharge.PerScene',
-                    },
+        },
+        resources: {
+            types: {
+                [ItemResource.Use]: {
+                    label: 'COSMERE.Item.Resources.Use.Singular',
+                    labelPlural: 'COSMERE.Item.Resources.Use.Plural',
+                },
+                [ItemResource.Charge]: {
+                    label: 'COSMERE.Item.Resources.Charge.Singular',
+                    labelPlural: 'COSMERE.Item.Resources.Charge.Plural',
+                },
+            },
+            recharge: {
+                [ItemRechargeType.PerScene]: {
+                    label: 'COSMERE.Item.Resources.Recharge.PerScene',
                 },
             },
         },

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -18,8 +18,12 @@ import {
     DeflectSource,
     ActivationType,
     ItemConsumeType,
+    ActionType,
     ActionCostType,
     DamageType,
+    ItemType,
+    AttackType,
+    ItemRechargeType,
 } from './types/cosmere';
 
 const COSMERE: CosmereRPGConfig = {
@@ -146,10 +150,12 @@ const COSMERE: CosmereRPGConfig = {
     attributes: {
         [Attribute.Strength]: {
             label: 'COSMERE.Actor.Attribute.Strength.long',
+            labelShort: 'COSMERE.Actor.Attribute.Strength.short',
             skills: [Skill.Athletics, Skill.HeavyWeapons],
         },
         [Attribute.Speed]: {
             label: 'COSMERE.Actor.Attribute.Speed.long',
+            labelShort: 'COSMERE.Actor.Attribute.Speed.short',
             skills: [
                 Skill.Agility,
                 Skill.LightWeapons,
@@ -159,6 +165,7 @@ const COSMERE: CosmereRPGConfig = {
         },
         [Attribute.Intellect]: {
             label: 'COSMERE.Actor.Attribute.Intellect.long',
+            labelShort: 'COSMERE.Actor.Attribute.Intellect.short',
             skills: [
                 Skill.Crafting,
                 Skill.Deduction,
@@ -168,14 +175,17 @@ const COSMERE: CosmereRPGConfig = {
         },
         [Attribute.Willpower]: {
             label: 'COSMERE.Actor.Attribute.Willpower.long',
+            labelShort: 'COSMERE.Actor.Attribute.Willpower.short',
             skills: [Skill.Discipline, Skill.Intimidation],
         },
         [Attribute.Awareness]: {
             label: 'COSMERE.Actor.Attribute.Awareness.long',
+            labelShort: 'COSMERE.Actor.Attribute.Awareness.short',
             skills: [Skill.Insight, Skill.Perception, Skill.Survival],
         },
         [Attribute.Presence]: {
             label: 'COSMERE.Actor.Attribute.Presence.long',
+            labelShort: 'COSMERE.Actor.Attribute.Presence.short',
             skills: [Skill.Deception, Skill.Leadership, Skill.Persuasion],
         },
     },
@@ -289,10 +299,54 @@ const COSMERE: CosmereRPGConfig = {
     },
 
     items: {
+        types: {
+            [ItemType.Weapon]: {
+                label: 'COSMERE.Item.Type.Weapon.label',
+                labelPlural: 'COSMERE.Item.Type.Weapon.label_plural',
+            },
+            [ItemType.Armor]: {
+                label: 'COSMERE.Item.Type.Armor.label',
+                labelPlural: 'COSMERE.Item.Type.Armor.label_plural',
+            },
+            [ItemType.Equipment]: {
+                label: 'COSMERE.Item.Type.Equipment.label',
+                labelPlural: 'COSMERE.Item.Type.Equipment.label_plural',
+            },
+            [ItemType.Ancestry]: {
+                label: 'COSMERE.Item.Type.Ancestry.label',
+                labelPlural: 'COSMERE.Item.Type.Ancestry.label_plural',
+            },
+            [ItemType.Path]: {
+                label: 'COSMERE.Item.Type.Path.label',
+                labelPlural: 'COSMERE.Item.Type.Path.label_plural',
+            },
+            [ItemType.Talent]: {
+                label: 'COSMERE.Item.Type.Talent.label',
+                labelPlural: 'COSMERE.Item.Type.Talent.label_plural',
+            },
+            [ItemType.Action]: {
+                label: 'COSMERE.Item.Type.Action.label',
+                labelPlural: 'COSMERE.Item.Type.Action.label_plural',
+            },
+            [ItemType.Trait]: {
+                label: 'COSMERE.Item.Type.Trait.label',
+                labelPlural: 'COSMERE.Item.Type.Trait.label_plural',
+            },
+            [ItemType.Injury]: {
+                label: 'COSMERE.Item.Type.Injury.label',
+                labelPlural: 'COSMERE.Item.Type.Injury.label_plural',
+            },
+        },
         activation: {
             types: {
+                [ActivationType.Action]: {
+                    label: 'COSMERE.Item.Activation.Type.Action',
+                },
                 [ActivationType.SkillTest]: {
-                    label: 'COSMERE.GENERIC.SkillTest',
+                    label: 'COSMERE.Item.Activation.Type.SkillTest',
+                },
+                [ActivationType.Utility]: {
+                    label: 'COSMERE.Item.Activation.Type.Utility',
                 },
             },
             consumeTypes: {
@@ -304,6 +358,13 @@ const COSMERE: CosmereRPGConfig = {
                 },
                 [ItemConsumeType.Item]: {
                     label: 'COSMERE.Item.Activation.ConsumeType.Item',
+                },
+            },
+            charges: {
+                recharge: {
+                    [ItemRechargeType.PerScene]: {
+                        label: 'COSMERE.Item.Activation.Resources.Charge.Recharge.PerScene',
+                    },
                 },
             },
         },
@@ -437,15 +498,34 @@ const COSMERE: CosmereRPGConfig = {
         },
     },
 
-    actionCosts: {
-        [ActionCostType.Action]: {
-            label: 'COSMERE.Actor.ActionCosts.Action',
+    action: {
+        types: {
+            [ActionType.Basic]: {
+                label: 'COSMERE.Item.Action.Type.Basic.label',
+                labelPlural: 'COSMERE.Item.Action.Type.Basic.label_plural',
+            },
         },
-        [ActionCostType.Reaction]: {
-            label: 'COSMERE.Actor.ActionCosts.Reaction',
+        costs: {
+            [ActionCostType.Action]: {
+                label: 'COSMERE.Actor.ActionCosts.Action',
+            },
+            [ActionCostType.Reaction]: {
+                label: 'COSMERE.Actor.ActionCosts.Reaction',
+            },
+            [ActionCostType.FreeAction]: {
+                label: 'COSMERE.Actor.ActionCosts.FreeAction',
+            },
         },
-        [ActionCostType.FreeAction]: {
-            label: 'COSMERE.Actor.ActionCosts.FreeAction',
+    },
+
+    attack: {
+        types: {
+            [AttackType.Melee]: {
+                label: 'COSMERE.Attack.Type.Melee',
+            },
+            [AttackType.Ranged]: {
+                label: 'COSMERE.Attack.Type.Ranged',
+            },
         },
     },
 
@@ -466,6 +546,9 @@ const COSMERE: CosmereRPGConfig = {
         [DamageType.Vital]: {
             label: 'COSMERE.DamageTypes.Vital',
             ignoreDeflect: true,
+        },
+        [DamageType.Healing]: {
+            label: 'COSMERE.DamageTypes.Healing',
         },
     },
 };

--- a/src/system/data/item/action.ts
+++ b/src/system/data/item/action.ts
@@ -1,5 +1,8 @@
+import { CosmereItem } from '@src/system/documents';
+
 // Mixins
 import { DataModelMixin } from '../mixins';
+import { TypedItemMixin, TypedItemData } from './mixins/typed';
 import {
     DescriptionItemMixin,
     DescriptionItemData,
@@ -8,14 +11,22 @@ import {
     ActivatableItemMixin,
     ActivatableItemData,
 } from './mixins/activatable';
+import { DamagingItemMixin, DamagingItemData } from './mixins/damaging';
 
 export interface ActionItemData
     extends DescriptionItemData,
-        ActivatableItemData {}
+        ActivatableItemData,
+        TypedItemData,
+        DamagingItemData {}
 
-export class ActionItemDataModel extends DataModelMixin(
+export class ActionItemDataModel extends DataModelMixin<
+    ActionItemData,
+    CosmereItem
+>(
+    TypedItemMixin(),
     DescriptionItemMixin(),
     ActivatableItemMixin(),
+    DamagingItemMixin(),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), {});

--- a/src/system/data/item/armor.ts
+++ b/src/system/data/item/armor.ts
@@ -16,9 +16,9 @@ export interface ArmorItemData
     extends TypedItemData,
         DescriptionItemData,
         EquippableItemData,
+        ExpertiseItemData,
         TraitsItemData,
-        PhysicalItemData,
-        ExpertiseItemData {
+        PhysicalItemData {
     deflect?: number;
 }
 
@@ -29,9 +29,9 @@ export class ArmorItemDataModel extends DataModelMixin<
     TypedItemMixin(),
     DescriptionItemMixin(),
     EquippableItemMixin(),
+    ExpertiseItemMixin(),
     TraitsItemMixin(),
     PhysicalItemMixin(),
-    ExpertiseItemMixin(),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), {

--- a/src/system/data/item/mixins/activatable.ts
+++ b/src/system/data/item/mixins/activatable.ts
@@ -5,6 +5,7 @@ import {
     Resource,
     Skill,
     Attribute,
+    ItemRechargeType,
 } from '@system/types/cosmere';
 import { CosmereItem } from '@system/documents';
 
@@ -32,6 +33,7 @@ export interface ActivatableItemData {
         charge?: {
             value: number;
             max?: number;
+            recharge?: ItemRechargeType;
         };
     };
 }
@@ -58,7 +60,7 @@ export function ActivatableItemMixin<P extends CosmereItem>() {
                                 }),
                                 type: new foundry.data.fields.StringField({
                                     choices: Object.keys(
-                                        CONFIG.COSMERE.actionCosts,
+                                        CONFIG.COSMERE.action.costs,
                                     ),
                                 }),
                             },
@@ -106,6 +108,7 @@ export function ActivatableItemMixin<P extends CosmereItem>() {
                             choices: Object.keys(CONFIG.COSMERE.skills),
                         }),
                         attribute: new foundry.data.fields.StringField({
+                            nullable: true,
                             blank: false,
                             choices: Object.keys(CONFIG.COSMERE.attributes),
                         }),
@@ -125,6 +128,15 @@ export function ActivatableItemMixin<P extends CosmereItem>() {
                                         min: 0,
                                         integer: true,
                                     }),
+                                    recharge:
+                                        new foundry.data.fields.StringField({
+                                            nullable: true,
+                                            blank: false,
+                                            choices: Object.keys(
+                                                CONFIG.COSMERE.items.activation
+                                                    .charges.recharge,
+                                            ),
+                                        }),
                                 },
                                 {
                                     required: false,

--- a/src/system/data/item/mixins/activatable.ts
+++ b/src/system/data/item/mixins/activatable.ts
@@ -3,11 +3,18 @@ import {
     ActionCostType,
     ItemConsumeType,
     Resource,
+    ItemResource,
     Skill,
     Attribute,
     ItemRechargeType,
 } from '@system/types/cosmere';
 import { CosmereItem } from '@system/documents';
+
+interface ItemResourceData {
+    value: number;
+    max?: number;
+    recharge?: ItemRechargeType;
+}
 
 export interface ActivatableItemData {
     activation: {
@@ -19,7 +26,7 @@ export interface ActivatableItemData {
         consume?: {
             type: ItemConsumeType;
             value: number;
-            resource?: Resource;
+            resource?: Resource | ItemResource;
         };
 
         flavor?: string;
@@ -29,13 +36,7 @@ export interface ActivatableItemData {
         attribute?: Attribute;
     };
 
-    resources?: {
-        charge?: {
-            value: number;
-            max?: number;
-            recharge?: ItemRechargeType;
-        };
-    };
+    resources?: Record<ItemResource, ItemResourceData | undefined>;
 }
 
 export function ActivatableItemMixin<P extends CosmereItem>() {
@@ -44,6 +45,8 @@ export function ActivatableItemMixin<P extends CosmereItem>() {
     ) => {
         return class mixin extends base {
             static defineSchema() {
+                const itemResources = CONFIG.COSMERE.items.resources.types;
+
                 return foundry.utils.mergeObject(super.defineSchema(), {
                     activation: new foundry.data.fields.SchemaField({
                         type: new foundry.data.fields.StringField({
@@ -80,7 +83,7 @@ export function ActivatableItemMixin<P extends CosmereItem>() {
                                         CONFIG.COSMERE.items.activation
                                             .consumeTypes,
                                     ),
-                                    initial: ItemConsumeType.Charge,
+                                    initial: ItemConsumeType.ItemResource,
                                 }),
                                 value: new foundry.data.fields.NumberField({
                                     required: true,
@@ -91,9 +94,16 @@ export function ActivatableItemMixin<P extends CosmereItem>() {
                                 }),
                                 resource: new foundry.data.fields.StringField({
                                     blank: false,
-                                    choices: Object.keys(
-                                        CONFIG.COSMERE.resources,
-                                    ),
+                                    choices: [
+                                        ...Object.keys(
+                                            CONFIG.COSMERE.resources,
+                                        ),
+                                        ...Object.keys(
+                                            CONFIG.COSMERE.items.resources
+                                                .types,
+                                        ),
+                                    ],
+                                    initial: ItemResource.Use,
                                 }),
                             },
                             {
@@ -114,37 +124,52 @@ export function ActivatableItemMixin<P extends CosmereItem>() {
                         }),
                     }),
                     resources: new foundry.data.fields.SchemaField(
-                        {
-                            charge: new foundry.data.fields.SchemaField(
-                                {
-                                    value: new foundry.data.fields.NumberField({
-                                        required: true,
-                                        nullable: false,
-                                        min: 0,
-                                        integer: true,
-                                        initial: 0,
-                                    }),
-                                    max: new foundry.data.fields.NumberField({
-                                        min: 0,
-                                        integer: true,
-                                    }),
-                                    recharge:
-                                        new foundry.data.fields.StringField({
-                                            nullable: true,
-                                            blank: false,
-                                            choices: Object.keys(
-                                                CONFIG.COSMERE.items.activation
-                                                    .charges.recharge,
+                        (Object.keys(itemResources) as ItemResource[]).reduce(
+                            (schema, resource) => {
+                                schema[resource] =
+                                    new foundry.data.fields.SchemaField(
+                                        {
+                                            value: new foundry.data.fields.NumberField(
+                                                {
+                                                    required: true,
+                                                    nullable: false,
+                                                    min: 0,
+                                                    integer: true,
+                                                },
                                             ),
-                                        }),
-                                },
-                                {
-                                    required: false,
-                                    nullable: true,
-                                    initial: null,
-                                },
-                            ),
-                        },
+                                            max: new foundry.data.fields.NumberField(
+                                                {
+                                                    min: 0,
+                                                    integer: true,
+                                                },
+                                            ),
+                                            recharge:
+                                                new foundry.data.fields.StringField(
+                                                    {
+                                                        nullable: true,
+                                                        blank: false,
+                                                        choices: Object.keys(
+                                                            CONFIG.COSMERE.items
+                                                                .resources
+                                                                .recharge,
+                                                        ),
+                                                    },
+                                                ),
+                                        },
+                                        {
+                                            required: false,
+                                            nullable: true,
+                                            initial: null,
+                                        },
+                                    );
+
+                                return schema;
+                            },
+                            {} as Record<
+                                string,
+                                foundry.data.fields.SchemaField
+                            >,
+                        ),
                         {
                             required: false,
                             nullable: true,

--- a/src/system/data/item/mixins/attacking.ts
+++ b/src/system/data/item/mixins/attacking.ts
@@ -1,0 +1,46 @@
+import { AttackType } from '@system/types/cosmere';
+import { CosmereItem } from '@system/documents';
+
+export interface AttackingItemData {
+    attack: {
+        type: AttackType;
+        range?: {
+            value?: number;
+            long?: number;
+            units?: string;
+        };
+    };
+}
+
+export function AttackingItemMixin<P extends CosmereItem>() {
+    return (
+        base: typeof foundry.abstract.TypeDataModel<AttackingItemData, P>,
+    ) => {
+        return class extends base {
+            static defineSchema() {
+                return foundry.utils.mergeObject(super.defineSchema(), {
+                    attack: new foundry.data.fields.SchemaField({
+                        type: new foundry.data.fields.StringField({
+                            required: true,
+                            nullable: false,
+                            initial: AttackType.Melee,
+                            choices: Object.keys(CONFIG.COSMERE.attack.types),
+                        }),
+                        range: new foundry.data.fields.SchemaField(
+                            {
+                                value: new foundry.data.fields.NumberField({
+                                    min: 0,
+                                }),
+                                long: new foundry.data.fields.NumberField({
+                                    min: 0,
+                                }),
+                                units: new foundry.data.fields.StringField(),
+                            },
+                            { required: false, nullable: true },
+                        ),
+                    }),
+                });
+            }
+        };
+    };
+}

--- a/src/system/data/item/mixins/damaging.ts
+++ b/src/system/data/item/mixins/damaging.ts
@@ -18,16 +18,20 @@ export function DamagingItemMixin<P extends CosmereItem>() {
             static defineSchema() {
                 return foundry.utils.mergeObject(super.defineSchema(), {
                     damage: new foundry.data.fields.SchemaField({
-                        formula: new foundry.data.fields.StringField(),
+                        formula: new foundry.data.fields.StringField({
+                            nullable: true,
+                            blank: false,
+                        }),
                         type: new foundry.data.fields.StringField({
+                            nullable: true,
                             choices: Object.keys(CONFIG.COSMERE.damageTypes),
                         }),
                         skill: new foundry.data.fields.StringField({
-                            initial: Skill.LightWeapons,
+                            nullable: true,
                             choices: Object.keys(CONFIG.COSMERE.skills),
                         }),
                         attribute: new foundry.data.fields.StringField({
-                            initial: Attribute.Speed,
+                            nullable: true,
                             choices: Object.keys(CONFIG.COSMERE.attributes),
                         }),
                     }),

--- a/src/system/data/item/mixins/description.ts
+++ b/src/system/data/item/mixins/description.ts
@@ -4,6 +4,7 @@ export interface DescriptionItemData {
     description?: {
         value?: string;
         chat?: string;
+        short?: string;
     };
 }
 
@@ -21,6 +22,7 @@ export function DescriptionItemMixin<P extends CosmereItem>() {
                         chat: new foundry.data.fields.HTMLField({
                             label: 'Chat description',
                         }),
+                        short: new foundry.data.fields.StringField(),
                     }),
                 });
             }

--- a/src/system/data/item/mixins/equippable.ts
+++ b/src/system/data/item/mixins/equippable.ts
@@ -1,8 +1,13 @@
+import { EquipType, HoldType } from '@system/types/cosmere';
 import { CosmereItem } from '@system/documents';
 
 export interface EquippableItemData {
     equipped: boolean;
     alwaysEquipped?: boolean;
+    equip: {
+        type: EquipType;
+        hold?: HoldType;
+    };
 }
 
 export function EquippableItemMixin<P extends CosmereItem>() {
@@ -20,6 +25,22 @@ export function EquippableItemMixin<P extends CosmereItem>() {
                     }),
                     alwaysEquipped: new foundry.data.fields.BooleanField({
                         nullable: true,
+                    }),
+                    equip: new foundry.data.fields.SchemaField({
+                        type: new foundry.data.fields.StringField({
+                            required: true,
+                            nullable: false,
+                            initial: EquipType.Wear,
+                            choices: Object.keys(
+                                CONFIG.COSMERE.items.equip.types,
+                            ),
+                        }),
+                        hold: new foundry.data.fields.StringField({
+                            nullable: true,
+                            choices: Object.keys(
+                                CONFIG.COSMERE.items.equip.hold,
+                            ),
+                        }),
                     }),
                 });
             }

--- a/src/system/data/item/mixins/equippable.ts
+++ b/src/system/data/item/mixins/equippable.ts
@@ -2,6 +2,7 @@ import { CosmereItem } from '@system/documents';
 
 export interface EquippableItemData {
     equipped: boolean;
+    alwaysEquipped?: boolean;
 }
 
 export function EquippableItemMixin<P extends CosmereItem>() {
@@ -16,6 +17,9 @@ export function EquippableItemMixin<P extends CosmereItem>() {
                         nullable: false,
                         initial: false,
                         label: 'Equipped',
+                    }),
+                    alwaysEquipped: new foundry.data.fields.BooleanField({
+                        nullable: true,
                     }),
                 });
             }

--- a/src/system/data/item/mixins/physical.ts
+++ b/src/system/data/item/mixins/physical.ts
@@ -1,6 +1,7 @@
 import { CosmereItem } from '@system/documents';
 
 export interface PhysicalItemData {
+    quantity: number;
     weight: {
         value?: number;
         unit?: string;
@@ -18,17 +19,20 @@ export function PhysicalItemMixin<P extends CosmereItem>() {
         return class extends base {
             static defineSchema() {
                 return foundry.utils.mergeObject(super.defineSchema(), {
+                    quantity: new foundry.data.fields.NumberField({
+                        min: 0,
+                        initial: 1,
+                        integer: true,
+                    }),
                     weight: new foundry.data.fields.SchemaField({
                         value: new foundry.data.fields.NumberField({
                             min: 0,
-                            initial: 0,
                         }),
                         unit: new foundry.data.fields.StringField(),
                     }),
                     price: new foundry.data.fields.SchemaField({
                         value: new foundry.data.fields.NumberField({
                             min: 0,
-                            initial: 0,
                         }),
                         unit: new foundry.data.fields.StringField(),
                     }),

--- a/src/system/data/item/mixins/physical.ts
+++ b/src/system/data/item/mixins/physical.ts
@@ -1,11 +1,11 @@
 import { CosmereItem } from '@system/documents';
 
 export interface PhysicalItemData {
-    weight?: {
+    weight: {
         value?: number;
         unit?: string;
     };
-    price?: {
+    price: {
         value?: number;
         unit?: string;
     };

--- a/src/system/data/item/mixins/traits.ts
+++ b/src/system/data/item/mixins/traits.ts
@@ -1,8 +1,9 @@
+import { WeaponTraitId, ArmorTraitId } from '@system/types/cosmere';
 import { CosmereItem } from '@system/documents';
 import { ExpertiseItemData } from './expertise';
 
 interface TraitData {
-    id: string;
+    id: WeaponTraitId | ArmorTraitId;
 
     /**
      * The default (not expertise) value of this trait

--- a/src/system/data/item/mixins/traits.ts
+++ b/src/system/data/item/mixins/traits.ts
@@ -55,6 +55,14 @@ export function TraitsItemMixin<P extends CosmereItem>() {
     return (base: typeof foundry.abstract.TypeDataModel<TraitsItemData, P>) => {
         return class extends base {
             static defineSchema() {
+                const superSchema = super.defineSchema();
+
+                if (!('expertise' in superSchema)) {
+                    throw new Error(
+                        'TraitsItemMixin must be used in combination with ExpertiseItemMixin and must follow it',
+                    );
+                }
+
                 return foundry.utils.mergeObject(super.defineSchema(), {
                     traits: new foundry.data.fields.SetField(
                         new foundry.data.fields.SchemaField({

--- a/src/system/data/item/weapon.ts
+++ b/src/system/data/item/weapon.ts
@@ -26,9 +26,9 @@ export interface WeaponItemData
         ActivatableItemData,
         AttackingItemData,
         DamagingItemData,
+        ExpertiseItemData,
         TraitsItemData,
-        PhysicalItemData,
-        ExpertiseItemData {}
+        PhysicalItemData {}
 
 export class WeaponItemDataModel extends DataModelMixin<
     WeaponItemData,
@@ -40,9 +40,9 @@ export class WeaponItemDataModel extends DataModelMixin<
     ActivatableItemMixin(),
     AttackingItemMixin(),
     DamagingItemMixin(),
+    ExpertiseItemMixin(),
     TraitsItemMixin(),
     PhysicalItemMixin(),
-    ExpertiseItemMixin(),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), {});

--- a/src/system/data/item/weapon.ts
+++ b/src/system/data/item/weapon.ts
@@ -1,4 +1,5 @@
 import { WeaponId } from '@system/types/cosmere';
+import { CosmereItem } from '@src/system/documents';
 
 // Mixins
 import { DataModelMixin } from '../mixins';
@@ -12,6 +13,7 @@ import {
     ActivatableItemMixin,
     ActivatableItemData,
 } from './mixins/activatable';
+import { AttackingItemMixin, AttackingItemData } from './mixins/attacking';
 import { DamagingItemMixin, DamagingItemData } from './mixins/damaging';
 import { TraitsItemMixin, TraitsItemData } from './mixins/traits';
 import { PhysicalItemMixin, PhysicalItemData } from './mixins/physical';
@@ -22,34 +24,27 @@ export interface WeaponItemData
         DescriptionItemData,
         EquippableItemData,
         ActivatableItemData,
+        AttackingItemData,
         DamagingItemData,
         TraitsItemData,
         PhysicalItemData,
-        ExpertiseItemData {
-    range?: {
-        value?: number;
-        long?: number;
-        units?: string;
-    };
-}
+        ExpertiseItemData {}
 
-export class WeaponItemDataModel extends DataModelMixin(
+export class WeaponItemDataModel extends DataModelMixin<
+    WeaponItemData,
+    CosmereItem
+>(
     TypedItemMixin(),
     DescriptionItemMixin(),
     EquippableItemMixin(),
     ActivatableItemMixin(),
+    AttackingItemMixin(),
     DamagingItemMixin(),
     TraitsItemMixin(),
     PhysicalItemMixin(),
     ExpertiseItemMixin(),
 ) {
     static defineSchema() {
-        return foundry.utils.mergeObject(super.defineSchema(), {
-            range: new foundry.data.fields.SchemaField({
-                value: new foundry.data.fields.NumberField({ min: 0 }),
-                long: new foundry.data.fields.NumberField({ min: 0 }),
-                units: new foundry.data.fields.StringField(),
-            }),
-        });
+        return foundry.utils.mergeObject(super.defineSchema(), {});
     }
 }

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -37,6 +37,25 @@ export class CosmereActor<
     T extends CommonActorDataModel = CommonActorDataModel,
 > extends Actor<T, CosmereItem> {
     /**
+     * Utility function to get the modifier for a given skill for this actor.
+     * @param skill The skill to get the modifier for
+     * @param attributeOverride An optional attribute override, used instead of the default attribute
+     */
+    public getSkillMod(skill: Skill, attributeOverride?: Attribute): number {
+        // Get attribute
+        const attribute =
+            attributeOverride ?? CONFIG.COSMERE.skills[skill].attribute;
+
+        // Get skill rank
+        const rank = this.system.skills[skill].rank;
+
+        // Get attribute value
+        const attrValue = this.system.attributes[attribute].value;
+
+        return attrValue + rank;
+    }
+
+    /**
      * Roll a skill for this actor
      */
     public async rollSkill(

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -19,6 +19,7 @@ import { PhysicalItemData } from '@system/data/item/mixins/physical';
 import { TypedItemData } from '@system/data/item/mixins/typed';
 import { TraitsItemData } from '@system/data/item/mixins/traits';
 import { EquippableItemData } from '@system/data/item/mixins/equippable';
+import { DescriptionItemData } from '@system/data/item/mixins/description';
 
 import { Derived } from '@system/data/fields';
 
@@ -112,6 +113,13 @@ export class CosmereItem<
      */
     public isEquippable(): this is CosmereItem<EquippableItemData> {
         return 'equipped' in this.system;
+    }
+
+    /**
+     * Does this item have a description?
+     */
+    public hasDescription(): this is CosmereItem<DescriptionItemData> {
+        return 'description' in this.system;
     }
 
     /* --- Roll & Usage utilities --- */

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -23,6 +23,7 @@ import {
     DamageType,
     ItemType,
     ItemRechargeType,
+    ItemResource,
 } from './cosmere';
 
 export interface SizeConfig {
@@ -106,11 +107,16 @@ export interface ActivationTypeConfig {
     label: string;
 }
 
+export interface ItemResourceConfig {
+    label: string;
+    labelPlural: string;
+}
+
 export interface ItemConsumeTypeConfig {
     label: string;
 }
 
-export interface ItemRechargeTypeConfig {
+export interface ItemRechargeConfig {
     label: string;
 }
 
@@ -155,9 +161,10 @@ export interface CosmereRPGConfig {
         activation: {
             types: Record<ActivationType, ActivationTypeConfig>;
             consumeTypes: Record<ItemConsumeType, ItemConsumeTypeConfig>;
-            charges: {
-                recharge: Record<ItemRechargeType, ItemRechargeTypeConfig>;
-            };
+        };
+        resources: {
+            types: Record<ItemResource, ItemResourceConfig>;
+            recharge: Record<ItemRechargeType, ItemRechargeConfig>;
         };
     };
 

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -24,6 +24,8 @@ import {
     ItemType,
     ItemRechargeType,
     ItemResource,
+    EquipType,
+    HoldType,
 } from './cosmere';
 
 export interface SizeConfig {
@@ -123,6 +125,8 @@ export interface ItemRechargeConfig {
 export interface ActionTypeConfig {
     label: string;
     labelPlural: string;
+    subtitle?: string;
+    hasMode?: boolean;
 }
 
 export interface ActionCostConfig {
@@ -145,6 +149,16 @@ export interface ItemTypeConfig {
     labelPlural: string;
 }
 
+export interface EquipTypeConfig {
+    label: string;
+    icon?: string;
+}
+
+export interface HoldTypeConfig {
+    label: string;
+    icon?: string;
+}
+
 export interface CosmereRPGConfig {
     sizes: Record<Size, SizeConfig>;
     creatureTypes: Record<CreatureType, CreatureTypeConfig>;
@@ -165,6 +179,10 @@ export interface CosmereRPGConfig {
         resources: {
             types: Record<ItemResource, ItemResourceConfig>;
             recharge: Record<ItemRechargeType, ItemRechargeConfig>;
+        };
+        equip: {
+            types: Record<EquipType, EquipTypeConfig>;
+            hold: Record<HoldType, HoldTypeConfig>;
         };
     };
 

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -17,8 +17,12 @@ import {
     DeflectSource,
     ActivationType,
     ItemConsumeType,
+    ActionType,
     ActionCostType,
+    AttackType,
     DamageType,
+    ItemType,
+    ItemRechargeType,
 } from './cosmere';
 
 export interface SizeConfig {
@@ -49,6 +53,7 @@ export interface AttributeGroupConfig {
 
 export interface AttributeConfig {
     label: string;
+    labelShort: string;
     skills: Skill[];
 }
 
@@ -105,15 +110,33 @@ export interface ItemConsumeTypeConfig {
     label: string;
 }
 
+export interface ItemRechargeTypeConfig {
+    label: string;
+}
+
+export interface ActionTypeConfig {
+    label: string;
+    labelPlural: string;
+}
+
 export interface ActionCostConfig {
     label: string;
     icon?: string;
+}
+
+export interface AttackTypeConfig {
+    label: string;
 }
 
 export interface DamageTypeConfig {
     label: string;
     icon?: string;
     ignoreDeflect?: boolean;
+}
+
+export interface ItemTypeConfig {
+    label: string;
+    labelPlural: string;
 }
 
 export interface CosmereRPGConfig {
@@ -128,9 +151,13 @@ export interface CosmereRPGConfig {
     skills: Record<Skill, SkillConfig>;
 
     items: {
+        types: Record<ItemType, ItemTypeConfig>;
         activation: {
             types: Record<ActivationType, ActivationTypeConfig>;
             consumeTypes: Record<ItemConsumeType, ItemConsumeTypeConfig>;
+            charges: {
+                recharge: Record<ItemRechargeType, ItemRechargeTypeConfig>;
+            };
         };
     };
 
@@ -152,6 +179,14 @@ export interface CosmereRPGConfig {
         sources: Record<DeflectSource, DeflectSourceConfig>;
     };
 
-    actionCosts: Record<ActionCostType, ActionCostConfig>;
+    action: {
+        types: Record<ActionType, ActionTypeConfig>;
+        costs: Record<ActionCostType, ActionCostConfig>;
+    };
+
+    attack: {
+        types: Record<AttackType, AttackTypeConfig>;
+    };
+
     damageTypes: Record<DamageType, DamageTypeConfig>;
 }

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -174,6 +174,8 @@ export enum DeflectSource {
 }
 
 export enum ActivationType {
+    Action = 'action',
+    Utility = 'utility',
     SkillTest = 'skill_test',
 }
 
@@ -183,10 +185,23 @@ export enum ItemConsumeType {
     Item = 'item',
 }
 
+export enum ItemRechargeType {
+    PerScene = 'per_scene',
+}
+
+export enum ActionType {
+    Basic = 'basic',
+}
+
 export enum ActionCostType {
     Action = 'act',
     Reaction = 'rea',
     FreeAction = 'fre',
+}
+
+export enum AttackType {
+    Melee = 'melee',
+    Ranged = 'ranged',
 }
 
 export enum DamageType {
@@ -195,6 +210,7 @@ export enum DamageType {
     Keen = 'keen',
     Spirit = 'spirit',
     Vital = 'vital',
+    Healing = 'heal',
 }
 
 /* --- System --- */

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -194,6 +194,17 @@ export enum ItemRechargeType {
     PerScene = 'per_scene',
 }
 
+export enum EquipType {
+    Hold = 'hold', // Item that you equip by holding it (either in one or two hands)
+    Wear = 'wear', // Item that you equip by wearing it
+}
+
+export enum HoldType {
+    MainHand = 'main_hand',
+    OffHand = 'off_hand',
+    TwoHanded = 'two_handed',
+}
+
 export enum ActionType {
     Basic = 'basic',
 }
@@ -202,6 +213,7 @@ export enum ActionCostType {
     Action = 'act',
     Reaction = 'rea',
     FreeAction = 'fre',
+    Special = 'spe',
 }
 
 export enum AttackType {

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -180,9 +180,14 @@ export enum ActivationType {
 }
 
 export enum ItemConsumeType {
-    Resource = 'resource',
-    Charge = 'charge',
+    ActorResource = 'actor_resource', // E.g. health, focus, investiture
+    ItemResource = 'item_resource', // E.g. uses, charges
     Item = 'item',
+}
+
+export enum ItemResource {
+    Use = 'use',
+    Charge = 'charge',
 }
 
 export enum ItemRechargeType {

--- a/src/system/util/handlebars/index.ts
+++ b/src/system/util/handlebars/index.ts
@@ -1,5 +1,34 @@
-import { CharacterActor } from '@system/documents/actor';
+import {
+    ArmorTraitId,
+    WeaponTraitId,
+    Skill,
+    Attribute,
+    ItemConsumeType,
+} from '@src/system/types/cosmere';
+
+import { CharacterActor, CosmereActor } from '@system/documents/actor';
+import { CosmereItem } from '@system/documents/item';
 import { Derived } from '@system/data/fields';
+
+import { ItemContext } from './types';
+
+Handlebars.registerHelper('add', (a: number, b: number) => a + b);
+Handlebars.registerHelper('sub', (a: number, b: number) => a - b);
+Handlebars.registerHelper('multi', (a: number, b: number) => a * b);
+Handlebars.registerHelper('divide', (a: number, b: number) => a / b);
+
+Handlebars.registerHelper(
+    'times',
+    (count: unknown, options: Handlebars.HelperOptions): string =>
+        [...Array(Number(count) || 0).keys()]
+            .map((i) =>
+                options.fn(i, {
+                    data: options.data as unknown,
+                    blockParams: [i],
+                }),
+            )
+            .join(''),
+);
 
 Handlebars.registerHelper(
     'greaterThan',
@@ -22,3 +51,219 @@ Handlebars.registerHelper(
 Handlebars.registerHelper('derived', (derived: Derived<string | number>) => {
     return Derived.getValue(derived);
 });
+
+Handlebars.registerHelper(
+    'skillMod',
+    (actor: CosmereActor, skill: Skill, attribute?: Attribute) => {
+        return actor.getSkillMod(skill, attribute);
+    },
+);
+
+Handlebars.registerHelper(
+    'formulaReplaceData',
+    (formula: string, data: Record<string, unknown>) => {
+        return Roll.replaceFormulaData(formula, data, { missing: '0' });
+    },
+);
+
+Handlebars.registerHelper('itemContext', (item: CosmereItem) => {
+    const context = {} as ItemContext;
+    const subtitle = [] as string[];
+
+    const isWeapon = item.isWeapon();
+
+    if (isWeapon) {
+        subtitle.push(
+            game.i18n!.localize(
+                CONFIG.COSMERE.attack.types[item.system.attack.type].label,
+            ),
+        );
+    }
+
+    if (item.hasTraits()) {
+        subtitle.push(
+            ...Array.from(item.system.traits)
+                .map((trait) => trait.id)
+                .map((traitId) =>
+                    isWeapon
+                        ? CONFIG.COSMERE.traits.weaponTraits[
+                              traitId as WeaponTraitId
+                          ].label
+                        : CONFIG.COSMERE.traits.armorTraits[
+                              traitId as ArmorTraitId
+                          ].label,
+                )
+                .map((label) => game.i18n!.localize(label)),
+        );
+    }
+
+    if (item.hasActivation()) {
+        // Check if a skill test is configured
+        if (item.system.activation.skill) {
+            const skill = item.system.activation.skill;
+            const attribute = item.system.activation.attribute;
+
+            context.hasSkillTest = true;
+            context.skillTest = {
+                skill,
+                skillLabel: CONFIG.COSMERE.skills[skill].label,
+                usesDefaultAttribute:
+                    !attribute ||
+                    attribute === CONFIG.COSMERE.skills[skill].attribute,
+
+                ...(attribute
+                    ? {
+                          attribute,
+                          attributeLabel:
+                              CONFIG.COSMERE.attributes[attribute].label,
+                          attributeLabelShort:
+                              CONFIG.COSMERE.attributes[attribute].labelShort,
+                      }
+                    : {}),
+            };
+        }
+
+        // Check if the activation consumes some resource
+        if (item.system.activation.consume) {
+            // Get the actor resource consumed
+            const resource = item.system.activation.consume.resource;
+
+            context.hasConsume = true;
+            context.consume = {
+                type: item.system.activation.consume.type,
+                value: item.system.activation.consume.value,
+                consumesResource:
+                    item.system.activation.consume.type ===
+                    ItemConsumeType.Resource,
+                consumesCharge:
+                    item.system.activation.consume.type ===
+                    ItemConsumeType.Charge,
+                consumesItem:
+                    item.system.activation.consume.type ===
+                    ItemConsumeType.Item,
+
+                ...(resource
+                    ? {
+                          resource,
+                          resourceLabel:
+                              CONFIG.COSMERE.resources[resource].label,
+                      }
+                    : {}),
+            };
+        }
+
+        // Check if an activation cost is set
+        if (item.system.activation.cost?.type) {
+            subtitle.push(
+                `${item.system.activation.cost.value ?? ''} ${game.i18n!.localize(
+                    CONFIG.COSMERE.action.costs[
+                        item.system.activation.cost.type
+                    ].label,
+                )}`.trim(),
+            );
+        }
+
+        // Check if item has resources
+        if (item.system.resources) {
+            context.hasResources = true;
+            context.resources = {};
+
+            // Check if item has charges
+            if (item.system.resources.charge) {
+                const hasMax = item.system.resources.charge.max != null;
+                const hasRecharge =
+                    item.system.resources.charge.recharge != null;
+
+                context.resources.hasCharges = true;
+                context.resources.charges = {
+                    value: item.system.resources.charge.value,
+                    hasMax,
+                    max: hasMax
+                        ? item.system.resources.charge.max
+                        : item.system.resources.charge.value,
+                    hasRecharge,
+
+                    ...(hasRecharge
+                        ? {
+                              recharge: item.system.resources.charge.recharge,
+                              rechargeLabel:
+                                  CONFIG.COSMERE.items.activation.charges
+                                      .recharge[
+                                      item.system.resources.charge.recharge!
+                                  ].label,
+                          }
+                        : {}),
+                };
+            }
+        }
+    }
+
+    if (item.hasDamage() && item.system.damage.formula) {
+        const skill = item.system.damage.skill;
+        const attribute = item.system.damage.attribute;
+
+        const hasSkill = !!skill;
+        const hasAttribute = !!attribute;
+
+        context.hasDamage = true;
+        context.damage = {
+            formula: item.system.damage.formula,
+            formulaData: {
+                ...item.actor?.getRollData(),
+            },
+            hasSkill,
+            hasAttribute,
+
+            ...(hasSkill
+                ? {
+                      skill,
+                      skillLabel: CONFIG.COSMERE.skills[skill].label,
+                      usesDefaultAttribute:
+                          !hasAttribute ||
+                          attribute === CONFIG.COSMERE.skills[skill].attribute,
+                  }
+                : {}),
+
+            ...(hasAttribute
+                ? {
+                      attribute,
+                      attributeLabel:
+                          CONFIG.COSMERE.attributes[attribute].label,
+                      attributeLabelShort:
+                          CONFIG.COSMERE.attributes[attribute].labelShort,
+                  }
+                : {}),
+
+            ...(item.system.damage.type
+                ? {
+                      type: item.system.damage.type,
+                      typeLabel:
+                          CONFIG.COSMERE.damageTypes[item.system.damage.type]
+                              .label,
+                  }
+                : {}),
+        };
+    }
+
+    return {
+        ...context,
+        subtitle: subtitle.join(', '),
+    };
+});
+
+export async function preloadHandlebarsTemplates() {
+    const partials = [
+        'systems/cosmere-rpg/templates/actors/parts/actions.hbs',
+        'systems/cosmere-rpg/templates/actors/parts/inventory.hbs',
+    ];
+
+    return await loadTemplates(
+        partials.reduce(
+            (partials, path) => {
+                partials[path.split('/').pop()!.replace('.hbs', '')] = path;
+                return partials;
+            },
+            {} as Record<string, string>,
+        ),
+    );
+}

--- a/src/system/util/handlebars/index.ts
+++ b/src/system/util/handlebars/index.ts
@@ -42,7 +42,9 @@ Handlebars.registerHelper(
         return actor.system.expertises
             .map(
                 (expertise) =>
-                    `${expertise.label} (${CONFIG.COSMERE.expertiseTypes[expertise.type].label})`,
+                    `${expertise.label} (${game.i18n!.localize(
+                        CONFIG.COSMERE.expertiseTypes[expertise.type].label,
+                    )})`,
             )
             .join(', ');
     },
@@ -83,6 +85,7 @@ Handlebars.registerHelper('itemContext', (item: CosmereItem) => {
     if (item.hasTraits()) {
         subtitle.push(
             ...Array.from(item.system.traits)
+                .filter((trait) => trait.active)
                 .map((trait) => trait.id)
                 .map((traitId) =>
                     isWeapon

--- a/src/system/util/handlebars/index.ts
+++ b/src/system/util/handlebars/index.ts
@@ -6,18 +6,27 @@ import {
     ItemConsumeType,
     Resource,
     ItemResource,
+    ItemType,
+    ActionCostType,
+    DamageType,
+    HoldType,
+    AttackType,
 } from '@src/system/types/cosmere';
 
 import { CharacterActor, CosmereActor } from '@system/documents/actor';
 import { CosmereItem } from '@system/documents/item';
 import { Derived } from '@system/data/fields';
 
-import { ItemContext } from './types';
+import { ItemContext, ItemContextOptions } from './types';
 
 Handlebars.registerHelper('add', (a: number, b: number) => a + b);
 Handlebars.registerHelper('sub', (a: number, b: number) => a - b);
 Handlebars.registerHelper('multi', (a: number, b: number) => a * b);
 Handlebars.registerHelper('divide', (a: number, b: number) => a / b);
+
+Handlebars.registerHelper('default', (v: unknown, defaultVal: unknown) => {
+    return v ? v : defaultVal;
+});
 
 Handlebars.registerHelper(
     'times',
@@ -31,6 +40,19 @@ Handlebars.registerHelper(
             )
             .join(''),
 );
+
+Handlebars.registerHelper('cosmereDingbat', (type: ActionCostType) => {
+    switch (type) {
+        case ActionCostType.FreeAction:
+            return '0';
+        case ActionCostType.Reaction:
+            return 'r';
+        case ActionCostType.Special:
+            return '*';
+        default:
+            return '';
+    }
+});
 
 Handlebars.registerHelper(
     'greaterThan',
@@ -70,54 +92,291 @@ Handlebars.registerHelper(
     },
 );
 
-Handlebars.registerHelper('itemContext', (item: CosmereItem) => {
-    try {
-        const context = {} as ItemContext;
-        const subtitle = [] as string[];
+Handlebars.registerHelper('itemHoldSelect', (selected?: HoldType) => {
+    const holdTypes = Object.keys(
+        CONFIG.COSMERE.items.equip.hold,
+    ) as HoldType[];
 
-        const isWeapon = item.isWeapon();
+    return `
+        <ul class="dropdown">
+        ${holdTypes
+            .map((hold) => {
+                // Get the config
+                const config = CONFIG.COSMERE.items.equip.hold[hold];
 
-        if (isWeapon) {
-            subtitle.push(
-                game.i18n!.localize(
-                    CONFIG.COSMERE.attack.types[item.system.attack.type].label,
-                ),
-            );
-        }
+                const isSelected = hold === selected;
 
-        if (item.hasTraits()) {
-            subtitle.push(
-                ...Array.from(item.system.traits)
-                    .filter((trait) => trait.active)
-                    .map((trait) => trait.id)
-                    .map((traitId) =>
-                        isWeapon
-                            ? CONFIG.COSMERE.traits.weaponTraits[
-                                  traitId as WeaponTraitId
-                              ].label
-                            : CONFIG.COSMERE.traits.armorTraits[
-                                  traitId as ArmorTraitId
-                              ].label,
+                return `
+            <li class="option">
+                <a role="button" 
+                    data-type="${hold}"
+                    data-action="equip-hold" 
+                    class="option-select ${isSelected ? 'selected' : ''}" 
+                    title="${game.i18n!.localize(config.label)}"
+                >
+                    ${config.icon}
+                </a>
+            </li>    
+        `;
+            })
+            .join('\n')}
+        </ul>
+    `;
+});
+
+Handlebars.registerHelper(
+    'itemContext',
+    (item: CosmereItem, options?: { hash?: ItemContextOptions }) => {
+        try {
+            const context = {} as Partial<ItemContext>;
+            const subtitle = [] as string[];
+
+            const isWeapon = item.isWeapon();
+
+            if (isWeapon) {
+                const attack = item.system.attack;
+
+                subtitle.push(
+                    game.i18n!.localize(
+                        CONFIG.COSMERE.attack.types[attack.type].label,
+                    ),
+                );
+
+                if (attack.range?.value) {
+                    if (attack.type === AttackType.Melee) {
+                        subtitle[0] += ` + ${attack.range.value}`;
+                    } else {
+                        subtitle[0] += ` (${attack.range.value}${attack.range.units}${
+                            attack.range.long
+                                ? `/${attack.range.long}${attack.range.units}`
+                                : ''
+                        })`;
+                    }
+                }
+            }
+
+            if (item.isPhysical()) {
+                context.isPhysical = true;
+                context.quantity = item.system.quantity;
+                context.weight = {
+                    value: item.system.weight.value,
+                    unit: item.system.weight.unit,
+                };
+                context.price = {
+                    value: item.system.price.value,
+                    unit: item.system.price.unit,
+                };
+            }
+
+            if (item.isEquippable() && !item.system.alwaysEquipped) {
+                context.isEquippable = true;
+                context.equipped = item.system.equipped;
+
+                const type = item.system.equip.type;
+                const hold = item.system.equip.hold;
+
+                context.equip = {
+                    type,
+                    typeLabel: CONFIG.COSMERE.items.equip.types[type].label,
+                    typeIcon: CONFIG.COSMERE.items.equip.types[type].icon,
+
+                    hold,
+                    ...(hold
+                        ? {
+                              holdLabel:
+                                  CONFIG.COSMERE.items.equip.hold[hold].label,
+                              holdIcon:
+                                  CONFIG.COSMERE.items.equip.hold[hold].icon,
+                          }
+                        : {}),
+                };
+
+                if (options?.hash?.showEquippedHand !== false) {
+                    if (hold && hold !== HoldType.TwoHanded) {
+                        subtitle.push(
+                            game.i18n!.localize(
+                                CONFIG.COSMERE.items.equip.hold[hold].label,
+                            ),
+                        );
+                    }
+                }
+            }
+
+            if (item.hasTraits()) {
+                subtitle.push(
+                    ...Array.from(item.system.traits)
+                        .filter((trait) => trait.active)
+                        .map((trait) => trait.id)
+                        .map((traitId) =>
+                            isWeapon
+                                ? CONFIG.COSMERE.traits.weaponTraits[
+                                      traitId as WeaponTraitId
+                                  ].label
+                                : CONFIG.COSMERE.traits.armorTraits[
+                                      traitId as ArmorTraitId
+                                  ].label,
+                        )
+                        .map((label) => game.i18n!.localize(label)),
+                );
+            }
+
+            if (item.hasActivation()) {
+                context.hasActivation = true;
+                context.activation = {};
+
+                if (item.system.activation.cost?.type) {
+                    context.activation.hasCost = true;
+                    context.activation.cost = {
+                        type: item.system.activation.cost.type,
+                        typeLabel:
+                            CONFIG.COSMERE.action.costs[
+                                item.system.activation.cost.type
+                            ].label,
+                        value: item.system.activation.cost.value,
+                    };
+                }
+
+                // Check if a skill test is configured
+                if (item.system.activation.skill) {
+                    const skill = item.system.activation.skill;
+                    const attribute = item.system.activation.attribute;
+
+                    context.hasSkillTest = true;
+                    context.skillTest = {
+                        skill,
+                        skillLabel: CONFIG.COSMERE.skills[skill].label,
+                        usesDefaultAttribute:
+                            !attribute ||
+                            attribute ===
+                                CONFIG.COSMERE.skills[skill].attribute,
+
+                        ...(attribute
+                            ? {
+                                  attribute,
+                                  attributeLabel:
+                                      CONFIG.COSMERE.attributes[attribute]
+                                          .label,
+                                  attributeLabelShort:
+                                      CONFIG.COSMERE.attributes[attribute]
+                                          .labelShort,
+                              }
+                            : {}),
+                    };
+                }
+
+                // Check if the activation consumes some resource
+                if (item.system.activation.consume) {
+                    // Get the actor resource consumed
+                    const resource = item.system.activation.consume.resource;
+                    const consumesActorResource =
+                        item.system.activation.consume.type ===
+                        ItemConsumeType.ActorResource;
+                    const consumesItemResource =
+                        item.system.activation.consume.type ===
+                        ItemConsumeType.ItemResource;
+
+                    context.hasConsume = true;
+                    context.consume = {
+                        type: item.system.activation.consume.type,
+                        value: item.system.activation.consume.value,
+                        consumesActorResource,
+                        consumesItemResource,
+                        consumesItem:
+                            item.system.activation.consume.type ===
+                            ItemConsumeType.Item,
+
+                        ...(resource
+                            ? {
+                                  resource,
+                                  resourceLabel: consumesActorResource
+                                      ? CONFIG.COSMERE.resources[
+                                            resource as Resource
+                                        ].label
+                                      : CONFIG.COSMERE.items.resources.types[
+                                            resource as ItemResource
+                                        ].label,
+                              }
+                            : {}),
+                    };
+                }
+
+                // Check if item has resources
+                if (item.system.resources) {
+                    context.hasResources = true;
+
+                    // Assign resources
+                    context.resources = (
+                        Object.keys(item.system.resources) as ItemResource[]
                     )
-                    .map((label) => game.i18n!.localize(label)),
-            );
-        }
+                        .map((resourceType) => {
+                            // Get resource
+                            const resource =
+                                item.system.resources![resourceType];
+                            if (!resource) return null;
 
-        if (item.hasActivation()) {
-            // Check if a skill test is configured
-            if (item.system.activation.skill) {
-                const skill = item.system.activation.skill;
-                const attribute = item.system.activation.attribute;
+                            // Get resource config
+                            const resourceConfig =
+                                CONFIG.COSMERE.items.resources.types[
+                                    resourceType
+                                ];
 
-                context.hasSkillTest = true;
-                context.skillTest = {
-                    skill,
-                    skillLabel: CONFIG.COSMERE.skills[skill].label,
-                    usesDefaultAttribute:
-                        !attribute ||
-                        attribute === CONFIG.COSMERE.skills[skill].attribute,
+                            const hasMax = resource.max != null;
+                            const hasRecharge = resource.recharge != null;
 
-                    ...(attribute
+                            return {
+                                id: resourceType,
+                                label:
+                                    resource.value > 1
+                                        ? resourceConfig.labelPlural
+                                        : resourceConfig.label,
+                                value: resource.value,
+                                hasMax,
+                                max: hasMax ? resource.max : resource.value,
+
+                                hasRecharge,
+                                ...(hasRecharge
+                                    ? {
+                                          recharge: resource.recharge,
+                                          rechargeLabel:
+                                              CONFIG.COSMERE.items.resources
+                                                  .recharge[resource.recharge!]
+                                                  .label,
+                                      }
+                                    : {}),
+                            };
+                        })
+                        .filter((v) => !!v);
+                }
+            }
+
+            if (item.hasDamage() && item.system.damage.formula) {
+                const skill = item.system.damage.skill;
+                const attribute = item.system.damage.attribute;
+
+                const hasSkill = !!skill;
+                const hasAttribute = !!attribute;
+
+                context.hasDamage = true;
+                context.damage = {
+                    formula: item.system.damage.formula,
+                    formulaData: {
+                        ...item.actor?.getRollData(),
+                    },
+                    hasSkill,
+                    hasAttribute,
+
+                    ...(hasSkill
+                        ? {
+                              skill,
+                              skillLabel: CONFIG.COSMERE.skills[skill].label,
+                              usesDefaultAttribute:
+                                  !hasAttribute ||
+                                  attribute ===
+                                      CONFIG.COSMERE.skills[skill].attribute,
+                          }
+                        : {}),
+
+                    ...(hasAttribute
                         ? {
                               attribute,
                               attributeLabel:
@@ -127,165 +386,52 @@ Handlebars.registerHelper('itemContext', (item: CosmereItem) => {
                                       .labelShort,
                           }
                         : {}),
-                };
-            }
 
-            // Check if the activation consumes some resource
-            if (item.system.activation.consume) {
-                // Get the actor resource consumed
-                const resource = item.system.activation.consume.resource;
-                const consumesActorResource =
-                    item.system.activation.consume.type ===
-                    ItemConsumeType.ActorResource;
-                const consumesItemResource =
-                    item.system.activation.consume.type ===
-                    ItemConsumeType.ItemResource;
-
-                context.hasConsume = true;
-                context.consume = {
-                    type: item.system.activation.consume.type,
-                    value: item.system.activation.consume.value,
-                    consumesActorResource,
-                    consumesItemResource,
-                    consumesItem:
-                        item.system.activation.consume.type ===
-                        ItemConsumeType.Item,
-
-                    ...(resource
+                    ...(item.system.damage.type
                         ? {
-                              resource,
-                              resourceLabel: consumesActorResource
-                                  ? CONFIG.COSMERE.resources[
-                                        resource as Resource
-                                    ].label
-                                  : CONFIG.COSMERE.items.resources.types[
-                                        resource as ItemResource
-                                    ].label,
+                              type: item.system.damage.type,
+                              typeLabel:
+                                  CONFIG.COSMERE.damageTypes[
+                                      item.system.damage.type
+                                  ].label,
                           }
                         : {}),
                 };
             }
 
-            // Check if an activation cost is set
-            if (item.system.activation.cost?.type) {
-                subtitle.push(
-                    `${item.system.activation.cost.value ?? ''} ${game.i18n!.localize(
-                        CONFIG.COSMERE.action.costs[
-                            item.system.activation.cost.type
-                        ].label,
-                    )}`.trim(),
-                );
+            if (item.hasDescription()) {
+                if (
+                    item.system.description?.short &&
+                    item.type === ItemType.Action
+                ) {
+                    subtitle.splice(
+                        0,
+                        subtitle.length,
+                        item.system.description.short,
+                    );
+                }
             }
 
-            // Check if item has resources
-            if (item.system.resources) {
-                context.hasResources = true;
-
-                // Assign resources
-                context.resources = (
-                    Object.keys(item.system.resources) as ItemResource[]
-                )
-                    .map((resourceType) => {
-                        // Get resource
-                        const resource = item.system.resources![resourceType];
-                        if (!resource) return null;
-
-                        // Get resource config
-                        const resourceConfig =
-                            CONFIG.COSMERE.items.resources.types[resourceType];
-
-                        const hasMax = resource.max != null;
-                        const hasRecharge = resource.recharge != null;
-
-                        return {
-                            id: resourceType,
-                            label:
-                                resource.value > 1
-                                    ? resourceConfig.labelPlural
-                                    : resourceConfig.label,
-                            value: resource.value,
-                            hasMax,
-                            max: hasMax ? resource.max : resource.value,
-
-                            hasRecharge,
-                            ...(hasRecharge
-                                ? {
-                                      recharge: resource.recharge,
-                                      rechargeLabel:
-                                          CONFIG.COSMERE.items.resources
-                                              .recharge[resource.recharge!]
-                                              .label,
-                                  }
-                                : {}),
-                        };
-                    })
-                    .filter((v) => !!v);
-            }
-        }
-
-        if (item.hasDamage() && item.system.damage.formula) {
-            const skill = item.system.damage.skill;
-            const attribute = item.system.damage.attribute;
-
-            const hasSkill = !!skill;
-            const hasAttribute = !!attribute;
-
-            context.hasDamage = true;
-            context.damage = {
-                formula: item.system.damage.formula,
-                formulaData: {
-                    ...item.actor?.getRollData(),
-                },
-                hasSkill,
-                hasAttribute,
-
-                ...(hasSkill
-                    ? {
-                          skill,
-                          skillLabel: CONFIG.COSMERE.skills[skill].label,
-                          usesDefaultAttribute:
-                              !hasAttribute ||
-                              attribute ===
-                                  CONFIG.COSMERE.skills[skill].attribute,
-                      }
-                    : {}),
-
-                ...(hasAttribute
-                    ? {
-                          attribute,
-                          attributeLabel:
-                              CONFIG.COSMERE.attributes[attribute].label,
-                          attributeLabelShort:
-                              CONFIG.COSMERE.attributes[attribute].labelShort,
-                      }
-                    : {}),
-
-                ...(item.system.damage.type
-                    ? {
-                          type: item.system.damage.type,
-                          typeLabel:
-                              CONFIG.COSMERE.damageTypes[
-                                  item.system.damage.type
-                              ].label,
-                      }
-                    : {}),
+            return {
+                ...context,
+                subtitle: subtitle.join(', '),
             };
+        } catch (err) {
+            console.error(err);
+            throw err;
         }
+    },
+);
 
-        return {
-            ...context,
-            subtitle: subtitle.join(', '),
-        };
-    } catch (err) {
-        console.error(err);
-        throw err;
-    }
+Handlebars.registerHelper('damageTypeConfig', (type: DamageType) => {
+    return CONFIG.COSMERE.damageTypes[type];
 });
 
 export async function preloadHandlebarsTemplates() {
     const partials = [
         'systems/cosmere-rpg/templates/actors/parts/actions.hbs',
         'systems/cosmere-rpg/templates/actors/parts/inventory.hbs',
+        'systems/cosmere-rpg/templates/chat/parts/roll-details.hbs',
     ];
 
     return await loadTemplates(

--- a/src/system/util/handlebars/types.ts
+++ b/src/system/util/handlebars/types.ts
@@ -16,8 +16,8 @@ export interface ItemContext {
     consume: Partial<{
         type: string;
         value: number;
-        consumesResource: boolean;
-        consumesCharge: boolean;
+        consumesActorResource: boolean;
+        consumesItemResource: boolean;
         consumesItem: boolean;
 
         resource: string;
@@ -26,17 +26,17 @@ export interface ItemContext {
 
     hasResources: boolean;
     resources: Partial<{
-        hasCharges: boolean;
-        charges: Partial<{
-            value: number;
-            hasMax: boolean;
-            max: number;
+        id: string;
+        label: string;
+        labelPlural: string;
+        value: number;
+        hasMax: boolean;
+        max: number;
 
-            hasRecharge: boolean;
-            recharge: string;
-            rechargeLabel: string;
-        }>;
-    }>;
+        hasRecharge: boolean;
+        recharge?: string;
+        rechargeLabel?: string;
+    }>[];
 
     hasDamage: boolean;
     damage: Partial<{

--- a/src/system/util/handlebars/types.ts
+++ b/src/system/util/handlebars/types.ts
@@ -1,5 +1,31 @@
+export interface ItemContextOptions {
+    showEquippedHand?: boolean;
+}
+
 export interface ItemContext {
     subtitle: string;
+
+    isPhysical: boolean;
+    quantity: number;
+    weight: Partial<{
+        value: number;
+        unit: string;
+    }>;
+    price: Partial<{
+        value: number;
+        unit: string;
+    }>;
+
+    isEquippable: boolean;
+    equipped: boolean;
+    equip: Partial<{
+        type: string;
+        typeLabel: string;
+        typeIcon: string;
+        hold: string;
+        holdLabel: string;
+        holdIcon: string;
+    }>;
 
     hasSkillTest: boolean;
     skillTest: Partial<{
@@ -10,6 +36,16 @@ export interface ItemContext {
         attribute: string;
         attributeLabel: string;
         attributeLabelShort: string;
+    }>;
+
+    hasActivation: boolean;
+    activation: Partial<{
+        hasCost: boolean;
+        cost: Partial<{
+            type: string;
+            typeLabel: string;
+            value: number;
+        }>;
     }>;
 
     hasConsume: boolean;

--- a/src/system/util/handlebars/types.ts
+++ b/src/system/util/handlebars/types.ts
@@ -1,0 +1,59 @@
+export interface ItemContext {
+    subtitle: string;
+
+    hasSkillTest: boolean;
+    skillTest: Partial<{
+        skill: string;
+        skillLabel: string;
+        usesDefaultAttribute: boolean;
+
+        attribute: string;
+        attributeLabel: string;
+        attributeLabelShort: string;
+    }>;
+
+    hasConsume: boolean;
+    consume: Partial<{
+        type: string;
+        value: number;
+        consumesResource: boolean;
+        consumesCharge: boolean;
+        consumesItem: boolean;
+
+        resource: string;
+        resourceLabel: string;
+    }>;
+
+    hasResources: boolean;
+    resources: Partial<{
+        hasCharges: boolean;
+        charges: Partial<{
+            value: number;
+            hasMax: boolean;
+            max: number;
+
+            hasRecharge: boolean;
+            recharge: string;
+            rechargeLabel: string;
+        }>;
+    }>;
+
+    hasDamage: boolean;
+    damage: Partial<{
+        formula: string;
+        formulaData: object;
+        hasSkill: boolean;
+        hasAttribute: boolean;
+
+        skill: string;
+        skillLabel: string;
+        usesDefaultAttribute: boolean;
+
+        attribute: string;
+        attributeLabel: string;
+        attributeLabelShort: string;
+
+        type: string;
+        typeLabel: string;
+    }>;
+}

--- a/src/templates/actors/character-sheet.hbs
+++ b/src/templates/actors/character-sheet.hbs
@@ -1,4 +1,4 @@
-<form class="sheet actor character" autocomplete="off">
+<form class="sheet" autocomplete="off">
     <header class="sheet-header">
         <img class="profile" src="{{actor.img}}" data-tooltip="{{actor.name}}" data-edit="img" />
         <section class="header-details flexcol">
@@ -142,6 +142,30 @@
             {{/each}}
         </section>
 
+        <section class="documents">
+            <section class="favorites">
 
+            </section>
+
+            <section class="tabs">
+                {{!-- Navigation --}}
+                <nav class="sheet-navigation flexrow">
+                    <a class="tab-item active" data-tab="actions">{{ localize "COSMERE.Actor.Sheet.Actions.label" }}</a>
+                    <a class="tab-item" data-tab="inventory">{{ localize "COSMERE.Actor.Sheet.Inventory.label" }}</a>
+                </nav>
+
+                <section class="tab-body">
+                    {{!-- Actions tab --}}
+                    <div class="tab actions active" data-tab="actions">
+                        {{> actions sections=items.actions }}
+                    </div>
+
+                    {{!-- Inventory tab --}}
+                    <div class="tab inventory" data-tab="inventory">
+                        {{> inventory sections=items.inventory }}
+                    </div>
+                </section>
+            </section>
+        </section>
     </section>
 </form>

--- a/src/templates/actors/character-sheet.hbs
+++ b/src/templates/actors/character-sheet.hbs
@@ -150,18 +150,18 @@
             <section class="tabs">
                 {{!-- Navigation --}}
                 <nav class="sheet-navigation flexrow">
-                    <a class="tab-item active" data-tab="actions">{{ localize "COSMERE.Actor.Sheet.Actions.label" }}</a>
-                    <a class="tab-item" data-tab="inventory">{{ localize "COSMERE.Actor.Sheet.Inventory.label" }}</a>
+                    <a class="tab-item {{#if (eq tab "actions")}}active{{/if}}" data-tab="actions">{{ localize "COSMERE.Actor.Sheet.Actions.label" }}</a>
+                    <a class="tab-item {{#if (eq tab "inventory")}}active{{/if}}" data-tab="inventory">{{ localize "COSMERE.Actor.Sheet.Inventory.label" }}</a>
                 </nav>
 
                 <section class="tab-body">
                     {{!-- Actions tab --}}
-                    <div class="tab actions active" data-tab="actions">
+                    <div class="tab actions {{#if (eq tab "actions")}}active{{/if}}" data-tab="actions">
                         {{> actions sections=items.actions }}
                     </div>
 
                     {{!-- Inventory tab --}}
-                    <div class="tab inventory" data-tab="inventory">
+                    <div class="tab inventory {{#if (eq tab "inventory")}}active{{/if}}" data-tab="inventory">
                         {{> inventory sections=items.inventory }}
                     </div>
                 </section>

--- a/src/templates/actors/character-sheet.hbs
+++ b/src/templates/actors/character-sheet.hbs
@@ -155,14 +155,16 @@
                 </nav>
 
                 <section class="tab-body">
-                    {{!-- Actions tab --}}
-                    <div class="tab actions {{#if (eq tab "actions")}}active{{/if}}" data-tab="actions">
-                        {{> actions sections=items.actions }}
-                    </div>
+                    <div class="scroll-container">
+                        {{!-- Actions tab --}}
+                        <div class="tab actions {{#if (eq tab "actions")}}active{{/if}}" data-tab="actions">
+                            {{> actions sections=items.actions }}
+                        </div>
 
-                    {{!-- Inventory tab --}}
-                    <div class="tab inventory {{#if (eq tab "inventory")}}active{{/if}}" data-tab="inventory">
-                        {{> inventory sections=items.inventory }}
+                        {{!-- Inventory tab --}}
+                        <div class="tab inventory {{#if (eq tab "inventory")}}active{{/if}}" data-tab="inventory">
+                            {{> inventory sections=items.inventory }}
+                        </div>
                     </div>
                 </section>
             </section>

--- a/src/templates/actors/parts/actions.hbs
+++ b/src/templates/actors/parts/actions.hbs
@@ -6,7 +6,12 @@
     </li>
 
     {{#each section.items as |item|}}
+
+    {{log item.name}}
+
     {{#with (itemContext item) as |ctx|}}
+
+    {{log ctx}}
 
     <li class="item rollable" data-item-id="{{item.id}}">
         <div class="item-name" data-action="use">
@@ -45,7 +50,7 @@
 
         {{!-- Consume --}}
         {{#if ctx.hasConsume}}
-        {{#if ctx.consume.consumesResource}}
+        {{#if ctx.consume.consumesActorResource}}
         <div class="consume">
             <span class="amount val">{{ ctx.consume.value }} {{localize ctx.consume.resourceLabel }}</span>
             <span class="cost sub">{{localize "GENERIC.Cost"}}</span>
@@ -55,25 +60,21 @@
 
         {{!-- Resources --}}
         {{#if ctx.hasResources}}
-        {{#if ctx.resources.hasCharges}}
-
-        <div class="charges">
-            {{#with ctx.resources.charges as |charges|}}
+        {{#each ctx.resources as |resource|}}
+        <div class="resource" data-resource="{{resource.id}}">
             <div class="val">
-                {{#times charges.value}}<i class="charge fa-regular fa-circle-dot"></i>{{/times}}
-                {{#times (sub charges.max charges.value)}}<i class="charge fa-regular fa-circle"></i>{{/times}}
+                {{#times resource.value}}<i class="charge fa-regular fa-circle-dot"></i>{{/times}}
+                {{#times (sub resource.max resource.value)}}<i class="charge fa-regular fa-circle"></i>{{/times}}
             </div>
             <span class="sub">
-                {{#if charges.hasRecharge}}
-                {{localize charges.rechargeLabel}}
+                {{#if resource.hasRecharge}}
+                {{localize resource.rechargeLabel}}
                 {{else}}
-                {{localize "COSMERE.Item.Activation.Resources.Charge.Singular"}}
+                {{localize resource.label}}
                 {{/if}}
             </span>
-            {{/with}}
         </div>
-
-        {{/if}}
+        {{/each}}
         {{/if}}
 
         {{!-- Editing --}}

--- a/src/templates/actors/parts/actions.hbs
+++ b/src/templates/actors/parts/actions.hbs
@@ -9,7 +9,7 @@
     {{#with (itemContext item) as |ctx|}}
 
     <li class="item rollable" data-item-id="{{item.id}}">
-        <div class="item-name">
+        <div class="item-name" data-action="use">
             <img class="item-image item-action" data-action="use" role="button" src="{{item.img}}">
             <div class="name">
                 <span class="title">{{item.name}}</span>
@@ -75,6 +75,17 @@
 
         {{/if}}
         {{/if}}
+
+        {{!-- Editing --}}
+        {{!-- Assume editable for now --}}
+        <div class="item-controls">
+            <a class="edit-btn" role="button" data-action="edit"><i class="fa-solid fa-pen-to-square"></i></a>
+
+            {{!-- Only show the delete button for items that are explicitly an action --}}
+            {{#if (eq item.type "action")}}
+            <a class="delete-btn" role="button" data-action="delete"><i class="fa-solid fa-trash"></i></a>
+            {{/if}}
+        </div>
     </li>
 
     {{/with}}

--- a/src/templates/actors/parts/actions.hbs
+++ b/src/templates/actors/parts/actions.hbs
@@ -1,30 +1,41 @@
 <ol class="actions-list">
     {{#each sections as |section|}}
 
-    <li class="item-header flexrow">
+    <li class="item-header flexcol" data-section-id="{{section.id}}">
         <span class="name">{{localize section.label}}</span>
+        {{#if section.subtitle}}
+        <span class="subtitle">{{localize section.subtitle}}</span>
+        {{/if}}
     </li>
 
     {{#each section.items as |item|}}
-
-    {{log item.name}}
-
     {{#with (itemContext item) as |ctx|}}
-
-    {{log ctx}}
 
     <li class="item rollable" data-item-id="{{item.id}}">
         <div class="item-name" data-action="use">
             <img class="item-image item-action" data-action="use" role="button" src="{{item.img}}">
             <div class="name">
-                <span class="title">{{item.name}}</span>
+                <span class="title">
+                    {{item.name}}
+                    {{#if ctx.hasActivation}}
+                    {{#if ctx.activation.hasCost}}
+                    <i class="cosmere-icon">
+                        {{#if (eq ctx.activation.cost.type "act")}}
+                        {{ ctx.activation.cost.value }}
+                        {{else}}
+                        {{cosmereDingbat ctx.activation.cost.type}}
+                        {{/if}}
+                    </i>
+                    {{/if}}
+                    {{/if}}
+                </span>
                 <span class="subtitle">{{ctx.subtitle}}</span>
             </div>
         </div>
 
         {{!-- Skill Test --}}
         {{#if ctx.hasSkillTest}}
-        <div class="skill-test">
+        <div class="skill-test col">
             <span class="mod val">+{{skillMod item.parent ctx.skillTest.skill ctx.skillTest.attribute}}</span>
 
             <span class="skill sub">
@@ -40,7 +51,7 @@
 
         {{!-- Damage --}}
         {{#if ctx.hasDamage}}
-        <div class="damage">
+        <div class="damage col">
             <span class="formula val">{{formulaReplaceData ctx.damage.formula ctx.damage.formulaData}}</span>
             {{#if ctx.damage.type}}
             <span class="type sub">{{localize ctx.damage.typeLabel}}</span>
@@ -51,7 +62,7 @@
         {{!-- Consume --}}
         {{#if ctx.hasConsume}}
         {{#if ctx.consume.consumesActorResource}}
-        <div class="consume">
+        <div class="consume col">
             <span class="amount val">{{ ctx.consume.value }} {{localize ctx.consume.resourceLabel }}</span>
             <span class="cost sub">{{localize "GENERIC.Cost"}}</span>
         </div>
@@ -61,7 +72,7 @@
         {{!-- Resources --}}
         {{#if ctx.hasResources}}
         {{#each ctx.resources as |resource|}}
-        <div class="resource" data-resource="{{resource.id}}">
+        <div class="resource col" data-resource="{{resource.id}}">
             <div class="val">
                 {{#times resource.value}}<i class="charge fa-regular fa-circle-dot"></i>{{/times}}
                 {{#times (sub resource.max resource.value)}}<i class="charge fa-regular fa-circle"></i>{{/times}}

--- a/src/templates/actors/parts/actions.hbs
+++ b/src/templates/actors/parts/actions.hbs
@@ -1,0 +1,84 @@
+<ol class="actions-list">
+    {{#each sections as |section|}}
+
+    <li class="item-header flexrow">
+        <span class="name">{{localize section.label}}</span>
+    </li>
+
+    {{#each section.items as |item|}}
+    {{#with (itemContext item) as |ctx|}}
+
+    <li class="item rollable" data-item-id="{{item.id}}">
+        <div class="item-name">
+            <img class="item-image item-action" data-action="use" role="button" src="{{item.img}}">
+            <div class="name">
+                <span class="title">{{item.name}}</span>
+                <span class="subtitle">{{ctx.subtitle}}</span>
+            </div>
+        </div>
+
+        {{!-- Skill Test --}}
+        {{#if ctx.hasSkillTest}}
+        <div class="skill-test">
+            <span class="mod val">+{{skillMod item.parent ctx.skillTest.skill ctx.skillTest.attribute}}</span>
+
+            <span class="skill sub">
+                {{localize ctx.skillTest.skillLabel}}
+                {{#if (not ctx.skillTest.usesDefaultAttribute)}}
+
+                <span class="skill-attribute">({{localize ctx.skillTest.attributeLabelShort }})</span>
+
+                {{/if}}
+            </span>
+        </div>
+        {{/if}}
+
+        {{!-- Damage --}}
+        {{#if ctx.hasDamage}}
+        <div class="damage">
+            <span class="formula val">{{formulaReplaceData ctx.damage.formula ctx.damage.formulaData}}</span>
+            {{#if ctx.damage.type}}
+            <span class="type sub">{{localize ctx.damage.typeLabel}}</span>
+            {{/if}}
+        </div>
+        {{/if}}
+
+        {{!-- Consume --}}
+        {{#if ctx.hasConsume}}
+        {{#if ctx.consume.consumesResource}}
+        <div class="consume">
+            <span class="amount val">{{ ctx.consume.value }} {{localize ctx.consume.resourceLabel }}</span>
+            <span class="cost sub">{{localize "GENERIC.Cost"}}</span>
+        </div>
+        {{/if}}
+        {{/if}}
+
+        {{!-- Resources --}}
+        {{#if ctx.hasResources}}
+        {{#if ctx.resources.hasCharges}}
+
+        <div class="charges">
+            {{#with ctx.resources.charges as |charges|}}
+            <div class="val">
+                {{#times charges.value}}<i class="charge fa-regular fa-circle-dot"></i>{{/times}}
+                {{#times (sub charges.max charges.value)}}<i class="charge fa-regular fa-circle"></i>{{/times}}
+            </div>
+            <span class="sub">
+                {{#if charges.hasRecharge}}
+                {{localize charges.rechargeLabel}}
+                {{else}}
+                {{localize "COSMERE.Item.Activation.Resources.Charge.Singular"}}
+                {{/if}}
+            </span>
+            {{/with}}
+        </div>
+
+        {{/if}}
+        {{/if}}
+    </li>
+
+    {{/with}}
+    {{/each}}
+
+    {{/each}}
+</ol>

--- a/src/templates/actors/parts/inventory.hbs
+++ b/src/templates/actors/parts/inventory.hbs
@@ -1,0 +1,19 @@
+<ol class="inventory-list">
+    {{#each sections as |section|}}
+
+    <li class="items-header flexrow">
+        <h3 class="item-name">{{localize section.label}}</h3>
+    </li>
+
+    {{#each section.items as |item|}}
+
+    <li class="item flexrow rollable" data-item-id="{{item.id}}">
+        <div class="item-name flexrow">
+            <img class="item-image item-action" data-action="use" role="button" src="{{item.image}}">
+        </div>
+    </li>
+
+    {{/each}}
+
+    {{/each}}
+</ol>


### PR DESCRIPTION
Partially addresses #4 

Adds the basic actions list to the character sheet and allows the user to roll/use the actions. 

![image](https://github.com/user-attachments/assets/b0e69635-2170-4635-8789-380b586d0175)

TODO:
- [x] Style tabs
- [x] Ensure all action types are supported
- [x] Support editing/viewing of items
- [x] Allow for deletion
- [x] Code clean up
