### PR TITLE
fix: complication opportunity thresholds

### DIFF
--- a/src/system/dice/d20-roll.ts
+++ b/src/system/dice/d20-roll.ts
@@ -383,6 +383,7 @@ export class D20Roll extends foundry.dice.Roll<D20RollData> {
                 modifiers,
             });
             const baseRoll = D20Roll.fromTerms([baseTerm]);
+            baseRoll.options = this.options;
 
             const total = (baseRoll?.total ?? 0) + (bonusRoll?.total ?? 0);
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where chat messages wouldn't show the opportunities or complications derived from a modified opportunity or complication threshold. Since this bug only affects temporary instances of the roll during chat message rendering, it should not break anything else in the roll workflow.

**Related Issue**  
Closes #377.

**How Has This Been Tested?**  
Tested with multiple different opportunity and complication thresholds to ensure the correct icons show up.

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
