### PR TITLE
Centralise and Localise Settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import './style.scss';
 import './system/hooks';
 
 import { preloadHandlebarsTemplates } from './system/util/handlebars';
-import { registerSettings } from './system/settings';
+import { registerSystemSettings } from './system/settings';
 
 import * as applications from './system/applications';
 import * as dataModels from './system/data';
@@ -94,7 +94,7 @@ Hooks.once('init', async () => {
     registerStatusEffects();
 
     // Register settings
-    registerSettings();
+    registerSystemSettings();
 });
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import './style.scss';
 import './system/hooks';
 
 import { preloadHandlebarsTemplates } from './system/util/handlebars';
-import { registerSettings } from './system/settings';
+import { SettingsUtility } from './system/settings';
 
 import * as applications from './system/applications';
 import * as dataModels from './system/data';
@@ -94,7 +94,7 @@ Hooks.once('init', async () => {
     registerStatusEffects();
 
     // Register settings
-    registerSettings();
+    SettingsUtility.registerSettings();
 });
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import './style.scss';
 import './system/hooks';
 
 import { preloadHandlebarsTemplates } from './system/util/handlebars';
-import { SettingsUtility } from './system/settings';
+import { registerSettings } from './system/settings';
 
 import * as applications from './system/applications';
 import * as dataModels from './system/data';
@@ -94,7 +94,7 @@ Hooks.once('init', async () => {
     registerStatusEffects();
 
     // Register settings
-    SettingsUtility.registerSettings();
+    registerSettings();
 });
 
 /**

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -941,7 +941,7 @@
         },
         "skipRollDialogByDefault": {
             "name": "Skip Roll Dialog by Default",
-            "hint": "If enabled, rolls will skip the roll configuration dialog when clicked, using the default roll configuration. The dialog can still be accessed by holding the 'Skip Dialog' key modifier from the system controls."
+            "hint": "If enabled, rolls will skip the roll configuration dialog when clicked, using the default roll configuration. The dialog can still be accessed by holding the 'Skip/Show Dialog' key modifier from the system controls."
         }
     }
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -933,5 +933,15 @@
         "Distance": {
             "Feet": "Feet"
         }
+    },
+    "SETTINGS": {
+        "itemSheetSideTabs": {
+            "name": "Vertical Side Tabs for Item Sheets",
+            "hint": "If enabled, item sheets use vertical tabs down the right-hand side, similar to the character sheet, instead of the default in-line horizontal ones."
+        },
+        "skipRollDialogByDefault": {
+            "name": "Skip Roll Dialog by Default",
+            "hint": "If enabled, rolls will skip the roll configuration dialog when clicked, using the default roll configuration. The dialog can still be accessed by holding the 'Skip Dialog' key modifier from the system controls."
+        }
     }
 }

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -5,7 +5,7 @@ import { DeepPartial, AnyObject } from '@system/types/utils';
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
 import { TabsApplicationMixin } from '@system/applications/mixins';
-import { getSystemSetting, SETTING_NAMES } from '@src/system/settings';
+import { getSystemSetting, SETTINGS } from '@src/system/settings';
 
 const { ItemSheetV2 } = foundry.applications.sheets;
 
@@ -287,7 +287,7 @@ export class BaseItemSheet extends TabsApplicationMixin(
             ).fields,
             editable: this.isEditable,
             descHtml: enrichedDescValue,
-            sideTabs: getSystemSetting(SETTING_NAMES.ITEM_SHEET_SIDE_TABS),
+            sideTabs: getSystemSetting(SETTINGS.ITEM_SHEET_SIDE_TABS),
         };
     }
 }

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -5,7 +5,7 @@ import { DeepPartial, AnyObject } from '@system/types/utils';
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
 import { TabsApplicationMixin } from '@system/applications/mixins';
-import { getSettingValue, SETTING_NAMES } from '@src/system/settings';
+import { getSystemSetting, SETTING_NAMES } from '@src/system/settings';
 
 const { ItemSheetV2 } = foundry.applications.sheets;
 
@@ -287,7 +287,7 @@ export class BaseItemSheet extends TabsApplicationMixin(
             ).fields,
             editable: this.isEditable,
             descHtml: enrichedDescValue,
-            sideTabs: getSettingValue(SETTING_NAMES.ITEM_SHEET_SIDE_TABS),
+            sideTabs: getSystemSetting(SETTING_NAMES.ITEM_SHEET_SIDE_TABS),
         };
     }
 }

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -5,7 +5,7 @@ import { DeepPartial, AnyObject } from '@system/types/utils';
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
 import { TabsApplicationMixin } from '@system/applications/mixins';
-import { SETTING_NAMES, SettingsUtility } from '@src/system/settings';
+import { getSettingValue, SETTING_NAMES } from '@src/system/settings';
 
 const { ItemSheetV2 } = foundry.applications.sheets;
 
@@ -287,9 +287,7 @@ export class BaseItemSheet extends TabsApplicationMixin(
             ).fields,
             editable: this.isEditable,
             descHtml: enrichedDescValue,
-            sideTabs: SettingsUtility.getSettingValue(
-                SETTING_NAMES.ITEM_SHEET_SIDE_TABS,
-            ),
+            sideTabs: getSettingValue(SETTING_NAMES.ITEM_SHEET_SIDE_TABS),
         };
     }
 }

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -1,7 +1,6 @@
 import { ArmorTraitId, WeaponTraitId } from '@system/types/cosmere';
 import { CosmereItem } from '@system/documents/item';
 import { DeepPartial, AnyObject } from '@system/types/utils';
-import { SYSTEM_ID } from '@src/system/constants';
 
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -6,6 +6,7 @@ import { SYSTEM_ID } from '@src/system/constants';
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
 import { TabsApplicationMixin } from '@system/applications/mixins';
+import { SETTING_NAMES, SettingsUtility } from '@src/system/settings';
 
 const { ItemSheetV2 } = foundry.applications.sheets;
 
@@ -287,7 +288,9 @@ export class BaseItemSheet extends TabsApplicationMixin(
             ).fields,
             editable: this.isEditable,
             descHtml: enrichedDescValue,
-            sideTabs: game.settings!.get(SYSTEM_ID, 'itemSheetSideTabs'),
+            sideTabs: SettingsUtility.getSettingValue(
+                SETTING_NAMES.ITEM_SHEET_SIDE_TABS,
+            ),
         };
     }
 }

--- a/src/system/hooks/sheets.ts
+++ b/src/system/hooks/sheets.ts
@@ -1,12 +1,10 @@
 import { BaseItemSheet } from '../applications/item/base';
-import { SETTING_NAMES, SettingsUtility } from '../settings';
+import { getSettingValue, SETTING_NAMES } from '../settings';
 
 Hooks.on(
     'renderItemSheetV2',
     (itemSheet: BaseItemSheet, node: HTMLFormElement) => {
-        if (
-            SettingsUtility.getSettingValue(SETTING_NAMES.ITEM_SHEET_SIDE_TABS)
-        ) {
+        if (getSettingValue(SETTING_NAMES.ITEM_SHEET_SIDE_TABS)) {
             node.classList.add('side-tabs');
         }
     },

--- a/src/system/hooks/sheets.ts
+++ b/src/system/hooks/sheets.ts
@@ -1,10 +1,10 @@
 import { BaseItemSheet } from '../applications/item/base';
-import { getSettingValue, SETTING_NAMES } from '../settings';
+import { getSystemSetting, SETTING_NAMES } from '../settings';
 
 Hooks.on(
     'renderItemSheetV2',
     (itemSheet: BaseItemSheet, node: HTMLFormElement) => {
-        if (getSettingValue(SETTING_NAMES.ITEM_SHEET_SIDE_TABS)) {
+        if (getSystemSetting(SETTING_NAMES.ITEM_SHEET_SIDE_TABS)) {
             node.classList.add('side-tabs');
         }
     },

--- a/src/system/hooks/sheets.ts
+++ b/src/system/hooks/sheets.ts
@@ -1,10 +1,13 @@
 import { BaseItemSheet } from '../applications/item/base';
 import { SYSTEM_ID } from '../constants';
+import { SETTING_NAMES, SettingsUtility } from '../settings';
 
 Hooks.on(
     'renderItemSheetV2',
     (itemSheet: BaseItemSheet, node: HTMLFormElement) => {
-        if (game.settings!.get(SYSTEM_ID, 'itemSheetSideTabs')) {
+        if (
+            SettingsUtility.getSettingValue(SETTING_NAMES.ITEM_SHEET_SIDE_TABS)
+        ) {
             node.classList.add('side-tabs');
         }
     },

--- a/src/system/hooks/sheets.ts
+++ b/src/system/hooks/sheets.ts
@@ -1,10 +1,10 @@
 import { BaseItemSheet } from '../applications/item/base';
-import { getSystemSetting, SETTING_NAMES } from '../settings';
+import { getSystemSetting, SETTINGS } from '../settings';
 
 Hooks.on(
     'renderItemSheetV2',
     (itemSheet: BaseItemSheet, node: HTMLFormElement) => {
-        if (getSystemSetting(SETTING_NAMES.ITEM_SHEET_SIDE_TABS)) {
+        if (getSystemSetting(SETTINGS.ITEM_SHEET_SIDE_TABS)) {
             node.classList.add('side-tabs');
         }
     },

--- a/src/system/hooks/sheets.ts
+++ b/src/system/hooks/sheets.ts
@@ -1,5 +1,4 @@
 import { BaseItemSheet } from '../applications/item/base';
-import { SYSTEM_ID } from '../constants';
 import { SETTING_NAMES, SettingsUtility } from '../settings';
 
 Hooks.on(

--- a/src/system/hooks/welcome.ts
+++ b/src/system/hooks/welcome.ts
@@ -1,13 +1,13 @@
 // Dialogs
 import { ReleaseNotesDialog } from '@system/applications/dialogs/release-notes';
 import { SYSTEM_ID } from '../constants';
-import { SETTING_NAMES, SettingsUtility } from '../settings';
+import { getSettingValue, SETTING_NAMES } from '../settings';
 
 Hooks.on('ready', async () => {
     // Ensure this message is only displayed when creating a new world
     if (
         !game.user!.isGM ||
-        !SettingsUtility.getSettingValue(SETTING_NAMES.INTERNAL_FIRST_CREATION)
+        !getSettingValue(SETTING_NAMES.INTERNAL_FIRST_CREATION)
     )
         return;
 
@@ -30,7 +30,7 @@ Hooks.on('ready', async () => {
     if (!game.user!.isGM) return;
 
     const currentVersion = game.system!.version;
-    const latestVersion = SettingsUtility.getSettingValue(
+    const latestVersion = getSettingValue(
         SETTING_NAMES.INTERNAL_LATEST_VERSION,
     ) as string;
 

--- a/src/system/hooks/welcome.ts
+++ b/src/system/hooks/welcome.ts
@@ -1,12 +1,13 @@
 // Dialogs
 import { ReleaseNotesDialog } from '@system/applications/dialogs/release-notes';
 import { SYSTEM_ID } from '../constants';
+import { SETTING_NAMES, SettingsUtility } from '../settings';
 
 Hooks.on('ready', async () => {
     // Ensure this message is only displayed when creating a new world
     if (
         !game.user!.isGM ||
-        !game.settings!.get(SYSTEM_ID, 'firstTimeWorldCreation')
+        !SettingsUtility.getSettingValue(SETTING_NAMES.INTERNAL_FIRST_CREATION)
     )
         return;
 
@@ -29,9 +30,8 @@ Hooks.on('ready', async () => {
     if (!game.user!.isGM) return;
 
     const currentVersion = game.system!.version;
-    const latestVersion = game.settings!.get(
-        SYSTEM_ID,
-        'latestVersion',
+    const latestVersion = SettingsUtility.getSettingValue(
+        SETTING_NAMES.INTERNAL_LATEST_VERSION,
     ) as string;
 
     if (currentVersion > latestVersion) {

--- a/src/system/hooks/welcome.ts
+++ b/src/system/hooks/welcome.ts
@@ -1,13 +1,13 @@
 // Dialogs
 import { ReleaseNotesDialog } from '@system/applications/dialogs/release-notes';
 import { SYSTEM_ID } from '../constants';
-import { getSettingValue, SETTING_NAMES } from '../settings';
+import { getSystemSetting, SETTING_NAMES } from '../settings';
 
 Hooks.on('ready', async () => {
     // Ensure this message is only displayed when creating a new world
     if (
         !game.user!.isGM ||
-        !getSettingValue(SETTING_NAMES.INTERNAL_FIRST_CREATION)
+        !getSystemSetting(SETTING_NAMES.INTERNAL_FIRST_CREATION)
     )
         return;
 
@@ -30,7 +30,7 @@ Hooks.on('ready', async () => {
     if (!game.user!.isGM) return;
 
     const currentVersion = game.system!.version;
-    const latestVersion = getSettingValue(
+    const latestVersion = getSystemSetting(
         SETTING_NAMES.INTERNAL_LATEST_VERSION,
     ) as string;
 

--- a/src/system/hooks/welcome.ts
+++ b/src/system/hooks/welcome.ts
@@ -1,14 +1,11 @@
 // Dialogs
 import { ReleaseNotesDialog } from '@system/applications/dialogs/release-notes';
 import { SYSTEM_ID } from '../constants';
-import { getSystemSetting, SETTING_NAMES } from '../settings';
+import { getSystemSetting, SETTINGS } from '../settings';
 
 Hooks.on('ready', async () => {
     // Ensure this message is only displayed when creating a new world
-    if (
-        !game.user!.isGM ||
-        !getSystemSetting(SETTING_NAMES.INTERNAL_FIRST_CREATION)
-    )
+    if (!game.user!.isGM || !getSystemSetting(SETTINGS.INTERNAL_FIRST_CREATION))
         return;
 
     // Get system version
@@ -31,7 +28,7 @@ Hooks.on('ready', async () => {
 
     const currentVersion = game.system!.version;
     const latestVersion = getSystemSetting(
-        SETTING_NAMES.INTERNAL_LATEST_VERSION,
+        SETTINGS.INTERNAL_LATEST_VERSION,
     ) as string;
 
     if (currentVersion > latestVersion) {

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -4,7 +4,7 @@ import { SYSTEM_ID } from './constants';
  * Enumerable of identifiers for setting names.
  * @enum {String}
  */
-export const SETTING_NAMES = {
+export const SETTINGS = {
     INTERNAL_FIRST_CREATION: 'firstTimeWorldCreation',
     INTERNAL_LATEST_VERSION: 'latestVersion',
     ITEM_SHEET_SIDE_TABS: 'itemSheetSideTabs',
@@ -12,10 +12,10 @@ export const SETTING_NAMES = {
 };
 
 /**
- * Registers all necessary system settings.
+ * Register all of the system's settings.
  */
-export function registerSettings() {
-    game.settings!.register(SYSTEM_ID, SETTING_NAMES.INTERNAL_FIRST_CREATION, {
+export function registerSystemSettings() {
+    game.settings!.register(SYSTEM_ID, SETTINGS.INTERNAL_FIRST_CREATION, {
         name: 'First Time World Creation',
         scope: 'world',
         config: false,
@@ -23,7 +23,7 @@ export function registerSettings() {
         type: Boolean,
     });
 
-    game.settings!.register(SYSTEM_ID, SETTING_NAMES.INTERNAL_LATEST_VERSION, {
+    game.settings!.register(SYSTEM_ID, SETTINGS.INTERNAL_LATEST_VERSION, {
         name: 'Latest Version',
         scope: 'world',
         config: false,
@@ -33,7 +33,7 @@ export function registerSettings() {
 
     // SHEET SETTINGS
     const sheetOptions = [
-        { name: SETTING_NAMES.ITEM_SHEET_SIDE_TABS, default: false },
+        { name: SETTINGS.ITEM_SHEET_SIDE_TABS, default: false },
     ];
 
     sheetOptions.forEach((option) => {
@@ -49,7 +49,7 @@ export function registerSettings() {
 
     // ROLL SETTINGS
     const rollOptions = [
-        { name: SETTING_NAMES.ROLL_SKIP_DIALOG_DEFAULT, default: false },
+        { name: SETTINGS.ROLL_SKIP_DIALOG_DEFAULT, default: false },
     ];
 
     rollOptions.forEach((option) => {

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -1,8 +1,7 @@
 import { SYSTEM_ID } from './constants';
 
 /**
- * Enumerable of identifiers for setting names.
- * @enum {String}
+ * Index of identifiers for system settings.
  */
 export const SETTINGS = {
     INTERNAL_FIRST_CREATION: 'firstTimeWorldCreation',

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -1,26 +1,84 @@
-export function registerSettings() {
-    game.settings!.register('cosmere-rpg', 'firstTimeWorldCreation', {
-        name: 'First Time World Creation',
-        scope: 'world',
-        config: false,
-        default: true,
-        type: Boolean,
-    });
+import { SYSTEM_ID } from './constants';
 
-    game.settings!.register('cosmere-rpg', 'latestVersion', {
-        name: 'Latest Version',
-        scope: 'world',
-        config: false,
-        default: '0.0.0',
-        type: String,
-    });
+/**
+ * Enumerable of identifiers for setting names.
+ * @enum {String}
+ */
+export const SETTING_NAMES = {
+    INTERNAL_FIRST_CREATION: 'firstTimeWorldCreation',
+    INTERNAL_LATEST_VERSION: 'latestVersion',
+    ITEM_SHEET_SIDE_TABS: 'itemSheetSideTabs',
+    ROLL_SKIP_DIALOG_DEFAULT: 'skipRollDialogByDefault',
+};
 
-    game.settings!.register('cosmere-rpg', 'itemSheetSideTabs', {
-        name: 'Vertical Side Tabs for Item Sheets',
-        hint: 'Toggle whether Item sheets should use vertical tabs down the right-hand side, similar to the character sheet, or leave the in-line horizontal ones (default).',
-        scope: 'world',
-        config: true,
-        type: Boolean,
-        default: false,
-    });
+/**
+ * Utility class for registry of module settings and retrieval of setting data.
+ */
+export class SettingsUtility {
+    static registerSettings() {
+        game.settings!.register(
+            SYSTEM_ID,
+            SETTING_NAMES.INTERNAL_FIRST_CREATION,
+            {
+                name: 'First Time World Creation',
+                scope: 'world',
+                config: false,
+                default: true,
+                type: Boolean,
+            },
+        );
+
+        game.settings!.register(
+            SYSTEM_ID,
+            SETTING_NAMES.INTERNAL_LATEST_VERSION,
+            {
+                name: 'Latest Version',
+                scope: 'world',
+                config: false,
+                default: '0.0.0',
+                type: String,
+            },
+        );
+
+        // SHEET SETTINGS
+        const sheetOptions = [
+            { name: SETTING_NAMES.ITEM_SHEET_SIDE_TABS, default: false },
+        ];
+
+        sheetOptions.forEach((option) => {
+            game.settings!.register(SYSTEM_ID, option.name, {
+                name: game.i18n!.localize(`SETTINGS.${option.name}.name`),
+                hint: game.i18n!.localize(`SETTINGS.${option.name}.hint`),
+                scope: 'world',
+                config: true,
+                type: Boolean,
+                default: option.default,
+            });
+        });
+
+        // ROLL SETTINGS
+        const rollOptions = [
+            { name: SETTING_NAMES.ROLL_SKIP_DIALOG_DEFAULT, default: false },
+        ];
+
+        rollOptions.forEach((option) => {
+            game.settings!.register(SYSTEM_ID, option.name, {
+                name: game.i18n!.localize(`SETTINGS.${option.name}.name`),
+                hint: game.i18n!.localize(`SETTINGS.${option.name}.hint`),
+                scope: 'client',
+                config: true,
+                type: Boolean,
+                default: option.default,
+            });
+        });
+    }
+
+    /**
+     * Retrieve a specific setting value for the provided key.
+     * @param {string} settingKey The identifier of the setting to retrieve.
+     * @returns {string|boolean} The value of the setting as set for the world/client.
+     */
+    static getSettingValue(settingKey: string) {
+        return game.settings!.get(SYSTEM_ID, settingKey);
+    }
 }

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -8,7 +8,7 @@ export const SETTINGS = {
     INTERNAL_LATEST_VERSION: 'latestVersion',
     ITEM_SHEET_SIDE_TABS: 'itemSheetSideTabs',
     ROLL_SKIP_DIALOG_DEFAULT: 'skipRollDialogByDefault',
-};
+} as const;
 
 /**
  * Register all of the system's settings.

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -12,9 +12,12 @@ export const SETTING_NAMES = {
 };
 
 /**
- * Utility class for registry of module settings and retrieval of setting data.
+ * Utility class for registry of system settings and retrieval of setting data.
  */
 export class SettingsUtility {
+    /**
+     * Registers all necessary system settings.
+     */
     static registerSettings() {
         game.settings!.register(
             SYSTEM_ID,

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -69,6 +69,6 @@ export function registerSettings() {
  * @param {string} settingKey The identifier of the setting to retrieve.
  * @returns {string|boolean} The value of the setting as set for the world/client.
  */
-export function getSettingValue(settingKey: string) {
+export function getSystemSetting(settingKey: string) {
     return game.settings!.get(SYSTEM_ID, settingKey);
 }

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -12,76 +12,63 @@ export const SETTING_NAMES = {
 };
 
 /**
- * Utility class for registry of system settings and retrieval of setting data.
+ * Registers all necessary system settings.
  */
-export class SettingsUtility {
-    /**
-     * Registers all necessary system settings.
-     */
-    static registerSettings() {
-        game.settings!.register(
-            SYSTEM_ID,
-            SETTING_NAMES.INTERNAL_FIRST_CREATION,
-            {
-                name: 'First Time World Creation',
-                scope: 'world',
-                config: false,
-                default: true,
-                type: Boolean,
-            },
-        );
+export function registerSettings() {
+    game.settings!.register(SYSTEM_ID, SETTING_NAMES.INTERNAL_FIRST_CREATION, {
+        name: 'First Time World Creation',
+        scope: 'world',
+        config: false,
+        default: true,
+        type: Boolean,
+    });
 
-        game.settings!.register(
-            SYSTEM_ID,
-            SETTING_NAMES.INTERNAL_LATEST_VERSION,
-            {
-                name: 'Latest Version',
-                scope: 'world',
-                config: false,
-                default: '0.0.0',
-                type: String,
-            },
-        );
+    game.settings!.register(SYSTEM_ID, SETTING_NAMES.INTERNAL_LATEST_VERSION, {
+        name: 'Latest Version',
+        scope: 'world',
+        config: false,
+        default: '0.0.0',
+        type: String,
+    });
 
-        // SHEET SETTINGS
-        const sheetOptions = [
-            { name: SETTING_NAMES.ITEM_SHEET_SIDE_TABS, default: false },
-        ];
+    // SHEET SETTINGS
+    const sheetOptions = [
+        { name: SETTING_NAMES.ITEM_SHEET_SIDE_TABS, default: false },
+    ];
 
-        sheetOptions.forEach((option) => {
-            game.settings!.register(SYSTEM_ID, option.name, {
-                name: game.i18n!.localize(`SETTINGS.${option.name}.name`),
-                hint: game.i18n!.localize(`SETTINGS.${option.name}.hint`),
-                scope: 'world',
-                config: true,
-                type: Boolean,
-                default: option.default,
-            });
+    sheetOptions.forEach((option) => {
+        game.settings!.register(SYSTEM_ID, option.name, {
+            name: game.i18n!.localize(`SETTINGS.${option.name}.name`),
+            hint: game.i18n!.localize(`SETTINGS.${option.name}.hint`),
+            scope: 'world',
+            config: true,
+            type: Boolean,
+            default: option.default,
         });
+    });
 
-        // ROLL SETTINGS
-        const rollOptions = [
-            { name: SETTING_NAMES.ROLL_SKIP_DIALOG_DEFAULT, default: false },
-        ];
+    // ROLL SETTINGS
+    const rollOptions = [
+        { name: SETTING_NAMES.ROLL_SKIP_DIALOG_DEFAULT, default: false },
+    ];
 
-        rollOptions.forEach((option) => {
-            game.settings!.register(SYSTEM_ID, option.name, {
-                name: game.i18n!.localize(`SETTINGS.${option.name}.name`),
-                hint: game.i18n!.localize(`SETTINGS.${option.name}.hint`),
-                scope: 'client',
-                config: true,
-                type: Boolean,
-                default: option.default,
-            });
+    rollOptions.forEach((option) => {
+        game.settings!.register(SYSTEM_ID, option.name, {
+            name: game.i18n!.localize(`SETTINGS.${option.name}.name`),
+            hint: game.i18n!.localize(`SETTINGS.${option.name}.hint`),
+            scope: 'client',
+            config: true,
+            type: Boolean,
+            default: option.default,
         });
-    }
+    });
+}
 
-    /**
-     * Retrieve a specific setting value for the provided key.
-     * @param {string} settingKey The identifier of the setting to retrieve.
-     * @returns {string|boolean} The value of the setting as set for the world/client.
-     */
-    static getSettingValue(settingKey: string) {
-        return game.settings!.get(SYSTEM_ID, settingKey);
-    }
+/**
+ * Retrieve a specific setting value for the provided key.
+ * @param {string} settingKey The identifier of the setting to retrieve.
+ * @returns {string|boolean} The value of the setting as set for the world/client.
+ */
+export function getSettingValue(settingKey: string) {
+    return game.settings!.get(SYSTEM_ID, settingKey);
 }


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Other (please describe):

**Description**  
Refactor the Settings script to do a couple of things:
- Create a single "getSettingValue" function that we can call without needing to import the SYSTEM ID everywhere. Also, if the foundry API for getting a setting value ever changes (which it has done in the past), we can simply change it in one place and be done.
- Create an object reference of Setting Names that can be imported elsewhere to refer to a specific setting directly without hardcoding the setting name everywhere. Also used to localise the setting key in the lang file, though unfortunately it has to be hardcoded in the lang file, so if a setting name changes we have to manually change it there.
- Setup for each loops for settings batches so the settings script isn't a huge list of duplicate code blocks
- Localise setting names and hints in the settings registry so that they can be used in different languages.

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.331.

**Additional context**  
As the settings list slowly expands, it will be very useful to manage setting names and setup in one singular place. Especially if we ever need to rename a specific setting. (Ignore the Skip dialog setting for now, that's just so I can have multiple batches set up for testing. I will use that later)

Also, setting localisation is 100% necessary so I set that up at the same time.
