### PR TITLE
style(editorconfig) add basic editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig: https://EditorConfig.org
+
+root = true
+
+# base rules
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# rules override for ts files
+#[.ts]
+#max_line_length = 120


### PR DESCRIPTION
**Type**  
What type of pull request is this? 
Adds a basic editorConfig file. This editorconfig will override default IDE settings like indent style (space/tab) and size (2/4 spaces)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [X] Other (please describe): src files homogeneity

**Description**  
Prevent custom style formatting from IDE.
On my default configuration, json files indents are 2spaced, and just saw that lang/en.json is 4spaced.

**Related Issue**  
Closes #100 

**How Has This Been Tested?**  
On my default IDE setting, without editorconfig : creating/updating a json file will use 2spaced indent.
After adding an editorconfig : creating/updating a json file will use 4spaced indents.

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [ ] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
I checked in various files to see if any code formatting standard was different based on it's extension, found nothing.
This is supported by nearly all IDE, so it don't require any module to be used when developping