### PR TITLE
feat: add cosmere initiative system

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,6 +36,10 @@ export default {
                     src: 'src/templates/roll/*.hbs',
                     dest: 'build/templates/roll/',
                 },
+                {
+                    src: 'src/templates/combat/*.hbs',
+                    dest: 'build/templates/combat/',
+                },
             ],
         }),
     ],

--- a/src/declarations/foundry/common/documents/combat.d.ts
+++ b/src/declarations/foundry/common/documents/combat.d.ts
@@ -1,0 +1,9 @@
+namespace foundry {
+    namespace documents {
+        declare class BaseCombat<
+            Schema extends
+                foundry.abstract.DataSchema = foundry.abstract.DataSchema,
+            Parent extends Document | null = null,
+        > extends foundry.abstract.Document<Schema, Parent> {}
+    }
+}

--- a/src/declarations/foundry/common/documents/combatant.d.ts
+++ b/src/declarations/foundry/common/documents/combatant.d.ts
@@ -1,0 +1,9 @@
+namespace foundry {
+    namespace documents {
+        declare class BaseCombatant<
+            Schema extends
+                foundry.abstract.DataSchema = foundry.abstract.DataSchema,
+            Parent extends Document | null = null,
+        > extends foundry.abstract.Document<Schema, Parent> {}
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,11 @@ import * as applications from './system/applications';
 import * as dataModels from './system/data';
 import * as documents from './system/documents';
 import * as dice from './system/dice';
+import {
+    CosmereCombat,
+    CosmereCombatTracker,
+    CosmereCombatant,
+} from './system/combat';
 
 declare global {
     interface LenientGlobalVariableTypes {
@@ -19,7 +24,7 @@ declare global {
     }
 }
 
-Hooks.once('init', () => {
+Hooks.once('init', async () => {
     CONFIG.COSMERE = COSMERE;
 
     CONFIG.Actor.dataModels = dataModels.actor.config;
@@ -27,6 +32,12 @@ Hooks.once('init', () => {
 
     CONFIG.Item.dataModels = dataModels.item.config;
     CONFIG.Item.documentClass = documents.CosmereItem;
+
+    CONFIG.Combat.documentClass = CosmereCombat;
+    CONFIG.Combatant.documentClass = CosmereCombatant;
+    CONFIG.ui.combat = CosmereCombatTracker;
+
+    await loadTemplates(['systems/cosmere-rpg/templates/combat/combatant.hbs']);
 
     Actors.unregisterSheet('core', ActorSheet);
     Actors.registerSheet('cosmere-rpg', applications.actor.CharacterSheet, {

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,1 +1,2 @@
 @import './style/sheets/module.scss';
+@import './style/combat.scss';

--- a/src/style/combat.scss
+++ b/src/style/combat.scss
@@ -1,0 +1,37 @@
+.cosmere-combatant-buttons {
+    display: flex;
+    text-align: center;
+    gap: 6px;
+}
+
+.cosmere-turn-speed-control,
+.cosmere-activate-control,
+.cosmere-activate-control-activated {
+    display: block;
+    width: 40px;
+    height: var(--sidebar-item-height);
+    background-size: 32px;
+    background-position: center;
+    background-repeat: no-repeat;
+    margin: 0 0.5em;
+}
+
+.cosmere-turn-speed-control {
+    background-image: url(/icons/svg/clockwork.svg);
+}
+
+.cosmere-activate-control,
+.cosmere-activate-control-activated {
+    background-image: url(/icons/svg/combat.svg);
+}
+
+.cosmere-activate-control-activated {
+    filter: brightness(40%);
+}
+
+.combat-phase {
+    padding: 0.5rem 0px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/src/system/combat/combat-tracker.ts
+++ b/src/system/combat/combat-tracker.ts
@@ -1,0 +1,148 @@
+import CosmereCombatant from './combatant';
+
+export default class CosmereCombatTracker extends CombatTracker {
+    //overrides default tracker template to implement slow/fast buckets and activation button.
+    //eslint-disable-next-line -- eslint rules want readonly field
+    get template() {
+        return 'systems/cosmere-rpg/templates/combat/combat-tracker.hbs';
+    }
+
+    //modifies data being sent to the combat tracker template to add turn speed, type and activation status and splitting turns between the initiative phases.
+    async getData(
+        options?: Partial<ApplicationOptions> | undefined,
+    ): Promise<object> {
+        const data = (await super.getData(options)) as {
+            turns: CosmereTurn[];
+            [x: string]: unknown;
+        };
+        data.turns = data.turns.map((turn) => {
+            const combatant: CosmereCombatant =
+                this.viewed!.getEmbeddedDocument(
+                    'Combatant',
+                    turn.id,
+                    {},
+                ) as CosmereCombatant;
+            return {
+                ...turn,
+                turnSpeed: combatant.getFlag(
+                    'cosmere-rpg',
+                    'turnSpeed',
+                ) as string,
+                type: combatant.actor.type,
+                activated: combatant.getFlag(
+                    'cosmere-rpg',
+                    'activated',
+                ) as boolean,
+            };
+        });
+        data.fastPlayers = data.turns.filter((turn) => {
+            return turn.type == 'character' && turn.turnSpeed == 'fast';
+        });
+        data.slowPlayers = data.turns.filter((turn) => {
+            return turn.type == 'character' && turn.turnSpeed == 'slow';
+        });
+        data.fastNPC = data.turns.filter((turn) => {
+            return turn.type == 'adversary' && turn.turnSpeed == 'fast';
+        });
+        data.slowNPC = data.turns.filter((turn) => {
+            return turn.type == 'adversary' && turn.turnSpeed == 'slow';
+        });
+
+        return data;
+    }
+
+    override activateListeners(html: JQuery<HTMLElement>): void {
+        super.activateListeners(html);
+        html.find('.cosmere-turn-speed-control').on(
+            'click',
+            this._onClickToggleTurnSpeed.bind(this),
+        );
+        html.find('.cosmere-activate-control').on(
+            'click',
+            this._onActivateCombatant.bind(this),
+        );
+    }
+
+    //toggles combatant turn speed on clicking the "fast/slow" text on the combat tracker window
+    protected _onClickToggleTurnSpeed(event: Event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const btn = event.currentTarget as HTMLElement;
+        const li = btn.closest<HTMLElement>('.combatant')!;
+        const combatant: CosmereCombatant = this.viewed!.getEmbeddedDocument(
+            'Combatant',
+            li.dataset.combatantId!,
+            {},
+        ) as CosmereCombatant;
+        void combatant.toggleTurnSpeed();
+    }
+
+    //activates the combatant when clicking the activation icon
+    protected _onActivateCombatant(event: Event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const btn = event.currentTarget as HTMLElement;
+        const li = btn.closest<HTMLElement>('.combatant')!;
+        const combatant: CosmereCombatant = this.viewed!.getEmbeddedDocument(
+            'Combatant',
+            li.dataset.combatantId!,
+            {},
+        ) as CosmereCombatant;
+        void combatant.setFlag('cosmere-rpg', 'activated', true);
+    }
+
+    //toggles combatant turn speed on clicking the "fast/slow" option in the turn tracker context menu
+    protected _onContextToggleTurnSpeed(li: JQuery<HTMLElement>) {
+        const combatant: CosmereCombatant = this.viewed!.getEmbeddedDocument(
+            'Combatant',
+            li.data('combatant-id') as string,
+            {},
+        ) as CosmereCombatant;
+        combatant.toggleTurnSpeed();
+    }
+
+    //resets combatants activation status to hasn't activated
+    protected _onContextResetActivation(li: JQuery<HTMLElement>) {
+        const combatant: CosmereCombatant = this.viewed!.getEmbeddedDocument(
+            'Combatant',
+            li.data('combatant-id') as string,
+            {},
+        ) as CosmereCombatant;
+        void combatant.setFlag('cosmere-rpg', 'activated', false);
+    }
+
+    _getEntryContextOptions(): ContextMenuEntry[] {
+        const menu: ContextMenuEntry[] = [
+            {
+                name: 'Toggle Turn Speed',
+                icon: '',
+                callback: this._onContextToggleTurnSpeed.bind(this),
+            },
+            {
+                name: 'Reset Activation',
+                icon: '',
+                callback: this._onContextResetActivation.bind(this),
+            },
+        ];
+        menu.push(
+            ...super
+                ._getEntryContextOptions()
+                .filter(
+                    (i) =>
+                        i.name !== 'COMBAT.CombatantReroll' &&
+                        i.name !== 'COMBAT.CombatantClear',
+                ),
+        );
+        return menu;
+    }
+}
+
+interface CosmereTurn {
+    id: string;
+    css: string;
+    pending: number;
+    finished: number;
+    type?: string;
+    turnSpeed?: string;
+    activated?: boolean;
+}

--- a/src/system/combat/combat-tracker.ts
+++ b/src/system/combat/combat-tracker.ts
@@ -15,6 +15,7 @@ export default class CosmereCombatTracker extends CombatTracker {
             turns: CosmereTurn[];
             [x: string]: unknown;
         };
+        console.log(data);
         data.turns = data.turns.map((turn) => {
             const combatant: CosmereCombatant =
                 this.viewed!.getEmbeddedDocument(
@@ -22,7 +23,7 @@ export default class CosmereCombatTracker extends CombatTracker {
                     turn.id,
                     {},
                 ) as CosmereCombatant;
-            return {
+            const newTurn: CosmereTurn = {
                 ...turn,
                 turnSpeed: combatant.getFlag(
                     'cosmere-rpg',
@@ -34,6 +35,9 @@ export default class CosmereCombatTracker extends CombatTracker {
                     'activated',
                 ) as boolean,
             };
+            //strips active player formatting
+            newTurn.css = '';
+            return newTurn;
         });
         data.fastPlayers = data.turns.filter((turn) => {
             return turn.type == 'character' && turn.turnSpeed == 'fast';

--- a/src/system/combat/combat.ts
+++ b/src/system/combat/combat.ts
@@ -1,0 +1,22 @@
+export default class CosmereCombat extends Combat {
+    //sets all defeated combatants activation status to true (already activated), and all others to false(hasn't activated yet)
+    resetActivations() {
+        for (const combatant of this.turns) {
+            void combatant.setFlag(
+                'cosmere-rpg',
+                'activated',
+                combatant.isDefeated ? true : false,
+            );
+        }
+    }
+
+    override async startCombat(): Promise<this> {
+        this.resetActivations();
+        return super.startCombat();
+    }
+
+    override async nextRound(): Promise<this | undefined> {
+        this.resetActivations();
+        return super.nextRound();
+    }
+}

--- a/src/system/combat/combatant.ts
+++ b/src/system/combat/combatant.ts
@@ -1,0 +1,42 @@
+import { DocumentModificationOptions } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/document.mjs';
+import { SchemaField } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/fields.mjs';
+import { CosmereActor } from '../documents';
+
+export default class CosmereCombatant extends Combatant {
+    //sets actor type to CosmereActor, to get typescript to stop yelling. Might be a better way to do this but I'm newish to TS and don't know how.
+    override get actor(): CosmereActor {
+        return super.actor as CosmereActor;
+    }
+
+    //on creation, combatants turn speed is set to slow, activation status to false, and then sets the initiative, bypassing the need to roll
+    protected override _onCreate(
+        data: SchemaField.InnerAssignmentType<DataSchema>,
+        options: DocumentModificationOptions,
+        userID: string,
+    ) {
+        super._onCreate(data, options, userID);
+        void this.setFlag('cosmere-rpg', 'turnSpeed', 'slow');
+        void this.setFlag('cosmere-rpg', 'activated', false);
+        void this.combat?.setInitiative(
+            this.id!,
+            this.generateInitiative(this.actor.type, 'slow'),
+        );
+    }
+
+    generateInitiative(type: string, speed: string): number {
+        let initiative: number = this.actor.system.attributes.spd.value;
+        if (type == 'character') initiative += 500;
+        if (speed == 'fast') initiative += 1000;
+        return initiative;
+    }
+
+    toggleTurnSpeed() {
+        const currentSpeed = this.getFlag('cosmere-rpg', 'turnSpeed') as string;
+        const newSpeed = currentSpeed == 'slow' ? 'fast' : 'slow';
+        void this.setFlag('cosmere-rpg', 'turnSpeed', newSpeed);
+        void this.combat?.setInitiative(
+            this.id!,
+            this.generateInitiative(this.actor.type, newSpeed),
+        );
+    }
+}

--- a/src/system/combat/index.ts
+++ b/src/system/combat/index.ts
@@ -1,0 +1,5 @@
+import CosmereCombat from './combat';
+import CosmereCombatTracker from './combat-tracker';
+import CosmereCombatant from './combatant';
+
+export { CosmereCombat, CosmereCombatTracker, CosmereCombatant };

--- a/src/templates/combat/combat-tracker.hbs
+++ b/src/templates/combat/combat-tracker.hbs
@@ -1,0 +1,110 @@
+<section class="{{cssClass}} directory flexcol" id="{{cssId}}" data-tab="{{tabName}}">
+    <header class="combat-tracker-header">
+        {{#if user.isGM}}
+        <nav class="encounters flexrow" aria-label="{{localize 'COMBAT.NavLabel'}}">
+            <a class="combat-button combat-create" aria-label="{{localize 'COMBAT.Create'}}" role="button"
+                data-tooltip="COMBAT.Create">
+                <i class="fas fa-plus"></i>
+            </a>
+            {{#if combatCount}}
+            <a class="combat-button combat-cycle" aria-label="{{localize 'COMBAT.EncounterPrevious'}}" role="button"
+                data-tooltip="COMBAT.EncounterPrevious" {{#if previousId}}data-document-id="{{previousId}}"
+                {{else}}disabled{{/if}}>
+                <i class="fas fa-caret-left"></i>
+            </a>
+            <h4 class="encounter">{{localize "COMBAT.Encounter"}} {{currentIndex}} / {{combatCount}}</h4>
+            <a class="combat-button combat-cycle" aria-label="{{localize 'COMBAT.EncounterNext'}}" role="button"
+                data-tooltip="COMBAT.EncounterNext" {{#if nextId}}data-document-id="{{nextId}}" {{else}}disabled{{/if}}>
+                <i class="fas fa-caret-right"></i>
+            </a>
+            {{/if}}
+            <a class="combat-button combat-control" aria-label="{{localize 'COMBAT.Delete'}}" role="button"
+                data-tooltip="COMBAT.Delete" data-control="endCombat" {{#unless combatCount}}disabled{{/unless}}>
+                <i class="fas fa-trash"></i>
+            </a>
+        </nav>
+        {{/if}}
+
+        <div class="encounter-controls flexrow {{#if hasCombat}}combat{{/if}}">
+            {{#if user.isGM}}
+            {{/if}}
+
+            {{#if combatCount}}
+            {{#if combat.round}}
+            <h3 class="encounter-title noborder">{{localize 'COMBAT.Round'}} {{combat.round}}</h3>
+            {{else}}
+            <h3 class="encounter-title noborder">{{localize 'COMBAT.NotStarted'}}</h3>
+            {{/if}}
+            {{else}}
+            <h3 class="encounter-title noborder">{{localize "COMBAT.None"}}</h3>
+            {{/if}}
+
+            {{#if user.isGM}}
+            <a class="combat-button combat-control" aria-label="{{localize 'labels.scope'}}" role="button"
+                data-tooltip="{{labels.scope}}" data-control="toggleSceneLink" {{#unless hasCombat}}disabled{{/unless}}>
+                <i class="fas fa-{{#unless linked}}un{{/unless}}link"></i>
+            </a>
+            {{/if}}
+            <a class="combat-button combat-settings" aria-label="{{localize 'COMBAT.Settings'}}" role="button"
+                data-tooltip="COMBAT.Settings" data-control="trackerSettings">
+                <i class="fas fa-cog"></i>
+            </a>
+        </div>
+    </header>
+
+    <ol id="combat-tracker" class="directory-list">
+        {{#if fastPlayers}}
+        <li class="combat-phase"><h4>Fast Players</h4></li>
+        {{#each fastPlayers}}
+        {{> "systems/cosmere-rpg/templates/combat/combatant.hbs"}}
+        {{/each}}
+        {{/if}}
+        {{#if fastNPC}}
+        <li class="combat-phase"><h4>Fast NPCs</h4></li>
+        {{#each fastNPC}}
+        {{> "systems/cosmere-rpg/templates/combat/combatant.hbs"}}
+        {{/each}}
+        {{/if}}
+        {{#if slowPlayers}}
+        <li class="combat-phase"><h4>Slow Players</h4></li>
+        {{#each slowPlayers}}
+        {{> "systems/cosmere-rpg/templates/combat/combatant.hbs"}}
+        {{/each}}
+        {{/if}}
+        {{#if slowNPC}}
+        <li class="combat-phase"><h4>Slow NPCs</h4></li>
+        {{#each slowNPC}}
+        {{> "systems/cosmere-rpg/templates/combat/combatant.hbs"}}
+        {{/each}}
+        {{/if}}
+    </ol>
+
+    <nav id="combat-controls" class="directory-footer flexrow" data-tooltip-direction="UP">
+        {{#if hasCombat}}
+        {{#if user.isGM}}
+        {{#if round}}
+        <a class="combat-control" aria-label="{{localize 'COMBAT.RoundPrev'}}" role="button"
+            data-tooltip="COMBAT.RoundPrev" data-control="previousRound"><i class="fas fa-step-backward"></i></a>
+        <a class="combat-control" aria-label="{{localize 'COMBAT.TurnPrev'}}" role="button"
+            data-tooltip="COMBAT.TurnPrev" data-control="previousTurn"><i class="fas fa-arrow-left"></i></a>
+        <a class="combat-control center" aria-label="{{localize 'COMBAT.End'}}" role="button"
+            data-control="endCombat">{{localize 'COMBAT.End'}}</a>
+        <a class="combat-control" aria-label="{{localize 'COMBAT.TurnNext'}}" role="button"
+            data-tooltip="COMBAT.TurnNext" data-control="nextTurn"><i class="fas fa-arrow-right"></i></a>
+        <a class="combat-control" aria-label="{{localize 'COMBAT.RoundNext'}}" role="button"
+            data-tooltip="COMBAT.RoundNext" data-control="nextRound"><i class="fas fa-step-forward"></i></a>
+        {{else}}
+        <a class="combat-control center" aria-label="{{localize 'COMBAT.Begin'}}" role="button"
+            data-control="startCombat">{{localize 'COMBAT.Begin'}}</a>
+        {{/if}}
+        {{else if control}}
+        <a class="combat-control" aria-label="{{localize 'COMBAT.TurnPrev'}}" role="button"
+            data-tooltip="COMBAT.TurnPrev" data-control="previousTurn"><i class="fas fa-arrow-left"></i></a>
+        <a class="combat-control center" aria-label="{{localize 'COMBAT.TurnEnd'}}" role="button"
+            data-control="nextTurn">{{localize 'COMBAT.TurnEnd'}}</a>
+        <a class="combat-control" aria-label="{{localize 'COMBAT.TurnNext'}}" role="button"
+            data-tooltip="COMBAT.TurnNext" data-control="nextTurn"><i class="fas fa-arrow-right"></i></a>
+        {{/if}}
+        {{/if}}
+    </nav>
+</section>

--- a/src/templates/combat/combat-tracker.hbs
+++ b/src/templates/combat/combat-tracker.hbs
@@ -85,25 +85,14 @@
         {{#if round}}
         <a class="combat-control" aria-label="{{localize 'COMBAT.RoundPrev'}}" role="button"
             data-tooltip="COMBAT.RoundPrev" data-control="previousRound"><i class="fas fa-step-backward"></i></a>
-        <a class="combat-control" aria-label="{{localize 'COMBAT.TurnPrev'}}" role="button"
-            data-tooltip="COMBAT.TurnPrev" data-control="previousTurn"><i class="fas fa-arrow-left"></i></a>
         <a class="combat-control center" aria-label="{{localize 'COMBAT.End'}}" role="button"
             data-control="endCombat">{{localize 'COMBAT.End'}}</a>
-        <a class="combat-control" aria-label="{{localize 'COMBAT.TurnNext'}}" role="button"
-            data-tooltip="COMBAT.TurnNext" data-control="nextTurn"><i class="fas fa-arrow-right"></i></a>
         <a class="combat-control" aria-label="{{localize 'COMBAT.RoundNext'}}" role="button"
             data-tooltip="COMBAT.RoundNext" data-control="nextRound"><i class="fas fa-step-forward"></i></a>
         {{else}}
         <a class="combat-control center" aria-label="{{localize 'COMBAT.Begin'}}" role="button"
             data-control="startCombat">{{localize 'COMBAT.Begin'}}</a>
         {{/if}}
-        {{else if control}}
-        <a class="combat-control" aria-label="{{localize 'COMBAT.TurnPrev'}}" role="button"
-            data-tooltip="COMBAT.TurnPrev" data-control="previousTurn"><i class="fas fa-arrow-left"></i></a>
-        <a class="combat-control center" aria-label="{{localize 'COMBAT.TurnEnd'}}" role="button"
-            data-control="nextTurn">{{localize 'COMBAT.TurnEnd'}}</a>
-        <a class="combat-control" aria-label="{{localize 'COMBAT.TurnNext'}}" role="button"
-            data-tooltip="COMBAT.TurnNext" data-control="nextTurn"><i class="fas fa-arrow-right"></i></a>
         {{/if}}
         {{/if}}
     </nav>

--- a/src/templates/combat/combatant.hbs
+++ b/src/templates/combat/combatant.hbs
@@ -1,0 +1,50 @@
+<li class="combatant actor directory-item flexrow {{this.css}}" data-combatant-id="{{this.id}}">
+    <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}" />
+    <div class="token-name flexcol">
+        <h4>{{this.name}}</h4>
+        <div class="combatant-controls flexrow">
+            {{#if ../user.isGM}}
+            <a class="combatant-control {{#if this.hidden}}active{{/if}}" aria-label="{{localize 'COMBAT.ToggleVis'}}"
+                role="button" data-tooltip="COMBAT.ToggleVis" data-control="toggleHidden">
+                <i class="fas fa-eye-slash"></i>
+            </a>
+            <a class="combatant-control {{#if this.defeated}}active{{/if}}"
+                aria-label="{{localize 'COMBAT.ToggleDead'}}" role="button" data-tooltip="COMBAT.ToggleDead"
+                data-control="toggleDefeated">
+                <i class="fas fa-skull"></i>
+            </a>
+            {{/if}}
+            {{#if this.canPing}}
+            <a class="combatant-control" aria-label="{{localize 'COMBAT.PingCombatant'}}" role="button"
+                data-tooltip="COMBAT.PingCombatant" data-control="pingCombatant">
+                <i class="fa-solid fa-bullseye-arrow"></i>
+            </a>
+            {{/if}}
+            {{#unless ../user.isGM}}
+            <a class="combatant-control" aria-label="{{localize 'COMBAT.PanToCombatant'}}" role="button"
+                data-tooltip="COMBAT.PanToCombatant" data-control="panToCombatant">
+                <i class="fa-solid fa-arrows-to-eye"></i>
+            </a>
+            {{/unless}}
+            <div class="token-effects">
+                {{#each this.effects}}
+                <img class="token-effect" src="{{this}}" />
+                {{/each}}
+            </div>
+        </div>
+    </div>
+
+    {{#if this.hasResource}}
+    <div class="token-resource">
+        <span class="resource">{{this.resource}}</span>
+    </div>
+    {{/if}}
+    <div class="cosmere-combatant-buttons">
+        <a class="cosmere-turn-speed-control"></a>
+            {{#if this.activated}}
+            <a class="cosmere-activate-control-activated"></a>
+            {{else}}
+            <a class="cosmere-activate-control"></a>
+            {{/if}}
+    </div>
+</li>


### PR DESCRIPTION
Never got around to creating an issue for this.

Overrides Foundry's default initiative rolling system to use the Cosmere RPGs slow/fast popcorn style initiative system. Implements a bucket/phases system to group combatants based on turn speed and whether they are a player character or an adversary. Defaults all combatants to slow turn speed when they are added to the combat. Added buttons to the combat tracker allowing them to switch turn speed and indicate they have acted for the turn, and set some basic styling for the combat-tracker template.

Done: 
* Create flags on combatant creation to store turn speed and activation status, defaulting to slow for the turn speed.
* Set initiative based on turn speed/character type, instead of rolling
* Add buttons to combat tracker to switch turn speed and indicate the character has activated for the turn (using default foundry icons as placeholders)
* Add headers to the combat tracker to sort player/npc turns (Fast Players, Fast NPCs, etc ...)
* Add context menu option to combat tracker combatants to reset activation status

To Do:
* Localization