### PR TITLE
feat(item sheets): add max height

### DIFF
--- a/src/style/sheets/item/module.scss
+++ b/src/style/sheets/item/module.scss
@@ -1,4 +1,6 @@
 .sheet.item {
+    max-height: 800px;
+
     &.side-tabs {
         overflow: visible;
 

--- a/src/system/applications/item/action-sheet.ts
+++ b/src/system/applications/item/action-sheet.ts
@@ -36,6 +36,7 @@ export class ActionItemSheet extends BaseItemSheet {
             'sheet-content': {
                 template:
                     'systems/cosmere-rpg/templates/item/action/parts/sheet-content.hbs',
+                scrollable: ['.tab-body'],
             },
         },
     );

--- a/src/system/applications/item/talent-sheet.ts
+++ b/src/system/applications/item/talent-sheet.ts
@@ -46,6 +46,7 @@ export class TalentItemSheet extends BaseItemSheet {
             'sheet-content': {
                 template:
                     'systems/cosmere-rpg/templates/item/talent/parts/sheet-content.hbs',
+                scrollable: ['.tab-body'],
             },
         },
     );

--- a/src/system/applications/item/weapon-sheet.ts
+++ b/src/system/applications/item/weapon-sheet.ts
@@ -36,6 +36,7 @@ export class WeaponItemSheet extends BaseItemSheet {
             'sheet-content': {
                 template:
                     'systems/cosmere-rpg/templates/item/parts/sheet-content.hbs',
+                scrollable: ['.tab-body'],
             },
         },
     );


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR gives item sheets a max height. This makes it so that items with a lot of options (like weapons) don't take up the entire screen height.

**Related Issue**  
Closes #92 

**How Has This Been Tested?**  
Opened an Item of each type and navigated to the details tab to verify the max height was applied properly (where needed).

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/11a78254-d3d2-463a-a994-4abb509de3ef)

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas. (Not relevant)
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.