### PR TITLE
fix(damage roll): make advantage correctly apply to damage rolls

### DIFF
--- a/src/style/chat/module.scss
+++ b/src/style/chat/module.scss
@@ -263,6 +263,10 @@
                     display: flex;
                     padding: 0.3rem 0.25rem;
                     margin: 0;
+
+                    .delim {
+                        margin-right: .5rem;
+                    }
                 }
             }
 
@@ -339,6 +343,10 @@
                         margin-right: 0.1rem;
                     }
                 }
+            }
+
+            &.discarded {
+                opacity: 0.3;
             }
 
             &::after {

--- a/src/system/dice/damage-roll.ts
+++ b/src/system/dice/damage-roll.ts
@@ -93,14 +93,24 @@ export class DamageRoll extends foundry.dice.Roll<DamageRollData> {
             const modifier = this.hasAdvantage ? 'kh' : 'kl';
 
             if (dieTerm.number && dieTerm.number > 1) {
+                // Remove one die from the original
+                dieTerm.number -= 1;
+
+                // Create a new term with the modifier
                 const newTerm = new foundry.dice.terms.Die({
-                    number: 1,
+                    number: 2,
                     faces: dieTerm.faces,
                     modifiers: [modifier],
                 });
 
-                this.terms.push(newTerm);
+                this.terms.push(
+                    new foundry.dice.terms.OperatorTerm({
+                        operator: '+',
+                    }),
+                    newTerm,
+                );
             } else if (dieTerm.number === 1) {
+                dieTerm.number = 2;
                 dieTerm.modifiers.push(modifier);
             }
         }

--- a/src/templates/chat/parts/roll-details.hbs
+++ b/src/templates/chat/parts/roll-details.hbs
@@ -35,7 +35,7 @@
             <ul>
                 {{#each dice as |die|}}
                 {{#each die.results as |roll|}}
-                <li class="die roll {{die.denomination}}">
+                <li class="die roll {{die.denomination}} {{#if roll.discarded}}discarded{{/if}}">
                     <span>
                     {{#if (not die.isPlotDie)}}
                         {{roll.result}}
@@ -52,6 +52,10 @@
                     </span>
                 </li>
                 {{/each}}
+
+                {{#if (not @last)}}
+                <li class="delim"></li>
+                {{/if}}
                 {{/each}}
             </ul>
         </div>


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes advantage not correctly applying to damage rolls. 

**Related Issue**  
Closes #84 

**How Has This Been Tested?**  
Rolled an attack from a character sheet, with a weapon which had the damage set to 2d10, with advantage.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/2a674269-7105-42e8-b333-e3ef1eb033cf)
![image](https://github.com/user-attachments/assets/5f1a4dac-1aeb-4766-91f8-0da12ceab027)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.