### PR TITLE
Skill Test Targets Display

### DIFF
--- a/src/declarations/foundry/client/data/documents/actor.d.ts
+++ b/src/declarations/foundry/client/data/documents/actor.d.ts
@@ -30,7 +30,9 @@ declare class Actor<
 
     get items(): Collection<I>;
     get effects(): Collection<ActiveEffect>;
+    get isToken(): boolean;
     get appliedEffects(): ActiveEffect[];
+    get token(): TokenDocument;
 
     /**
      * Return a data object which defines the data schema against which dice rolls can be evaluated.
@@ -54,6 +56,19 @@ declare class Actor<
         statusId: string,
         options?: Actor.ToggleStatusEffectOptions,
     ): Promise<ActiveEffect | boolean | undefined>;
+
+    /**
+     * Retrieve an Array of active tokens which represent this Actor in the current canvas Scene. 
+     * If the canvas is not currently active, or there are no linked actors, the returned Array will be empty. 
+     * If the Actor is a synthetic token actor, only the exact Token which it represents will be returned.
+     * @param linked Limit results to Tokens which are linked to the Actor. Otherwise, return all Tokens even those which are not linked.
+     * @param document Return the Document instance rather than the PlaceableObject
+     * @returns An array of Token instances in the current Scene which reference this Actor.
+     */
+    public getActiveTokens(
+        linked?: boolean,
+        document?: boolean
+    ): (TokenDocument | Token)[];
 
     /**
      * Get all ActiveEffects that may apply to this Actor.

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -862,6 +862,9 @@
                 "RollAdvantage": "Click to roll with advantage.",
                 "RollDisadvantage": "Click to roll with disadvantage."
             },
+            "Trays": {
+                "Targets": "Targets"
+            },
             "InjuryRoll": "Injury Roll",
             "InjuryDuration": {
                 "Dead": "{actor} has <strong>died</strong>.",

--- a/src/style/chat/module.scss
+++ b/src/style/chat/module.scss
@@ -477,14 +477,110 @@
                 }
             }            
 
+            .chat-card-tray {
+                & > label {
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    gap: 0.25rem;
+                    font-size: var(--font-size-11);
+                    font-family: var(--plotweaver-font-normal);
+                    font-weight: bold;
+                    text-transform: uppercase;
+
+                    & > span {
+                        flex: none;
+                    }
+
+                    & > i:first-of-type {
+                        color: var(--plotweaver-color-light-2);
+                    }
+                }
+
+                & > label::before,
+                & > label::after {
+                    content: "";
+                    flex-basis: 50%;
+                    border-top: 1px dotted var(--plotweaver-color-dark-6);
+                    align-self: center;
+                }
+
+                .target-headers {
+                    color: var(--plotweaver-color-light-2);
+                    font-size: var(--font-size-10);
+                    font-family: var(--plotweaver-font-condensed);
+                    font-weight: 600;
+                    text-transform: uppercase;
+                    display: flex;
+                    align-items: center;
+                    justify-content: flex-end;
+                    margin-top: 0.25rem;
+
+                    & > span {
+                        width: 15%;
+                        text-align: center;
+                    }
+                }
+
+                .target-list {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 0.25rem;
+                    list-style: none;
+                    padding: 0;
+                    margin: 0.25rem 0;
+
+                    .target {
+                        display: flex;
+                        align-items: center;
+                        cursor: pointer;
+                        font-size: var(--font-size-13);
+                        font-family: var(--plotweaver-font-normal);
+                        font-weight: bold;
+
+                        .name {
+                            color: var(--plotweaver-color-dark-1);
+                            width: 55%;
+                        }
+
+                        .result {                            
+                            color: var(--plotweaver-color-dark-4);
+                            width: 15%;
+                            text-align: center;
+
+                            .success {
+                                color: var(--plotweaver-color-health-front)
+                            }
+
+                            .failure {
+                                color: var(--plotweaver-color-complication)
+                            }
+                        }
+                    }
+                }
+            }
+
             .collapsible {
                 cursor: pointer;
 
                 .collapsible-content {
                     display: grid;
                     grid-template-rows: 0fr;
-                    transition: grid-template-rows 250ms ease;                    
-                }    
+                    transition: grid-template-rows 250ms ease;
+
+                    & > .wrapper {
+                        overflow: hidden;
+                    }
+                }
+
+                .fa-caret-down {
+                    transform: rotate(-90deg);
+                    transition: all 250ms ease;
+                }
+
+                &.expanded .fa-caret-down {
+                    transform: rotate(0deg);
+                }
                 
                 &.expanded .collapsible-content {
                     grid-template-rows: 1fr;

--- a/src/system/dice/d20-roll.ts
+++ b/src/system/dice/d20-roll.ts
@@ -400,6 +400,14 @@ export class D20Roll extends foundry.dice.Roll<D20RollData> {
         });
     }
 
+    /**
+     * Recalculates the roll total from the current (potentially modified) terms.
+     * @returns {number} The new total of the roll.
+     */
+    public resetTotal(): number {
+        return (this._total = this._evaluateTotal());
+    }
+
     /* --- Internal Functions --- */
 
     private configureModifiers() {

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -37,6 +37,7 @@ import { d20Roll, D20Roll, D20RollData, DamageRoll } from '@system/dice';
 // Dialogs
 import { ShortRestDialog } from '@system/applications/actor/dialogs/short-rest';
 import { MESSAGE_TYPES } from './chat-message';
+import { getTargetDescriptors } from '../utils/generic';
 
 export type CharacterActor = CosmereActor<CharacterActorDataModel>;
 export type AdversaryActor = CosmereActor<AdversaryActorDataModel>;
@@ -713,6 +714,7 @@ export class CosmereActor<
         rollData.messageData.flags[SYSTEM_ID] = {
             message: {
                 type: MESSAGE_TYPES.SKILL,
+                targets: getTargetDescriptors(),
             },
         };
 

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -226,7 +226,7 @@ export class CosmereChatMessage extends ChatMessage {
         const tray = $(trayHTML as unknown as HTMLElement);
 
         tray.find('li.target').on('click', (event) => {
-            this.onClickTarget(event);
+            void this.onClickTarget(event);
         });
 
         html.find('.chat-card').append(tray);

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -63,7 +63,11 @@ import {
 } from '@system/dice';
 import { AdvantageMode } from '@system/types/roll';
 import { RollMode } from '@system/dice/types';
-import { determineConfigurationMode, hasKey } from '../utils/generic';
+import {
+    determineConfigurationMode,
+    getTargetDescriptors,
+    hasKey,
+} from '../utils/generic';
 import { MESSAGE_TYPES } from './chat-message';
 import { renderSystemTemplate, TEMPLATES } from '../utils/templates';
 
@@ -855,6 +859,7 @@ export class CosmereItem<
             message: {
                 type: MESSAGE_TYPES.ACTION,
                 description: await this.getDescriptionHTML(),
+                targets: getTargetDescriptors(),
             },
         };
 

--- a/src/system/utils/generic.ts
+++ b/src/system/utils/generic.ts
@@ -1,3 +1,4 @@
+import { CosmereActor } from '../documents';
 import {
     getSystemKeybinding,
     getSystemSetting,
@@ -167,4 +168,50 @@ export function getApplyTargets() {
     }
 
     return new Set([...selectTokens, ...targetTokens]);
+}
+
+export interface TargetDescriptor {
+    /**
+     * The UUID of the target.
+     */
+    uuid: string;
+
+    /**
+     * The target's name.
+     */
+    name: string;
+
+    /**
+     * The target's image.
+     */
+    img: string;
+
+    /**
+     * The target's defense values.
+     */
+    def: {
+        phy: number;
+        cog: number;
+        spi: number;
+    };
+}
+
+/**
+ * Grab the targeted tokens and return relevant information on them.
+ * @returns {TargetDescriptor[]}
+ */
+export function getTargetDescriptors() {
+    const targets = new Map();
+    for (const token of game.user!.targets) {
+        const { name, img, system, uuid } = (token.actor as CosmereActor) ?? {};
+        const phy = system.defenses.phy.value.value ?? 10;
+        const cog = system.defenses.cog.value.value ?? 10;
+        const spi = system.defenses.spi.value.value ?? 10;
+
+        if (uuid) {
+            targets.set(uuid, { name, img, uuid, def: { phy, cog, spi } });
+        }
+    }
+
+    return Array.from(targets.values());
 }

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -52,6 +52,8 @@ export const TEMPLATES = {
     CHAT_CARD_INJURY: 'chat/card-injury.hbs',
     CHAT_CARD_DAMAGE_BUTTONS: 'chat/card-damage-buttons.hbs',
 
+    CHAT_CARD_TRAY_TARGETS: 'chat/card-tray-targets.hbs',
+
     CHAT_ROLL_D20: 'chat/roll-d20.hbs',
     CHAT_ROLL_DAMAGE: 'chat/roll-damage.hbs',
     CHAT_ROLL_TOOLTIP: 'chat/roll-tooltip.hbs',

--- a/src/templates/chat/card-tray-targets.hbs
+++ b/src/templates/chat/card-tray-targets.hbs
@@ -13,7 +13,7 @@
             </div>
             <ul class="target-list">
                 {{#each targets}}
-                <li class="target">
+                <li class="target" data-uuid="{{this.uuid}}">
                     <span class="name">{{this.name}}</span>
                     <span class="result">{{this.phyDef}} {{{this.phyIcon}}}</span>
                     <span class="result">{{this.cogDef}} {{{this.cogIcon}}}</span>

--- a/src/templates/chat/card-tray-targets.hbs
+++ b/src/templates/chat/card-tray-targets.hbs
@@ -1,0 +1,26 @@
+<section class="chat-card-tray collapsible">
+    <label>
+          <i class="fas fa-bullseye" inert=""></i>
+          <span>{{ localize "COSMERE.ChatMessage.Trays.Targets" }}</span>
+          <i class="fas fa-caret-down" inert=""></i>
+    </label>
+    <div class="collapsible-content">
+        <div class="wrapper">            
+            <div class="target-headers">
+                <span>{{ localize "COSMERE.AttributeGroup.Physical.short" }} <i class="fa-solid fa-shield"></i></span>
+                <span>{{ localize "COSMERE.AttributeGroup.Cognitive.short" }} <i class="fa-solid fa-shield"></i></span>
+                <span>{{ localize "COSMERE.AttributeGroup.Spiritual.short" }} <i class="fa-solid fa-shield"></i></span>
+            </div>
+            <ul class="target-list">
+                {{#each targets}}
+                <li class="target">
+                    <span class="name">{{this.name}}</span>
+                    <span class="result">{{this.phyDef}} {{{this.phyIcon}}}</span>
+                    <span class="result">{{this.cogDef}} {{{this.cogIcon}}}</span>
+                    <span class="result">{{this.spiDef}} {{{this.spiIcon}}}</span>
+                </li>
+                {{/each}}
+            </ul>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds a collapsible list of actors that were targeted when the skill test was made. This list shows the appropriate defence values for each actor, and adds an indicator for whether or not each defence was beaten by the skill test. Target info is stored within the message flags, which means the card will persist even post reload, keeping a tray with the targets that were selected when it was made.

**Related Issue**  
Closes #153.

**How Has This Been Tested?**  
Tested with multiple actors targeted and ensure targets are stored into the message on refresh.

**Screenshots (if applicable)**  
![image](https://github.com/user-attachments/assets/445d0eb2-63a5-4926-aadc-74bfa83e464f)

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].