### PR TITLE
fix(armor): fix issue causing always equipped armor to not count as equipped and implement natural deflect on actors

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -127,6 +127,12 @@
                 "Deflect": "Deflect",
                 "NoObscuredSense": "Unaffected by Obscured Senses."
             },
+            "Deflect": {
+                "Natural": {
+                    "Label": "Natural Deflect",
+                    "Hint": "Natural deflect is used when no armor is worn, or when the natural deflect is higher than the worn armor."
+                }
+            },
             "Size": {
                 "Small": "Small",
                 "Medium": "Medium",
@@ -207,6 +213,7 @@
                 "ToggleShowSkills": "Show skills without ranks",
                 "ToggleCollapseSkills": "Hide skills without ranks",
                 "ConfigureDefense": "Configure Defense",
+                "ConfigureDeflect": "Configure Deflect",
                 "ConfigureMovement": "Configure Movement Rate",
                 "ConfigureSensesRange": "Configure Senses Range",
                 "ConfigureRecovery": "Configure Recovery Die",
@@ -807,6 +814,9 @@
         },
         "ConfigureRecoveryDie": {
             "Title": "Configure Recovery Die: {actor}"
+        },
+        "ConfigureDeflect": {
+            "Title": "Configure Deflect: {actor}"
         },
         "EditTalentPrerequisite": {
             "Title": "Edit Prerequisite"

--- a/src/style/module.scss
+++ b/src/style/module.scss
@@ -3,3 +3,10 @@
 @import './style/sidebar/combat.scss';
 @import './style/dialog.scss';
 @import './style/components.scss';
+
+.application {
+    p.notes,
+    p.hint {
+        color: #efe6d8bf;
+    }
+}

--- a/src/style/sheets/actor/module.scss
+++ b/src/style/sheets/actor/module.scss
@@ -269,6 +269,7 @@
         }
 
         .deflect {
+            position: relative;
             background: rgb(11 10 19 / 100%);
             width: 2rem;
             display: flex;
@@ -280,6 +281,13 @@
 
             span {
                 margin: -0.1rem 0 0.3rem 0 !important
+            }
+
+            a[data-action="configure-deflect"] {
+                position: absolute;
+                font-size: 6pt;
+                left: 1.2rem;
+                top: 0;
             }
         }
     }

--- a/src/style/sheets/item/module.scss
+++ b/src/style/sheets/item/module.scss
@@ -110,11 +110,6 @@
         flex-direction: column;
     }
 
-    p.notes,
-    p.hint {
-        color: #efe6d8bf;
-    }
-
     fieldset:not(:first-child) {
         margin-top: 0.5rem;
     }

--- a/src/system/applications/actor/components/details.ts
+++ b/src/system/applications/actor/components/details.ts
@@ -5,9 +5,9 @@ import { ConstructorOf } from '@system/types/utils';
 import { ConfigureMovementRateDialog } from '@system/applications/actor/dialogs/configure-movement-rate';
 import { ConfigureSensesRangeDialog } from '@system/applications/actor/dialogs/configure-senses-range';
 import { ConfigureRecoveryDieDialog } from '@system/applications/actor/dialogs/configure-recovery-die';
+import { ConfigureDeflectDialog } from '@system/applications/actor/dialogs/configure-deflect';
 
 // Component imports
-// import { HandlebarsApplicationComponent } from '../../mixins/component-handlebars-application-mixin';
 import { HandlebarsApplicationComponent } from '@system/applications/component-system';
 import { BaseActorSheet, BaseActorSheetRenderContext } from '../base';
 import { CosmereActor } from '@src/system/documents';
@@ -29,6 +29,7 @@ export class ActorDetailsComponent extends HandlebarsApplicationComponent<
         'configure-movement-rate': this.onConfigureMovementRate,
         'configure-senses-range': this.onConfigureSensesRange,
         'configure-recovery': this.onConfigureRecovery,
+        'configure-deflect': this.onConfigureDeflect,
         'edit-img': this.onEditImg,
     };
     /* eslint-enable @typescript-eslint/unbound-method */
@@ -49,6 +50,10 @@ export class ActorDetailsComponent extends HandlebarsApplicationComponent<
 
     private static onConfigureSensesRange(this: ActorDetailsComponent) {
         void ConfigureSensesRangeDialog.show(this.application.actor);
+    }
+
+    private static onConfigureDeflect(this: ActorDetailsComponent) {
+        void ConfigureDeflectDialog.show(this.application.actor);
     }
 
     private static onConfigureRecovery(this: ActorDetailsComponent) {

--- a/src/system/applications/actor/dialogs/configure-deflect.ts
+++ b/src/system/applications/actor/dialogs/configure-deflect.ts
@@ -1,0 +1,143 @@
+import { AttributeGroup } from '@system/types/cosmere';
+import { CosmereActor } from '@system/documents';
+import { AnyObject } from '@system/types/utils';
+
+import { CommonActorData } from '@system/data/actor/common';
+import { Derived } from '@system/data/fields';
+
+const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+
+export class ConfigureDeflectDialog extends HandlebarsApplicationMixin(
+    ApplicationV2<AnyObject>,
+) {
+    /**
+     * NOTE: Unbound methods is the standard for defining actions and forms
+     * within ApplicationV2
+     */
+    /* eslint-disable @typescript-eslint/unbound-method */
+    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
+        {
+            window: {
+                minimizable: false,
+                positioned: true,
+            },
+            classes: ['dialog', 'configure-deflect'],
+            tag: 'dialog',
+            position: {
+                width: 350,
+            },
+            actions: {
+                'update-deflect': this.onUpdateDeflect,
+            },
+        },
+    );
+
+    static PARTS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.PARTS),
+        {
+            form: {
+                template:
+                    'systems/cosmere-rpg/templates/actors/dialogs/configure-deflect.hbs',
+                forms: {
+                    form: {
+                        handler: this.onFormEvent,
+                        submitOnChange: true,
+                    },
+                },
+            },
+        },
+    );
+    /* eslint-enable @typescript-eslint/unbound-method */
+
+    private data: CommonActorData['deflect'];
+    private mode: Derived.Mode;
+
+    private constructor(private actor: CosmereActor) {
+        super({
+            id: `${actor.uuid}.Deflect`,
+            window: {
+                title: game.i18n!.format('DIALOG.ConfigureDeflect.Title', {
+                    actor: actor.name,
+                }),
+            },
+        });
+
+        this.data = actor.system.deflect;
+        this.data.value ??= 0;
+        this.data.natural ??= 0;
+        this.data.override ??= this.data.value ?? 0;
+        this.data.bonus ??= 0;
+        this.mode = Derived.getMode(this.data);
+    }
+
+    /* --- Statics --- */
+
+    public static show(actor: CosmereActor) {
+        void new ConfigureDeflectDialog(actor).render(true);
+    }
+
+    /* --- Actions --- */
+
+    private static onUpdateDeflect(this: ConfigureDeflectDialog) {
+        void this.actor.update({
+            'system.deflect': this.data,
+        });
+        void this.close();
+    }
+
+    /* --- Form --- */
+
+    private static onFormEvent(
+        this: ConfigureDeflectDialog,
+        event: Event,
+        form: HTMLFormElement,
+        formData: FormDataExtended,
+    ) {
+        if (event instanceof SubmitEvent) return;
+
+        const target = event.target as HTMLInputElement;
+
+        this.mode = formData.get('mode') as Derived.Mode;
+
+        if (target.name !== 'mode') {
+            if (this.mode === Derived.Mode.Override) {
+                this.data.override = Number(formData.object.value ?? 0);
+            } else {
+                this.data.natural = Number(formData.object.natural ?? 0);
+                this.data.bonus = Number(formData.object.bonus ?? 0);
+            }
+        }
+
+        if (isNaN(this.data.override!)) this.data.override = 0;
+        if (isNaN(this.data.natural!)) this.data.natural = 0;
+        if (isNaN(this.data.bonus!)) this.data.bonus = 0;
+
+        // Assign mode
+        Derived.setMode(this.data, this.mode);
+
+        // Render
+        void this.render(true);
+    }
+
+    /* --- Lifecycle --- */
+
+    protected _onRender(context: AnyObject, options: AnyObject): void {
+        super._onRender(context, options);
+
+        $(this.element).prop('open', true);
+    }
+
+    /* --- Context --- */
+
+    protected _prepareContext() {
+        return Promise.resolve({
+            ...this.data,
+            mode: this.mode,
+            modes: {
+                ...Derived.Modes,
+                [Derived.Mode.Derived]: 'TYPES.Item.armor',
+            },
+        });
+    }
+}

--- a/src/system/data/item/mixins/equippable.ts
+++ b/src/system/data/item/mixins/equippable.ts
@@ -72,6 +72,14 @@ export function EquippableItemMixin<P extends CosmereItem>(
                     }),
                 });
             }
+
+            public prepareDerivedData() {
+                super.prepareDerivedData();
+
+                if (this.alwaysEquipped) {
+                    this.equipped = true;
+                }
+            }
         };
     };
 }

--- a/src/templates/actors/components/details.hbs
+++ b/src/templates/actors/components/details.hbs
@@ -28,6 +28,14 @@
         <span class="value">{{derived deflect}}</span>
 
         {{/with}}
+
+        {{#if isEditMode}}
+        <a data-action="configure-deflect"
+            data-tooltip="COSMERE.Actor.Sheet.ConfigureDeflect"
+        >
+            <i class="fa-solid fa-gear"></i>
+        </a>
+        {{/if}}
     </div>
     {{/if}}
 </div>
@@ -76,6 +84,13 @@
             {{#with actor.system.deflect as |deflect|}}
             <span class="value">{{derived deflect}}</span>
             {{/with}}
+            {{#if isEditMode}}
+            <a data-action="configure-deflect"
+                data-tooltip="COSMERE.Actor.Sheet.ConfigureDeflect"
+            >
+                <i class="fa-solid fa-gear"></i>
+            </a>
+            {{/if}}
         </div>
         <span class="label">
             {{localize "COSMERE.Actor.Statistics.Deflect"}}

--- a/src/templates/actors/dialogs/configure-deflect.hbs
+++ b/src/templates/actors/dialogs/configure-deflect.hbs
@@ -1,26 +1,51 @@
 <form>
+    {{!-- Value --}}
     <div class="form-group">
         <input 
-            name="formula" 
-            {{#if (eq mode 'derived')}}
-            type="text" 
-            value="{{formula}}" 
-            readonly
-            {{else}}
+            name="value" 
             style="text-align: center; font-size: 15pt"
-            type="number"
-            value="{{override}}"
+            type="number" 
             min="0"
             step="1"
+            {{#if (eq mode 'derived')}}
+            value="{{value}}" 
+            readonly
+            {{else}}
+            value="{{override}}"
             {{/if}}
         >
     </div>
+
+    {{!-- Mode --}}
     <div class="form-group">
         <label>{{localize "GENERIC.Mode"}}</label>
         <select name="mode">
             {{selectOptions modes selected=mode localize=true}}
         </select>
     </div>
+
+    {{!-- Natural deflect --}}
+    <div class="form-group">
+        <label>{{localize "COSMERE.Actor.Deflect.Natural.Label"}}</label>
+        <input 
+            name="natural" 
+            {{#if (eq mode 'derived')}}
+            type="number" 
+            value="{{this.natural}}" 
+            min="0" 
+            step="1" 
+            {{else}}
+            type="text"
+            value="—"
+            readonly
+            {{/if}}
+        >
+    </div>
+    <p class="hint">
+        {{localize "COSMERE.Actor.Deflect.Natural.Hint"}}
+    </p>
+
+    {{!-- Bonus --}}
     <div class="form-group">
         <label>{{localize "GENERIC.Bonus"}}</label>
         <input 
@@ -37,9 +62,11 @@
             {{/if}}
         >
     </div>
+
+    {{!-- Submit --}}
     <br>
     <div class="form-group">
-        <button data-action="update-defense" type="submit">
+        <button data-action="update-deflect" type="submit">
             {{localize "GENERIC.Button.Update"}}
         </button>
     </div>


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes an issue causing armor with "Always Equipped" set, to not count as equipped if it wasn't equipped at least once first. Additionally this PR implements natural deflect for Actors, which catches a lot of the edge cases where always equipped armor was needed.

**Related Issue**  
Closes #106 

**How Has This Been Tested?**  
Created a new armor item, ensured it wasn't equipped yet, set it to always equipped and checked the deflect value of the Actor.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331