### PR TITLE
Modify goals-list and connections-list to automatically adapt to text size

### DIFF
--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -259,6 +259,10 @@
 
                 &:not(.collapsed):not(:first-child):not(:last-child) {
                     border-bottom: 1px solid #302831;
+                    height:auto;
+                    min-height: 1.5rem;
+                    padding-top: 0.25rem;
+                    padding-bottom: 0.25rem;
                 }
 
                 &:not(.details) {

--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -368,6 +368,10 @@
             .goal {
                 &:not(:first-child):not(:last-child) {
                     border-bottom: 1px solid #463a47 !important;
+                    height: auto;
+                    min-height: 1.5rem;
+                    padding-top: 0.25rem;
+                    padding-bottom: 0.25rem;
                 }
             }
         }
@@ -376,6 +380,10 @@
             .connection {
                 &:nth-child(even):not(:last-child) {
                     border-bottom: 1px solid #463a47 !important;
+                    height: auto;
+                    min-height: 1.5rem;
+                    padding-top: 0.25rem;
+                    padding-bottom: 0.25rem;
                 }
             }
         }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Currently, the goals and connections list are not configured to scale, and automatically force a height of 2rem for all elements. This leads to overflow issues when larger goals or connections are written. 

I have modified the height to be automatic and added a small amount of padding on the top and bottom so the text looks naturally seated within the range. The overall height for a one-line goal is the same(.25 top padding, 1.5 min-size, .25 bottom padding)

**Related Issue**  
Closes #112 

**How Has This Been Tested?**  
Tested goals and connections of various sizes, and verify that all previous elements fit and still work as intended.

**Screenshots (if applicable)**  
Before:
![image](https://github.com/user-attachments/assets/3518a635-eb88-4b6f-b7cd-b043514cc39e)


After:
![image](https://github.com/user-attachments/assets/e059137a-47f7-4254-98b4-c77add2bb230)


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 12.331
**Additional context**  
_Add any other context or information here that would be useful for reviewers._
