### PR TITLE
feat(character): add defaults for character actor prototype token (sight, data link, disposition)

### DIFF
--- a/src/declarations/foundry/client/data/documents/actor.d.ts
+++ b/src/declarations/foundry/client/data/documents/actor.d.ts
@@ -21,6 +21,7 @@ declare class Actor<
     public readonly name: string;
     public readonly img: string;
     public readonly system: D;
+    public prototypeToken: TokenDocument | null;
 
     /**
      * The statuses that are applied to this actor by active effects

--- a/src/declarations/foundry/common/abstract/data.d.ts
+++ b/src/declarations/foundry/common/abstract/data.d.ts
@@ -530,6 +530,76 @@ namespace foundry {
              * @returns The updated document instance
              */
             async unsetFlag(scope: string, key: string): Promise<Document>;
+
+            /* --- Database Creation Operations --- */
+
+            /**
+             * Pre-process a creation operation for a single Document instance. Pre-operation events only occur for the client
+             * which requested the operation.
+             *
+             * Modifications to the pending Document instance must be performed using {@link Document#updateSource}.
+             *
+             * @param data                          The initial data object provided to the document creation request
+             * @param options                       Additional options which modify the creation request
+             * @param user                          The User requesting the document creation
+             *                                      Return false to exclude this Document from the creation operation
+             * @internal
+             */
+            async _preCreate(
+                data: object,
+                options: object,
+                user: documents.BaseUser,
+            ): Promise<boolean | void>;
+
+            /**
+             * Post-process a creation operation for a single Document instance. Post-operation events occur for all connected
+             * clients.
+             *
+             * @param data                          The initial data object provided to the document creation request
+             * @param options                       Additional options which modify the creation request
+             * @param userId                        The id of the User requesting the document update
+             * @internal
+             */
+            _onCreate(data: object, options: object, userId: string): void;
+
+            /**
+             * Pre-process a creation operation, potentially altering its instructions or input data. Pre-operation events only
+             * occur for the client which requested the operation.
+             *
+             * This batch-wise workflow occurs after individual {@link Document#_preCreate} workflows and provides a final
+             * pre-flight check before a database operation occurs.
+             *
+             * Modifications to pending documents must mutate the documents array or alter individual document instances using
+             * {@link Document#updateSource}.
+             *
+             * @param documents                     Pending document instances to be created
+             * @param operation                     Parameters of the database creation operation
+             * @param user                          The User requesting the creation operation
+             * @returns                             Return false to cancel the creation operation entirely
+             * @internal
+             */
+            static async _preCreateOperation(
+                documents: Document[],
+                operation: DatabaseCreateOperation,
+                user: documents.BaseUser,
+            ): Promise<boolean | void>;
+
+            /**
+             * Post-process a creation operation, reacting to database changes which have occurred. Post-operation events occur
+             * for all connected clients.
+             *
+             * This batch-wise workflow occurs after individual {@link Document#_onCreate} workflows.
+             *
+             * @param documents                     The Document instances which were created
+             * @param operation                     Parameters of the database creation operation
+             * @param user                          The User who performed the creation operation
+             * @internal
+             */
+            static async _onCreateOperation(
+                documents: Document[],
+                operation: DatabaseCreateOperation,
+                user: documents.BaseUser,
+            ): Promise<void>;
         }
 
         interface DataValidationOptions {

--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -5,6 +5,19 @@
         }
     }
 
+    .cultures-placeholder {
+        border: 1px dashed;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem 1rem;
+        opacity: 0.5;
+        box-shadow: 0 0 1rem 0.1rem black;
+        background: #00000036;
+        text-align: center;
+        border-radius: 0.3rem;
+        margin-bottom: 1rem;
+    }
+
     /* --- Tabs --- */
 
     .tab.split {

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -157,6 +157,30 @@ export class CosmereActor<
 
     /* --- Lifecycle --- */
 
+    public override async _preCreate(
+        data: object,
+        options: object,
+        user: foundry.documents.BaseUser,
+    ): Promise<boolean | void> {
+        if ((await super._preCreate(data, options, user)) === false)
+            return false;
+
+        // Configure prototype token settings
+        const prototypeToken = {};
+
+        if (this.isCharacter()) {
+            foundry.utils.mergeObject(prototypeToken, {
+                sight: {
+                    enabled: true,
+                },
+                actorLink: true,
+                disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+            });
+        }
+
+        this.updateSource({ prototypeToken });
+    }
+
     public override async createEmbeddedDocuments(
         embeddedName: string,
         data: object[],


### PR DESCRIPTION
…ght, data link, disposition)

<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds default values for several fields of the Character Actor prototype token. Specifically it enables vision, links actor data and sets the disposition to friendly. These settings are only set upon Character creation, so only apply to new Characters.

**Related Issue**  
Closes #83 

**How Has This Been Tested?**  
Created a new Character and checked if the prototype token had the expected settings

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/8fe7284e-1ca5-46bf-8216-8c9b882ba0be)
![image](https://github.com/user-attachments/assets/598e3338-89a0-4fc8-80b7-e8a4a9f5b8a7)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.