### PR TITLE
Switch all hardcoded system tags to single constant reference

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { ActorType, Condition, ItemType } from './system/types/cosmere';
-
+import { SYSTEM_ID } from './system/constants';
 import COSMERE from './system/config';
 
 import './style.scss';
 import './system/hooks';
 
 import { preloadHandlebarsTemplates } from './system/util/handlebars';
-import { registerSettings } from './system/settings';
+import { SettingsUtility } from './system/settings';
 
 import * as applications from './system/applications';
 import * as dataModels from './system/data';
@@ -94,7 +94,7 @@ Hooks.once('init', async () => {
     registerStatusEffects();
 
     // Register settings
-    registerSettings();
+    SettingsUtility.registerSettings();
 });
 
 /**
@@ -127,7 +127,7 @@ function registerActorSheet(
     type: ActorType,
     sheet: typeof foundry.applications.api.ApplicationV2<any, any, any>,
 ) {
-    Actors.registerSheet('cosmere-rpg', sheet as any, {
+    Actors.registerSheet(SYSTEM_ID, sheet as any, {
         types: [type],
         makeDefault: true,
         label: `TYPES.Actor.${type}`,
@@ -138,7 +138,7 @@ function registerItemSheet(
     type: ItemType,
     sheet: typeof foundry.applications.api.ApplicationV2<any, any, any>,
 ) {
-    Items.registerSheet('cosmere-rpg', sheet as any, {
+    Items.registerSheet(SYSTEM_ID, sheet as any, {
         types: [type],
         makeDefault: true,
         label: `TYPES.Item.${type}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import './style.scss';
 import './system/hooks';
 
 import { preloadHandlebarsTemplates } from './system/util/handlebars';
-import { SettingsUtility } from './system/settings';
+import { registerSettings } from './system/settings';
 
 import * as applications from './system/applications';
 import * as dataModels from './system/data';
@@ -94,7 +94,7 @@ Hooks.once('init', async () => {
     registerStatusEffects();
 
     // Register settings
-    SettingsUtility.registerSettings();
+    registerSettings();
 });
 
 /**

--- a/src/system/applications/actor/adversary-sheet.ts
+++ b/src/system/applications/actor/adversary-sheet.ts
@@ -1,4 +1,5 @@
 import { AdversaryActor } from '@system/documents';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Components
 import { SearchBarInputEvent } from './components';
@@ -26,7 +27,7 @@ export class AdversarySheet extends BaseActorSheet<AdversarySheetRenderContext> 
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'actor', 'adversary'],
+            classes: [SYSTEM_ID, 'sheet', 'actor', 'adversary'],
             position: {
                 width: 850,
                 height: 850,
@@ -60,9 +61,7 @@ export class AdversarySheet extends BaseActorSheet<AdversarySheetRenderContext> 
     }
 
     get areSkillsCollapsed(): boolean {
-        return (
-            this.actor.getFlag('cosmere-rpg', 'sheet.skillsCollapsed') ?? false
-        );
+        return this.actor.getFlag(SYSTEM_ID, 'sheet.skillsCollapsed') ?? false;
     }
 
     /* --- Actions --- */
@@ -70,7 +69,7 @@ export class AdversarySheet extends BaseActorSheet<AdversarySheetRenderContext> 
     private static onToggleSkillsCollapsed(this: AdversarySheet) {
         // Update the flag
         void this.actor.setFlag(
-            'cosmere-rpg',
+            SYSTEM_ID,
             'sheet.skillsCollapsed',
             !this.areSkillsCollapsed,
         );

--- a/src/system/applications/actor/base.ts
+++ b/src/system/applications/actor/base.ts
@@ -1,6 +1,7 @@
 import { Resource } from '@src/system/types/cosmere';
 import { CosmereActor } from '@system/documents/actor';
 import { DeepPartial, AnyObject } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Utils
 import AppUtils from '@system/applications/utils';
@@ -102,7 +103,7 @@ export class BaseActorSheet<
     /* --- Accessors --- */
 
     public get mode(): ActorSheetMode {
-        return this.actor.getFlag('cosmere-rpg', 'sheet.mode') ?? 'edit';
+        return this.actor.getFlag(SYSTEM_ID, 'sheet.mode') ?? 'edit';
     }
 
     /* --- Drag drop --- */

--- a/src/system/applications/actor/character-sheet.ts
+++ b/src/system/applications/actor/character-sheet.ts
@@ -2,6 +2,7 @@ import './components';
 
 import { ItemType } from '@system/types/cosmere';
 import { CharacterActor } from '@system/documents';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseActorSheet } from './base';
@@ -15,7 +16,7 @@ export class CharacterSheet extends BaseActorSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'actor', 'character'],
+            classes: [SYSTEM_ID, 'sheet', 'actor', 'character'],
             position: {
                 width: 850,
                 height: 1000,

--- a/src/system/applications/actor/components/character/goals-list.ts
+++ b/src/system/applications/actor/components/character/goals-list.ts
@@ -1,4 +1,5 @@
 import { ConstructorOf, MouseButton } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Component imports
 import { HandlebarsApplicationComponent } from '@system/applications/component-system';
@@ -107,7 +108,7 @@ export class CharacterGoalsListComponent extends HandlebarsApplicationComponent<
         // Get current state
         const hideCompletedGoals =
             this.application.actor.getFlag<boolean>(
-                'cosmere-rpg',
+                SYSTEM_ID,
                 HIDE_COMPLETED_FLAG,
             ) ?? false;
 
@@ -202,7 +203,7 @@ export class CharacterGoalsListComponent extends HandlebarsApplicationComponent<
     ) {
         const hideCompletedGoals =
             this.application.actor.getFlag<boolean>(
-                'cosmere-rpg',
+                SYSTEM_ID,
                 HIDE_COMPLETED_FLAG,
             ) ?? false;
 

--- a/src/system/applications/combat/combat-tracker.ts
+++ b/src/system/applications/combat/combat-tracker.ts
@@ -1,5 +1,6 @@
 import { ActorType, TurnSpeed } from '@src/system/types/cosmere';
 import { CosmereCombatant } from '@src/system/documents/combatant';
+import { SYSTEM_ID } from '@src/system/constants';
 
 /**
  * Overrides default tracker template to implement slow/fast buckets and combatant activation button.
@@ -35,14 +36,11 @@ export class CosmereCombatTracker extends CombatTracker {
             const newTurn: CosmereTurn = {
                 ...turn,
                 turnSpeed: combatant.getFlag(
-                    'cosmere-rpg',
+                    SYSTEM_ID,
                     'turnSpeed',
                 ) as TurnSpeed,
                 type: combatant.actor.type,
-                activated: combatant.getFlag(
-                    'cosmere-rpg',
-                    'activated',
-                ) as boolean,
+                activated: combatant.getFlag(SYSTEM_ID, 'activated') as boolean,
             };
             //strips active player formatting
             newTurn.css = '';
@@ -122,7 +120,7 @@ export class CosmereCombatTracker extends CombatTracker {
             li.dataset.combatantId!,
             {},
         ) as CosmereCombatant;
-        void combatant.setFlag('cosmere-rpg', 'activated', true);
+        void combatant.setFlag(SYSTEM_ID, 'activated', true);
     }
 
     /**
@@ -146,7 +144,7 @@ export class CosmereCombatTracker extends CombatTracker {
             li.data('combatant-id') as string,
             {},
         ) as CosmereCombatant;
-        void combatant.setFlag('cosmere-rpg', 'activated', false);
+        void combatant.setFlag(SYSTEM_ID, 'activated', false);
     }
 
     /**

--- a/src/system/applications/item/action-sheet.ts
+++ b/src/system/applications/item/action-sheet.ts
@@ -1,5 +1,6 @@
 import { ActionItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class ActionItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'action'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'action'],
             position: {
                 width: 550,
             },

--- a/src/system/applications/item/ancestry-sheet.ts
+++ b/src/system/applications/item/ancestry-sheet.ts
@@ -1,5 +1,6 @@
 import { AncestryItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 import { BaseItemSheet } from './base';
 
@@ -7,7 +8,7 @@ export class AncestrySheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'ancestry'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'ancestry'],
             position: {
                 width: 600,
                 height: 550,

--- a/src/system/applications/item/armor-sheet.ts
+++ b/src/system/applications/item/armor-sheet.ts
@@ -1,5 +1,6 @@
 import { ArmorItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -13,7 +14,7 @@ export class ArmorItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'armor'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'armor'],
             position: {
                 width: 730,
                 height: 500,

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -1,6 +1,7 @@
 import { ArmorTraitId, WeaponTraitId } from '@system/types/cosmere';
 import { CosmereItem } from '@system/documents/item';
 import { DeepPartial, AnyObject } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
@@ -286,7 +287,7 @@ export class BaseItemSheet extends TabsApplicationMixin(
             ).fields,
             editable: this.isEditable,
             descHtml: enrichedDescValue,
-            sideTabs: game.settings!.get('cosmere-rpg', 'itemSheetSideTabs'),
+            sideTabs: game.settings!.get(SYSTEM_ID, 'itemSheetSideTabs'),
         };
     }
 }

--- a/src/system/applications/item/connection-sheet.ts
+++ b/src/system/applications/item/connection-sheet.ts
@@ -1,5 +1,6 @@
 import { ConnectionItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class ConnectionItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'connection'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'connection'],
             position: {
                 width: 550,
                 height: 500,

--- a/src/system/applications/item/culture-sheet.ts
+++ b/src/system/applications/item/culture-sheet.ts
@@ -1,5 +1,6 @@
 import { CultureItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class CultureItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'culture'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'culture'],
             position: {
                 width: 550,
                 height: 500,

--- a/src/system/applications/item/equipment-sheet.ts
+++ b/src/system/applications/item/equipment-sheet.ts
@@ -1,5 +1,6 @@
 import { EquipmentItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class EquipmentItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'equipment'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'equipment'],
             position: {
                 width: 730,
                 height: 500,

--- a/src/system/applications/item/injury-sheet.ts
+++ b/src/system/applications/item/injury-sheet.ts
@@ -1,6 +1,7 @@
 import { InjuryType } from '@system/types/cosmere';
 import { InjuryItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -9,7 +10,7 @@ export class InjuryItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'injury'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'injury'],
             position: {
                 width: 550,
                 height: 500,

--- a/src/system/applications/item/loot-sheet.ts
+++ b/src/system/applications/item/loot-sheet.ts
@@ -1,5 +1,6 @@
 import { LootItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class LootItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'loot'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'loot'],
             position: {
                 width: 730,
                 height: 500,

--- a/src/system/applications/item/path-sheet.ts
+++ b/src/system/applications/item/path-sheet.ts
@@ -1,5 +1,6 @@
 import { PathItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class PathItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'path'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'path'],
             position: {
                 width: 550,
                 height: 500,

--- a/src/system/applications/item/specialty-sheet.ts
+++ b/src/system/applications/item/specialty-sheet.ts
@@ -1,5 +1,6 @@
 import { SpecialtyItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class SpecialtyItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'specialty'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'specialty'],
             position: {
                 width: 550,
                 height: 500,

--- a/src/system/applications/item/talent-sheet.ts
+++ b/src/system/applications/item/talent-sheet.ts
@@ -1,6 +1,7 @@
 import { Talent } from '@system/types/item';
 import { TalentItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -14,7 +15,7 @@ export class TalentItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'talent'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'talent'],
             position: {
                 width: 550,
             },

--- a/src/system/applications/item/trait-sheet.ts
+++ b/src/system/applications/item/trait-sheet.ts
@@ -1,5 +1,6 @@
 import { TraitItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class TraitItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'trait'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'trait'],
             position: {
                 width: 550,
                 height: 500,

--- a/src/system/applications/item/weapon-sheet.ts
+++ b/src/system/applications/item/weapon-sheet.ts
@@ -1,5 +1,6 @@
 import { WeaponItem } from '@system/documents/item';
 import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 // Base
 import { BaseItemSheet } from './base';
@@ -8,7 +9,7 @@ export class WeaponItemSheet extends BaseItemSheet {
     static DEFAULT_OPTIONS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.DEFAULT_OPTIONS),
         {
-            classes: ['cosmere-rpg', 'sheet', 'item', 'weapon'],
+            classes: [SYSTEM_ID, 'sheet', 'item', 'weapon'],
             position: {
                 width: 730,
             },

--- a/src/system/constants.ts
+++ b/src/system/constants.ts
@@ -24,3 +24,13 @@ export const IMPORTED_RESOURCES = {
     PLOT_DICE_OP:
         'https://dl.dropboxusercontent.com/scl/fi/cdswnywdr57sp79l4f9zd/Op.png?rlkey=4v6pgtxcrmwuzgazjgcpbs4xq&st=qnzdxl58&raw=1&t=.png',
 };
+
+/**
+ * String identifier for the module used throughout other scripts.
+ */
+export const SYSTEM_ID = 'cosmere-rpg';
+
+/**
+ * Full title string of the module.
+ */
+export const SYSTEM_NAME = 'Cosmere Roleplaying Game';

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -24,7 +24,7 @@ import {
 import { CharacterActorDataModel } from '@system/data/actor/character';
 import { AdversaryActorDataModel } from '@system/data/actor/adversary';
 import { Derived } from '@system/data/fields';
-
+import { SYSTEM_ID } from '../constants';
 import { d20Roll, D20Roll, D20RollData, DamageRoll } from '@system/dice';
 
 // Dialogs
@@ -119,11 +119,11 @@ export class CosmereActor<
 
     public get favorites(): CosmereItem[] {
         return this.items
-            .filter((i) => i.getFlag('cosmere-rpg', 'favorites.isFavorite'))
+            .filter((i) => i.getFlag(SYSTEM_ID, 'favorites.isFavorite'))
             .sort(
                 (a, b) =>
-                    a.getFlag<number>('cosmere-rpg', 'favorites.sort') -
-                    b.getFlag<number>('cosmere-rpg', 'favorites.sort'),
+                    a.getFlag<number>(SYSTEM_ID, 'favorites.sort') -
+                    b.getFlag<number>(SYSTEM_ID, 'favorites.sort'),
             );
     }
 
@@ -276,7 +276,7 @@ export class CosmereActor<
     /* --- Functions --- */
 
     public async setMode(modality: string, mode: string) {
-        await this.setFlag('cosmere-rpg', `mode.${modality}`, mode);
+        await this.setFlag(SYSTEM_ID, `mode.${modality}`, mode);
 
         // Get all effects for this modality
         const effects = this.applicableEffects.filter(
@@ -305,7 +305,7 @@ export class CosmereActor<
     }
 
     public async clearMode(modality: string) {
-        await this.unsetFlag('cosmere-rpg', `mode.${modality}`);
+        await this.unsetFlag(SYSTEM_ID, `mode.${modality}`);
 
         // Get all effects for this modality
         const effects = this.effects.filter(
@@ -356,7 +356,7 @@ export class CosmereActor<
 
         // Get injury data
         const data: { type: InjuryType; durationFormula: string } =
-            result.getFlag('cosmere-rpg', 'injury-data');
+            result.getFlag(SYSTEM_ID, 'injury-data');
 
         if (
             data.type !== InjuryType.Death &&

--- a/src/system/documents/combat.ts
+++ b/src/system/documents/combat.ts
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from '../constants';
 import { CosmereCombatant } from './combatant';
 
 export class CosmereCombat extends Combat {
@@ -10,7 +11,7 @@ export class CosmereCombat extends Combat {
     resetActivations() {
         for (const combatant of this.turns) {
             void combatant.setFlag(
-                'cosmere-rpg',
+                SYSTEM_ID,
                 'activated',
                 combatant.isDefeated ? true : false,
             );

--- a/src/system/documents/combatant.ts
+++ b/src/system/documents/combatant.ts
@@ -2,6 +2,7 @@ import { DocumentModificationOptions } from '@league-of-foundry-developers/found
 import { SchemaField } from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/fields.mjs';
 import { CosmereActor } from './actor';
 import { ActorType, TurnSpeed } from '@src/system/types/cosmere';
+import { SYSTEM_ID } from '../constants';
 
 export class CosmereCombatant extends Combatant {
     override get actor(): CosmereActor {
@@ -17,8 +18,8 @@ export class CosmereCombatant extends Combatant {
         userID: string,
     ) {
         super._onCreate(data, options, userID);
-        void this.setFlag('cosmere-rpg', 'turnSpeed', TurnSpeed.Slow);
-        void this.setFlag('cosmere-rpg', 'activated', false);
+        void this.setFlag(SYSTEM_ID, 'turnSpeed', TurnSpeed.Slow);
+        void this.setFlag(SYSTEM_ID, 'activated', false);
         void this.combat?.setInitiative(
             this.id!,
             this.generateInitiative(this.actor.type, TurnSpeed.Slow),
@@ -41,13 +42,10 @@ export class CosmereCombatant extends Combatant {
      * Utility function to flip the combatants current turn speed between slow and fast. It then updates initiative to force an update of the combat-tracker ui
      */
     toggleTurnSpeed() {
-        const currentSpeed = this.getFlag(
-            'cosmere-rpg',
-            'turnSpeed',
-        ) as TurnSpeed;
+        const currentSpeed = this.getFlag(SYSTEM_ID, 'turnSpeed') as TurnSpeed;
         const newSpeed =
             currentSpeed === TurnSpeed.Slow ? TurnSpeed.Fast : TurnSpeed.Slow;
-        void this.setFlag('cosmere-rpg', 'turnSpeed', newSpeed);
+        void this.setFlag(SYSTEM_ID, 'turnSpeed', newSpeed);
         void this.combat?.setInitiative(
             this.id!,
             this.generateInitiative(this.actor.type, newSpeed),

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -6,6 +6,7 @@ import {
     ActivationType,
 } from '@system/types/cosmere';
 import { CosmereActor } from './actor';
+import { SYSTEM_ID } from '../constants';
 
 import { Derived } from '@system/data/fields';
 
@@ -216,7 +217,7 @@ export class CosmereItem<
     /* --- Accessors --- */
 
     public get isFavorite(): boolean {
-        return this.getFlag('cosmere-rpg', 'favorites.isFavorite');
+        return this.getFlag(SYSTEM_ID, 'favorites.isFavorite');
     }
 
     /**
@@ -237,10 +238,7 @@ export class CosmereItem<
         const modalityId = this.system.modality;
 
         // Check actor modality flag
-        const activeMode = this.actor.getFlag(
-            'cosmere-rpg',
-            `mode.${modalityId}`,
-        );
+        const activeMode = this.actor.getFlag(SYSTEM_ID, `mode.${modalityId}`);
 
         // Check if the actor has the mode active
         return activeMode === this.system.id;
@@ -876,7 +874,7 @@ export class CosmereItem<
         await this.update(
             {
                 flags: {
-                    'cosmere-rpg': {
+                    SYSTEM_ID: {
                         favorites: {
                             isFavorite: true,
                             sort: index,
@@ -890,8 +888,8 @@ export class CosmereItem<
 
     public async clearFavorite() {
         await Promise.all([
-            this.unsetFlag('cosmere-rpg', 'favorites.isFavorite'),
-            this.unsetFlag('cosmere-rpg', 'favorites.sort'),
+            this.unsetFlag(SYSTEM_ID, 'favorites.isFavorite'),
+            this.unsetFlag(SYSTEM_ID, 'favorites.sort'),
         ]);
     }
 

--- a/src/system/hooks/modules/dice-so-nice.ts
+++ b/src/system/hooks/modules/dice-so-nice.ts
@@ -1,7 +1,7 @@
-import { IMPORTED_RESOURCES } from '@system/constants';
+import { IMPORTED_RESOURCES, SYSTEM_ID } from '@system/constants';
 
 Hooks.once('diceSoNiceReady', (dice3d: Dice3D) => {
-    dice3d.addSystem({ id: 'cosmere-rpg', name: 'Cosmere RPG' }, true);
+    dice3d.addSystem({ id: SYSTEM_ID, name: 'Cosmere RPG' }, true);
     dice3d.addDicePreset({
         type: 'dp',
         labels: [
@@ -20,6 +20,6 @@ Hooks.once('diceSoNiceReady', (dice3d: Dice3D) => {
             IMPORTED_RESOURCES.PLOT_DICE_OP_BUMP,
             IMPORTED_RESOURCES.PLOT_DICE_OP_BUMP,
         ],
-        system: 'cosmere-rpg',
+        system: SYSTEM_ID,
     });
 });

--- a/src/system/hooks/sheets.ts
+++ b/src/system/hooks/sheets.ts
@@ -1,9 +1,10 @@
 import { BaseItemSheet } from '../applications/item/base';
+import { SYSTEM_ID } from '../constants';
 
 Hooks.on(
     'renderItemSheetV2',
     (itemSheet: BaseItemSheet, node: HTMLFormElement) => {
-        if (game.settings!.get('cosmere-rpg', 'itemSheetSideTabs')) {
+        if (game.settings!.get(SYSTEM_ID, 'itemSheetSideTabs')) {
             node.classList.add('side-tabs');
         }
     },

--- a/src/system/hooks/welcome.ts
+++ b/src/system/hooks/welcome.ts
@@ -1,11 +1,12 @@
 // Dialogs
 import { ReleaseNotesDialog } from '@system/applications/dialogs/release-notes';
+import { SYSTEM_ID } from '../constants';
 
 Hooks.on('ready', async () => {
     // Ensure this message is only displayed when creating a new world
     if (
         !game.user!.isGM ||
-        !game.settings!.get('cosmere-rpg', 'firstTimeWorldCreation')
+        !game.settings!.get(SYSTEM_ID, 'firstTimeWorldCreation')
     )
         return;
 
@@ -20,7 +21,7 @@ Hooks.on('ready', async () => {
     });
 
     // Mark the setting so the message doesn't appear again
-    await game.settings!.set('cosmere-rpg', 'firstTimeWorldCreation', false);
+    await game.settings!.set(SYSTEM_ID, 'firstTimeWorldCreation', false);
 });
 
 Hooks.on('ready', async () => {
@@ -29,17 +30,13 @@ Hooks.on('ready', async () => {
 
     const currentVersion = game.system!.version;
     const latestVersion = game.settings!.get(
-        'cosmere-rpg',
+        SYSTEM_ID,
         'latestVersion',
     ) as string;
 
     if (currentVersion > latestVersion) {
         // Record the latest version of the system
-        await game.settings!.set(
-            'cosmere-rpg',
-            'latestVersion',
-            currentVersion,
-        );
+        await game.settings!.set(SYSTEM_ID, 'latestVersion', currentVersion);
 
         // Show the release notes
         void ReleaseNotesDialog.show();


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)
- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Other (please describe):

**Description**  
A relatively minor change, but an important one. I switched all hardcoded 'cosmere-rpg' tags to refer instead to a constant that holds the system ID. If we need to change this to (for example) 'plotweaver' later for license reasons, it will save us a lot of sweat blood and tears to simply change that single constant over changing every single tag.

This also helps ensure that we don't have hard to detect mistakes such as a flag being set with a typo and polluting the object data.

**How Has This Been Tested?**  
System still loads, sheets still open, rolls still happen. I made sure the imports were correct so this shouldn't change any functionality at all.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
Learned from past experience (read as: pain) that having the possibility to change the entire tag for a system/module in foundry at the drop of a hat is a good idea. Better to set it up now than when we have a million references to the tag.
