### PR TITLE
feat(character sheet): add functionality to add actions directly from the sheet

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -278,7 +278,8 @@
                 "Armor": {
                     "label": "Armor",
                     "label_plural": "Armor",
-                    "desc_placeholder": "Edit this to describe what this armor is & how it looks."
+                    "desc_placeholder": "Edit this to describe what this armor is & how it looks.",
+                    "New": "New Armor"
                 },
                 "Equipment": {
                     "label": "Equipment",
@@ -289,7 +290,8 @@
                 "Loot": {
                     "label": "Loot",
                     "label_plural": "Loot",
-                    "desc_placeholder": "Edit this to describe the item."
+                    "desc_placeholder": "Edit this to describe the item.",
+                    "New": "New Loot"
                 },
                 "Ancestry": {
                     "label": "Ancestry",
@@ -862,6 +864,7 @@
         "Clear": "Clear",
         "Name": "Name",
         "Level": "Level",
+        "Add": "Add",
         "Button": {
             "Roll": "Roll",
             "Continue": "Continue",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -155,7 +155,10 @@
                     "Consume": "Cost",
                     "Uses": "Uses",
                     "Use": "Use action",
-                    "Strike": "Strike"
+                    "Strike": "Strike",
+                    "BaseSectionName": "{type} Actions",
+                    "MiscSectionName": "Miscellaneous Actions",
+                    "NewItem": "Add Action"
                 },
                 "Equipment": {
                     "Quantity": "Quantity",
@@ -269,7 +272,8 @@
                 "Weapon": {
                     "label": "Weapon",
                     "label_plural": "Weapons",
-                    "desc_placeholder": "Edit this to describe what this weapon is & how it looks."
+                    "desc_placeholder": "Edit this to describe what this weapon is & how it looks.",
+                    "New": "New Weapon"
                 },
                 "Armor": {
                     "label": "Armor",
@@ -279,7 +283,8 @@
                 "Equipment": {
                     "label": "Equipment",
                     "label_plural": "Equipment",
-                    "desc_placeholder": "Edit this to describe what this piece of equipment is & how it looks."
+                    "desc_placeholder": "Edit this to describe what this piece of equipment is & how it looks.",
+                    "New": "New Equipment"
                 },
                 "Loot": {
                     "label": "Loot",
@@ -309,17 +314,20 @@
                 "Talent": {
                     "label": "Talent",
                     "label_plural": "Talents",
-                    "desc_placeholder": "Edit this to describe what this Talent does."
+                    "desc_placeholder": "Edit this to describe what this Talent does.",
+                    "New": "New Talent"
                 },
                 "Action": {
                     "label": "Action",
                     "label_plural": "Actions",
-                    "desc_placeholder": "Edit this to describe what this action is and does."
+                    "desc_placeholder": "Edit this to describe what this action is and does.",
+                    "New": "New Action"
                 },
                 "Trait": {
                     "label": "Trait",
                     "label_plural": "Traits",
-                    "desc_placeholder": "Edit this to describe this trait."
+                    "desc_placeholder": "Edit this to describe this trait.",
+                    "New": "New Trait"
                 },
                 "Injury": {
                     "label": "Injury",

--- a/src/style/sheets/actor/module.scss
+++ b/src/style/sheets/actor/module.scss
@@ -740,8 +740,6 @@
                 }
 
                 .controls {
-                    // width: 3rem;
-                    color: rgba(231, 209, 177, 0.3);
                     height: 100%;
 
                     > * {
@@ -756,6 +754,10 @@
                     &.edit {
                         width: 5rem;
                     }
+                }
+
+                &:not(.header) .controls {
+                    color: rgba(231, 209, 177, 0.3);
                 }
 
                 &:not(.expanded) {

--- a/src/system/applications/actor/components/adversary/actions-list.ts
+++ b/src/system/applications/actor/components/adversary/actions-list.ts
@@ -33,17 +33,6 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
                     item.system.alwaysEquipped,
             );
 
-        // Get all traits items
-        const traitItems = activatableItems.filter((item) => item.isTrait());
-
-        // Get all weapon items
-        const weaponItems = activatableItems.filter((item) => item.isWeapon());
-
-        // Get all action items (all non-trait, non-weapon items)
-        const actionItems = activatableItems.filter(
-            (item) => !item.isTrait() && !item.isWeapon(),
-        );
-
         // Ensure all items have an expand state record
         activatableItems.forEach((item) => {
             if (!(item.id in this.itemState)) {
@@ -69,19 +58,19 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
             sections: [
                 await this.prepareSectionData(
                     this.sections[0],
-                    traitItems,
+                    activatableItems,
                     searchText,
                     sortDir,
                 ),
                 await this.prepareSectionData(
                     this.sections[1],
-                    weaponItems,
+                    activatableItems,
                     searchText,
                     sortDir,
                 ),
                 await this.prepareSectionData(
                     this.sections[2],
-                    actionItems,
+                    activatableItems,
                     searchText,
                     sortDir,
                 ),
@@ -139,6 +128,7 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
     ) {
         // Get items for section, filter by search text, and sort
         const sectionItems = items
+            .filter(section.filter)
             .filter((i) => i.name.toLowerCase().includes(searchText))
             .sort(
                 (a, b) =>

--- a/src/system/applications/component-system/system.ts
+++ b/src/system/applications/component-system/system.ts
@@ -310,8 +310,8 @@ export async function renderComponent(
 
     // Render
     const content = await renderTemplate(ComponentClass.TEMPLATE, {
-        ...context,
         ...instance,
+        ...context,
         __application: instance.application,
         __componentRef: componentRef,
         partId: instance.partId,

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -136,6 +136,10 @@ export class CosmereItem<
         return this.type === ItemType.Trait;
     }
 
+    public isEquipment(): this is CosmereItem<EquipmentItemDataModel> {
+        return this.type === ItemType.Equipment;
+    }
+
     /* --- Mixin type guards --- */
 
     /**

--- a/src/templates/actors/components/actions-list.hbs
+++ b/src/templates/actors/components/actions-list.hbs
@@ -14,7 +14,15 @@
         <div class="col controls flexrow">
             <div></div>
             {{#if @root.editable}}
-            <div></div>
+                {{#if section.canAddNewItems}}
+                    <a data-action="new-item"
+                        data-tooltip="COSMERE.Actor.Sheet.Actions.NewItem"
+                    >
+                        <i class="fa-solid fa-plus"></i>
+                    </a>
+                {{else}}
+                    <div></div>
+                {{/if}}
             {{/if}}
         </div>
     </li>

--- a/src/templates/actors/components/equipment-list.hbs
+++ b/src/templates/actors/components/equipment-list.hbs
@@ -12,7 +12,15 @@
         <div class="col controls flexrow">
             <div></div>
             {{#if @root.editable}}
-            <div></div>
+                {{#if section.canAddNewItems}}
+                    <a data-action="new-item"
+                        data-tooltip="{{concat (localize "GENERIC.Add") " " (localize (concat "TYPES.Item." section.id))}}"
+                    >
+                        <i class="fa-solid fa-plus"></i>
+                    </a>
+                {{else}}
+                    <div></div>
+                {{/if}}
             {{/if}}
         </div>
     </li>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR adds the ability to add items directly from the Actor sheet, rather than having to create them from the side menu first.

**Related Issue**  
Closes #87 

**How Has This Been Tested?**  
Tested creating actions from the Character and Adversary sheet.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/b2f1bc68-8e41-4028-971f-8f5e3b50dd78)
![image](https://github.com/user-attachments/assets/c3501cce-d3c3-4cd7-aa86-09b1a33d6a84)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.