### PR TITLE
Fix build on Windows

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -77,6 +77,10 @@ function markdownParser(config) {
 
                 // Construct the destination path
                 const dest = path.join(srcPath, config.targets[index].dest, `${fileName}.html`);
+                const destDir = path.join(srcPath, config.targets[index].dest);
+                if(!fs.existsSync(destDir)){
+                    fs.mkdirSync(destDir);
+                }
 
                 // Write the parsed markdown to the destination path
                 fs.writeFileSync(dest, `<div>${markdown}</div>`);


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
On windows, a directory must exist before writing a file to it. The release notes markdown was causing the build to fail until the build directory was created (which happens when the build finishes successfully).

**Related Issue**  
I didn't bother to make an issue, but when following the instructions in CONTRIBUTING.md, I was unable to successfully build with `npm run build`

**How Has This Been Tested?**  
I've run the build both before and after creating a `build` directory.

**Screenshots (if applicable)**  
N/A

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [ ] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
