### PR TITLE
fix(style): fix issue causing Penumbra font to not be loaded properly

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -62,13 +62,7 @@
 /*  Fonts                                    */
 /* ----------------------------------------- */
 @import url('https://fonts.googleapis.com/css2?family=Didact+Gothic&display=swap');
-
-@font-face {
-    font-family: 'Penumbra Web Pro';
-    font-style: normal;
-    font-weight: 400;
-    src: url('https://fonts.cdnfonts.com/css/penumbra-web-pro')
-}
+@import url('https://fonts.cdnfonts.com/css/penumbra-web-pro');
 
 @font-face {
     font-family: 'cosmere-dingbats';


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes the incorrect import of the Penumbra font.

**Related Issue**  
Closes #103 

**How Has This Been Tested?**  
Opened the console and checked if the warning still appeared.

**Checklist:**  
- [ ] I have commented on my code, particularly in hard-to-understand areas. (Not relevant)
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.