### PR TITLE
feat(ancestries): [DRAFT] Adding ancestry sheets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,11 @@ Hooks.once('init', async () => {
         },
     );
 
+    Items.registerSheet('cosmere-rpg', applications.item.AncestrySheet, {
+        types: ['ancestry'],
+        label: `${game.i18n?.localize('COSMERE.Item.Type.Ancestry.label')}`,
+    });
+
     CONFIG.Dice.types.push(dice.PlotDie);
     CONFIG.Dice.terms.p = dice.PlotDie;
     CONFIG.Dice.termTypes[dice.PlotDie.name] = dice.PlotDie;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -252,7 +252,8 @@
                 },
                 "Ancestry": {
                     "label": "Ancestry",
-                    "label_plural": "Ancestries"
+                    "label_plural": "Ancestries",
+                    "desc_placeholder": "Brief description of the culture to go here. Also include any special rules text for players to read."
                 },
                 "Path": {
                     "label": "Path",

--- a/src/system/applications/actor/character-sheet.ts
+++ b/src/system/applications/actor/character-sheet.ts
@@ -252,7 +252,9 @@ export class CharacterSheet extends TabsApplicationMixin(
             })),
 
             // TODO: Default localization
-            ancestryLabel: ancestryItem?.name ?? 'DEFAULT_ANCESTRY_LABEL',
+            ancestryLabel:
+                ancestryItem?.name ??
+                game.i18n?.localize('COSMERE.Item.Type.Ancestry.label'),
 
             attributeGroups: Object.keys(CONFIG.COSMERE.attributeGroups),
             resources: Object.keys(this.actor.system.resources),

--- a/src/system/applications/actor/components/character/ancestry.ts
+++ b/src/system/applications/actor/components/character/ancestry.ts
@@ -26,7 +26,9 @@ export class CharacterAncestryComponent extends HandlebarsApplicationComponent<
             ...context,
 
             ancestry: {
-                label: ancestryItem?.name ?? 'DEFAULT_ANCESTRY_LABEL',
+                label:
+                    ancestryItem?.name ??
+                    game.i18n?.localize('COSMERE.Item.Type.Ancestry.label'),
             },
         });
     }

--- a/src/system/applications/index.ts
+++ b/src/system/applications/index.ts
@@ -1,2 +1,3 @@
 export * as actor from './actor';
+export * as item from './item';
 export * as combat from './combat';

--- a/src/system/applications/item/ancestry-sheet.ts
+++ b/src/system/applications/item/ancestry-sheet.ts
@@ -1,0 +1,24 @@
+import { CosmereItem } from '@src/system/documents';
+import { BaseSheet } from './base-sheet';
+import { AncestryItemDataModel } from '@src/system/data/item';
+
+export class AncestrySheet extends BaseSheet {
+    static get defaultOptions() {
+        return foundry.utils.mergeObject(super.defaultOptions, {
+            classes: ['cosmere-rpg', 'sheet', 'item', 'ancestry'],
+            width: 520,
+            height: 250,
+            resizeable: true,
+        });
+    }
+
+    get item() {
+        return super.item as CosmereItem<AncestryItemDataModel>;
+    }
+
+    getData() {
+        return {
+            ...super.getData(),
+        };
+    }
+}

--- a/src/system/applications/item/base-sheet.ts
+++ b/src/system/applications/item/base-sheet.ts
@@ -1,0 +1,21 @@
+import { CosmereItem } from '@system/documents/item';
+
+export class BaseSheet extends ItemSheet {
+    get template() {
+        return `systems/cosmere-rpg/templates/item/${this.item.type}-sheet.hbs`;
+    }
+
+    get item(): CosmereItem {
+        return super.item;
+    }
+
+    getData() {
+        return {
+            ...(super.getData() as ItemSheet.ItemSheetData),
+            desc: this.item.hasDescription()
+                ? this.item.system.description
+                : undefined,
+            // effects: prepareActiveEffectCategories(this.item.effects)
+        };
+    }
+}

--- a/src/system/applications/item/index.ts
+++ b/src/system/applications/item/index.ts
@@ -1,0 +1,1 @@
+export * from './ancestry-sheet';

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -358,6 +358,7 @@ const COSMERE: CosmereRPGConfig = {
             [ItemType.Ancestry]: {
                 label: 'COSMERE.Item.Type.Ancestry.label',
                 labelPlural: 'COSMERE.Item.Type.Ancestry.label_plural',
+                desc_placeholder: 'COSEMERE.Item.Type.Ancestry.desc_placeholer',
             },
             [ItemType.Path]: {
                 label: 'COSMERE.Item.Type.Path.label',

--- a/src/system/data/item/ancestry.ts
+++ b/src/system/data/item/ancestry.ts
@@ -10,11 +10,28 @@ export interface AncestryItemData extends TypedItemData, DescriptionItemData {}
 
 export class AncestryItemDataModel extends DataModelMixin(
     TypedItemMixin(),
-    DescriptionItemMixin(),
+    DescriptionItemMixin({
+        value: 'COSMERE.Item.Type.Ancestry.desc_placeholder',
+    }),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), {
-            // TODO: Advancements
+            advancement: new foundry.data.fields.SchemaField({
+                extraTalentPicks: new foundry.data.fields.SchemaField({
+                    levels: new foundry.data.fields.ArrayField(
+                        new foundry.data.fields.NumberField(),
+                    ),
+                    restrictions: new foundry.data.fields.ObjectField(),
+                    // ^ how to define a rule object?... e.g. "only attaches to owned talent in singer tree"
+                }),
+                extraTalentTrees: new foundry.data.fields.StringField(),
+                extraTalents: new foundry.data.fields.ArrayField(
+                    new foundry.data.fields.SchemaField({
+                        name: new foundry.data.fields.StringField(),
+                        level: new foundry.data.fields.NumberField(),
+                    }),
+                ),
+            }),
         });
     }
 }

--- a/src/system/data/item/mixins/description.ts
+++ b/src/system/data/item/mixins/description.ts
@@ -8,7 +8,13 @@ export interface DescriptionItemData {
     };
 }
 
-export function DescriptionItemMixin<P extends CosmereItem>() {
+export interface InitialDescriptionItemValues {
+    value: string;
+}
+
+export function DescriptionItemMixin<P extends CosmereItem>(
+    params?: InitialDescriptionItemValues,
+) {
     return (
         base: typeof foundry.abstract.TypeDataModel<DescriptionItemData, P>,
     ) => {
@@ -18,6 +24,7 @@ export function DescriptionItemMixin<P extends CosmereItem>() {
                     description: new foundry.data.fields.SchemaField({
                         value: new foundry.data.fields.HTMLField({
                             label: 'Description',
+                            initial: params?.value ? params.value : undefined,
                         }),
                         chat: new foundry.data.fields.HTMLField({
                             label: 'Chat description',

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -172,6 +172,7 @@ export interface DamageTypeConfig {
 export interface ItemTypeConfig {
     label: string;
     labelPlural: string;
+    desc_placeholder?: string;
 }
 
 export interface EquipTypeConfig {

--- a/src/templates/item/ancestry-sheet.hbs
+++ b/src/templates/item/ancestry-sheet.hbs
@@ -1,0 +1,12 @@
+<form class="sheet" autocomplete="off">
+    <header class="sheet-header">
+        <img class="profile" src="{{item.img}}" data-tooltip="{{img.name}}" data-edit="img" />
+        <h1 class="document-name">
+            <input class="value" type="text" name="name" value={{item.name}} />
+        </h1>
+    </header>
+    <div>
+        {{ log desc }}
+        {{editor (localize desc.value) target="desc.value" button=true owner=owner editable=true engine="prosemirror"}}
+    </div>
+</form>


### PR DESCRIPTION
Continuation of #34 
Resolves: #12

feat(ancestry items): Base item sheets and ancestry sheet created, added rough advancement data model for ancestries, included default description placeholder.

CURRENTLY BREAKING OTHER ITEM TYPES - the initial values in the description mixin are not as optional as I want them to be...

Pushing before switching to V2 sheets

To Do:

- [ ] Switch to V2 sheets
- [ ] Fix the default value issues
- [ ] Figure out how the Handlebars Editor helper actually works
- [ ] Resolve Editor permissions
-- Only GM + {perm level} can edit
-- Add fields for editors to allow changes to short & chat descriptions
-- Add a second tab for updating mechanics
- [ ] Styling