### PR TITLE
fix(long rest dialog): set correct localization string

### DIFF
--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -688,7 +688,7 @@ export class CosmereActor<
                         title: 'COSMERE.Actor.Sheet.LongRest',
                     },
                     content: `<span>${game.i18n!.localize(
-                        'COSMERE.Actor.Sheet.ShouldPerformLongRest',
+                        'DIALOG.LongRest.ShouldPerform',
                     )}</span>`,
                     buttons: [
                         {


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR replaces the localization string in the long rest dialog with the correct one. 

**Related Issue**  
Closes #85 

**How Has This Been Tested?**  
Opened the character sheet and clicked on the long rest button.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/14146d6e-b08b-4254-b5aa-01abb1ac1db8)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.