### PR TITLE
Issue 104 Fix.  ContextMenu trying to render inside constructor

### DIFF
--- a/src/system/applications/utils/context-menu.ts
+++ b/src/system/applications/utils/context-menu.ts
@@ -37,9 +37,7 @@ export class AppContextMenu {
         private parent: AppContextMenu.Parent,
         private anchor: AppContextMenu.Anchor,
         private items: AppContextMenu.Item[],
-    ) {
-        void this.render();
-    }
+    ) {}
 
     /**
      * Utility function to create a context menu


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
The ListComponents were calling the .create() method of AppContextMenu before their own element objects were fully initialized.  This caused the error as .AppendChild was clearly not available inside of the ContextMenu create() method.  I've changed this functionality to take place in _onRender instead of _onInitialize to ensure better timing of the element initializations.  I also implemented some cleanup methods _onDestroy in the ListComponents which properly cleans up their ContextMenus, Thanks Claude!

**Related Issue**  
Fixes Issues #104 

**How Has This Been Tested?**  
Opening, closing and opening a character sheet any number of times.  Also adding objects to each of the lists still saves and reloads on subsequent restarts of Foundry.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.331.
