### PR TITLE
Textarea not configured to inherit font-family by default

### DIFF
--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -47,6 +47,7 @@
                 background: #302831;
                 padding: 0.3rem 0.5rem;
                 min-height: 5rem;
+                font-family: inherit;
 
                 &:read-only {
                     background: #0b0a13;


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
My first commit to the repository. Simply just fixing a minor CSS error where the font in the character sheet "Purposes and Obstacles" field is defaulting to Calibri, rather than than one of the previously used fonts

**Related Issue**  
Closes #127 

**How Has This Been Tested?**  
Create a new "Character" actor, navigate to the goals tab, verify the font underneath the "Purpose" and "Obstacle" header.

**Screenshots (if applicable)**
Prior:
![image](https://github.com/user-attachments/assets/cba17a16-0cee-443a-9717-572f857fe0fb)


Updated:  
![image](https://github.com/user-attachments/assets/6ed6453c-c91d-497a-acbc-96cbdaeac0f9)


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: v12.331.

**Additional context**  
Let me know if I have done any of this process wrong per the contribution rules of this repository. Thanks!
