### PR TITLE
feat(styling): bring talent tree editor menu styling up-to-date

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -562,8 +562,15 @@
                     "CreateConnection": "Select a talent to connect to."
                 },
                 "ViewBounds": {
-                    "Label": "View Bounds",
+                    "Label": "Bounds",
                     "CaptureTooltip": "Capture current view bounds",
+                    "ExpandTooltip": "View view bound details",
+                    "Origin": {
+                        "Label": "Origin"
+                    },
+                    "Size": {
+                        "Label": "Size"
+                    },
                     "X": {
                         "Label": "X"
                     },
@@ -844,6 +851,9 @@
                         "Edit": "Edit rule",
                         "Delete": "Remove rule"
                     }
+                },
+                "TalentTree": {
+                    "View": "View"
                 },
                 "Goal": {
                     "Reward": {

--- a/src/style/sheets/item/module.scss
+++ b/src/style/sheets/item/module.scss
@@ -310,6 +310,7 @@
     app-item-details-id,
     app-item-details-modality,
     app-item-details-type,
+    app-talent-tree-editor .menu,
     .item-details-form {
         display: flex;
         flex-direction: column;

--- a/src/style/sheets/item/talent-tree.scss
+++ b/src/style/sheets/item/talent-tree.scss
@@ -27,19 +27,17 @@ app-talent-tree-editor {
 
         .view {
             flex: 1;
+            background-color: var(--cosmere-color-base-2);
+            border-top: 1px solid var(--cosmere-color-accent);
+            border-right: 1px solid var(--cosmere-color-accent);
         }
 
-        .menu {
-            // position: absolute;
-            // top: 0;
-            // bottom: 0;
-            
-            width: 25rem;
-            right: -25rem;
+        .menu {         
+            width: 30rem;
+            right: -30rem;
             transition: right 0.3s;
+            gap: 0.75rem !important;
 
-            background: var(--background);
-            border-left: 1px solid var(--color-border-dark-2);
             padding: 0.2rem 0.5rem;
 
             font-size: .7rem;
@@ -50,6 +48,49 @@ app-talent-tree-editor {
 
             &.open {
                 right: 0;
+            }
+
+            .collapsible {
+                .header .controls {
+                    flex: 0;
+                }
+
+                .collapsible-content {
+                    .form-group-stacked > .form-group > label {
+                        font-style: italic;
+                        text-indent: 2em;
+                    }
+                }
+            }
+
+            .form-group-stacked.collapsible .header > label {
+                flex: 1 !important;
+            }
+
+            fieldset > .form-group, .collapsible-content .form-group-stacked > .form-group, .form-group-stacked.collapsible > .form-group {
+                > .form-fields {
+                    flex: 4 !important;
+                }
+            }
+
+            .form-group button {
+                display: block !important;
+
+                &.capture-view {
+                    padding: 0 6px;
+
+                    > i {
+                        margin: 0;
+                    }
+                } 
+            }
+
+            .view-bounds {
+                &.expanded {
+                    .header .form-fields span {
+                        display: none;
+                    }
+                }
             }
         }
     }

--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -172,6 +172,10 @@
                         color: var(--cosmere-color-text-accent);
                     }
                 }
+
+                &.inline {
+                    display: block;
+                }
             }
 
             .subtitle,

--- a/src/system/applications/item/components/talent-tree/constants.ts
+++ b/src/system/applications/item/components/talent-tree/constants.ts
@@ -1,3 +1,4 @@
 export const GRID_SIZE = 50;
 export const SUB_GRID_SIZE = 50 / 5;
 export const MIN_SUB_GRID_ZOOM = 0.5;
+export const EDIT_MENU_WIDTH = 480;

--- a/src/system/applications/item/components/talent-tree/talent-tree-editor.ts
+++ b/src/system/applications/item/components/talent-tree/talent-tree-editor.ts
@@ -20,7 +20,7 @@ import { AppContextMenu } from '@system/applications/utils/context-menu';
 import { GridViewport, TalentTreeWorld, CanvasElements } from './canvas';
 
 // Constants
-import { GRID_SIZE } from './constants';
+import { GRID_SIZE, EDIT_MENU_WIDTH } from './constants';
 
 export class TalentTreeEditorComponent extends TalentTreeViewComponent {
     static TEMPLATE =
@@ -45,6 +45,7 @@ export class TalentTreeEditorComponent extends TalentTreeViewComponent {
         event: Event,
     ) {
         event.preventDefault();
+        event.stopPropagation();
 
         // Get the visible bounds
         const bounds = this.app!.viewport.visibleBounds;
@@ -70,7 +71,7 @@ export class TalentTreeEditorComponent extends TalentTreeViewComponent {
                 height: bounds.height,
             },
             'system.display': {
-                width: windowSize.width - 400,
+                width: windowSize.width - EDIT_MENU_WIDTH,
                 height: windowSize.height,
             },
         });
@@ -83,7 +84,10 @@ export class TalentTreeEditorComponent extends TalentTreeViewComponent {
         const bounds = this.element!.getBoundingClientRect();
 
         // Set size
-        this.app!.app.renderer.resize(bounds.width - 400, bounds.height);
+        this.app!.app.renderer.resize(
+            bounds.width - EDIT_MENU_WIDTH,
+            bounds.height,
+        );
 
         // Render canvas
         await this.canvasTree!.refresh();

--- a/src/system/applications/item/components/talent-tree/talent-tree-view.ts
+++ b/src/system/applications/item/components/talent-tree/talent-tree-view.ts
@@ -563,13 +563,14 @@ export class TalentTreeViewComponent<
 
     public async _prepareContext(params: P, context: never) {
         const item =
-            !!this.selected &&
-            this.selectedType === 'node' &&
-            (this.selected as TalentTree.Node).type ===
-                TalentTree.Node.Type.Talent
+            !!this.selected && this.selectedType === 'node'
                 ? ((await fromUuid(
-                      (this.selected as TalentTree.TalentNode).uuid,
-                  )) as TalentItem | null)
+                      (
+                          this.selected as
+                              | TalentTree.TalentNode
+                              | TalentTree.TreeNode
+                      ).uuid,
+                  )) as TalentItem | TalentTreeItem | null)
                 : null;
 
         const itemLink = item ? item.toAnchor().outerHTML : null;

--- a/src/system/applications/item/talent-tree-sheet.ts
+++ b/src/system/applications/item/talent-tree-sheet.ts
@@ -16,6 +16,7 @@ import { TalentTreeViewComponent } from './components/talent-tree/talent-tree-vi
 const { ItemSheetV2 } = foundry.applications.sheets;
 
 // Constants
+import { EDIT_MENU_WIDTH } from './components/talent-tree/constants';
 const DEFAULT_WIDTH = 800;
 const DEFAULT_HEIGHT = 650;
 
@@ -74,7 +75,7 @@ export class TalentTreeItemSheet extends EditModeApplicationMixin(
             position: {
                 width:
                     (tree.system.display.width ?? DEFAULT_WIDTH) +
-                    (mode === 'edit' ? 400 : 0),
+                    (mode === 'edit' ? EDIT_MENU_WIDTH : 0),
                 height: tree.system.display.height ?? DEFAULT_HEIGHT,
             },
         });
@@ -171,6 +172,13 @@ export class TalentTreeItemSheet extends EditModeApplicationMixin(
 
     /* --- Lifecycle --- */
 
+    protected _onRender(context: AnyObject, options: AnyObject) {
+        super._onRender(context, options);
+        $(this.element)
+            .find('.collapsible .header')
+            .on('click', (event) => this.onClickCollapsible(event));
+    }
+
     protected override async _renderFrame(
         options: AnyObject,
     ): Promise<HTMLElement> {
@@ -260,8 +268,15 @@ export class TalentTreeItemSheet extends EditModeApplicationMixin(
         this.setPosition({
             width:
                 (this.position.width as number) +
-                (this.isEditMode ? 400 : -400),
+                (this.isEditMode ? EDIT_MENU_WIDTH : -EDIT_MENU_WIDTH),
         });
+    }
+
+    /* --- Event handlers --- */
+
+    private onClickCollapsible(event: JQuery.ClickEvent) {
+        const target = event.currentTarget as HTMLElement;
+        target?.parentElement?.classList.toggle('expanded');
     }
 
     /* --- Context --- */

--- a/src/system/data/item/fields/talent-tree-node-collection.ts
+++ b/src/system/data/item/fields/talent-tree-node-collection.ts
@@ -67,10 +67,12 @@ class TalentTreeNodeField extends foundry.data.fields.SchemaField {
                         x: new foundry.data.fields.NumberField({
                             required: true,
                             nullable: false,
+                            label: 'COSMERE.Item.TalentTree.Node.Position.X.Label',
                         }),
                         y: new foundry.data.fields.NumberField({
                             required: true,
                             nullable: false,
+                            label: 'COSMERE.Item.TalentTree.Node.Position.Y.Label',
                         }),
                     },
                     {

--- a/src/templates/item/components/talent-tree-editor.hbs
+++ b/src/templates/item/components/talent-tree-editor.hbs
@@ -4,127 +4,174 @@
         {{#if (not hasSelection)}}
             {{!-- No select, general configuration --}}
 
-            {{!-- Name --}}
-            {{formGroup
-                documentSchema.fields.name
-                label=(localize "GENERIC.Name")
-                name="name"
-                value=tree.name
-                localize=true
-            }}
-            {{formGroup
-                documentSchema.fields.img
-                label=(localize "GENERIC.Image")
-                name="img"
-                value=tree.img
-                localize=true
-            }}
-            <br>
-            
-            {{!-- View bounds --}}
-            <div class="form-group-stacked">
-                <div class="form-group">
-                    <label><b>{{localize "COSMERE.Item.TalentTree.ViewBounds.Label"}}</b></label>
-                    <button type="button" data-action="capture-view"
-                        data-tooltip="{{localize "COSMERE.Item.TalentTree.ViewBounds.CaptureTooltip"}}"
-                    >
-                        <i class="fas fa-crop-alt fa-fw"></i>
-                    </button>
-                </div>
-                <div class="form-group">
-                    <div class="form-fields">
-                        {{formField
-                            systemSchema.fields.viewBounds.fields.x
-                            value=tree.system.viewBounds.x
-                            localize=true
-                        }}
-                        {{formField
-                            systemSchema.fields.viewBounds.fields.y
-                            value=tree.system.viewBounds.y
-                            localize=true
-                        }}
-                        {{formField
-                            systemSchema.fields.viewBounds.fields.width
-                            value=tree.system.viewBounds.width
-                            localize=true
-                        }}
-                        {{formField
-                            systemSchema.fields.viewBounds.fields.height
-                            value=tree.system.viewBounds.height
-                            localize=true
-                        }}
+            <fieldset>
+                <legend>{{localize "COSMERE.Item.Sheet.Basics"}}</legend>
+
+                {{!-- Name --}}
+                {{formGroup
+                    documentSchema.fields.name
+                    label=(localize "GENERIC.Name")
+                    name="name"
+                    value=tree.name
+                    localize=true
+                }}
+                {{formGroup
+                    documentSchema.fields.img
+                    label=(localize "GENERIC.Image")
+                    name="img"
+                    value=tree.img
+                    localize=true
+                }}
+            </fieldset>
+
+
+            <fieldset>
+                <legend>{{localize "COSMERE.Item.Sheet.TalentTree.View"}}</legend>
+
+                {{!-- View bounds --}}
+                <div class="view-bounds form-group-stacked collapsible">
+                    <div class="header form-group" data-action="toggle-view-bounds-collapsed">
+                        <label>
+                            {{localize "COSMERE.Item.TalentTree.ViewBounds.Label"}}
+                        </label>
+
+                        <div class="form-fields">
+                            <span class="hint">
+                                ({{tree.system.viewBounds.x}}, {{tree.system.viewBounds.y}}) — {{tree.system.viewBounds.width}} x {{tree.system.viewBounds.height}}
+                            </span>
+
+                            <button class="capture-view" type="button" data-action="capture-view"
+                                data-tooltip="{{localize "COSMERE.Item.TalentTree.ViewBounds.CaptureTooltip"}}"
+                            >
+                                <i class="fas fa-crop-alt fa-fw"></i>
+                            </button>
+                        </div>
+
+                        <div class="controls">
+                            <a data-tooltip="{{localize "COSMERE.Item.TalentTree.ViewBounds.ExpandTooltip"}}">
+                                <i class="fa-solid fa-chevron-down"></i>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="collapsible-content">
+                        <div class="wrapper">
+                            <div class="form-group-stacked">
+                                {{!-- Origin --}}
+                                <div class="form-group">
+                                    <label>{{localize "COSMERE.Item.TalentTree.ViewBounds.Origin.Label"}}</label>
+
+                                    <div class="form-fields">
+                                        {{formField
+                                            systemSchema.fields.viewBounds.fields.x
+                                            value=tree.system.viewBounds.x
+                                            localize=true
+                                            units="pt"
+                                        }}
+                                        {{formField
+                                            systemSchema.fields.viewBounds.fields.y
+                                            value=tree.system.viewBounds.y
+                                            localize=true
+                                            units="pt"
+                                        }}
+                                    </div>
+                                </div>
+
+                                {{!-- Size --}}
+                                <div class="form-group">
+                                    <label>{{localize "COSMERE.Item.TalentTree.ViewBounds.Size.Label"}}</label>
+                                    <div class="form-fields">
+                                        {{formField
+                                            systemSchema.fields.viewBounds.fields.width
+                                            value=tree.system.viewBounds.width
+                                            localize=true
+                                            units="pt"
+                                        }}
+                                        {{formField
+                                            systemSchema.fields.viewBounds.fields.height
+                                            value=tree.system.viewBounds.height
+                                            localize=true
+                                            units="pt"
+                                        }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <br>
 
-            {{!-- Display --}}
-            <div class="form-group-stacked">
-                <label><b>{{localize "COSMERE.Item.TalentTree.Display.Label"}}</b></label>
+                {{!-- Display --}}
                 <div class="form-group">
+                    <label>{{localize "COSMERE.Item.TalentTree.Display.Label"}}</label>
                     <div class="form-fields">
                         {{formField
                             systemSchema.fields.display.fields.width
                             value=tree.system.display.width
                             localize=true
+                            units="px"
                         }}
                         {{formField
                             systemSchema.fields.display.fields.height
                             value=tree.system.display.height
                             localize=true
+                            units="px"
                         }}
                     </div>
                 </div>
-            </div>
-            <br>
+            </fieldset>
 
-            <div class="form-group">
-                <label><b>{{localize "COSMERE.Item.TalentTree.Background.Label"}}</b></label>
-            </div>
-            {{!-- Background image --}}
-            {{formGroup
-                systemSchema.fields.background.fields.img
-                value=tree.system.background.img
-                localize=true
-            }}
-            <div class="form-group">
-                <label>{{localize "COSMERE.Item.TalentTree.Background.Size.Label"}}</label>
+
+            <fieldset>
+                <legend>Background</legend>
+
+                {{!-- Background image --}}
+                {{formGroup
+                    systemSchema.fields.background.fields.img
+                    value=tree.system.background.img
+                    localize=true
+                }}
                 <div class="form-group">
+                    <label>{{localize "COSMERE.Item.TalentTree.Background.Size.Label"}}</label>
                     <div class="form-fields">
                         {{formField
                             systemSchema.fields.background.fields.width
                             value=tree.system.background.width
                             localize=true
+                            units="pt"
                         }}
                         {{formField
                             systemSchema.fields.background.fields.height
                             value=tree.system.background.height
                             localize=true
+                            units="pt"
                         }}
                     </div>
                 </div>
-            </div>
-            <div class="form-group">
-                <label>{{localize "COSMERE.Item.TalentTree.Background.Position.Label"}}</label>
                 <div class="form-group">
+                    <label>{{localize "COSMERE.Item.TalentTree.Background.Position.Label"}}</label>
                     <div class="form-fields">
                         {{formField
                             systemSchema.fields.background.fields.position.fields.x
                             value=tree.system.background.position.x
                             localize=true
+                            units="pt"
                         }}
                         {{formField
                             systemSchema.fields.background.fields.position.fields.y
                             value=tree.system.background.position.y
                             localize=true
+                            units="pt"
                         }}
                     </div>
                 </div>
-            </div>
-        {{else}}
-            {{#if (eq selectedType "node")}}
+            </fieldset>
+        {{else if (eq selectedType "node")}}
+            <fieldset>
+                <legend>{{localize "COSMERE.Item.Sheet.Basics"}}</legend>
+
                 <div class="form-group">
-                    <label>{{localize "GENERIC.Talent"}}</label>
+                    <label>
+                        {{localize (concat "TYPES.Item." item.type)}}
+                    </label>
                     <div class="form-field">
                         {{{itemLink}}}
                     </div>
@@ -132,22 +179,30 @@
 
                 <div class="form-group">
                     <label>{{localize "COSMERE.Item.TalentTree.Node.Position.Label"}}</label>
-                    <div class="form-group">
-                        <label>{{localize "COSMERE.Item.TalentTree.Node.Position.X.Label"}}</label>
-                        <input type="number" name="node.position.x" value={{selected.position.x}} min="0" step="1">
-                    </div>
-                    <div class="form-group">
-                        <label>{{localize "COSMERE.Item.TalentTree.Node.Position.Y.Label"}}</label>
-                        <input type="number" name="node.position.y" value={{selected.position.y}} min="0" step="1">
-                    </div>
-                </div>
 
-                <div class="form-group">
-                    <label><b>{{localize "COSMERE.Item.TalentTree.Node.Prerequisites.Label"}}</b></label>
+                    <div class="form-fields">
+                        {{formField systemSchema.fields.nodes.model.fields.position.fields.x
+                            value=selected.position.x
+                            localize=true
+                            units="px"
+                        }}
+                        {{formField systemSchema.fields.nodes.model.fields.position.fields.y
+                            value=selected.position.y
+                            localize=true
+                            units="px"
+                        }}
+                    </div>
                 </div>
-                {{app-talent-tree-node-prerequisites
-                    node=selected
-                }}
+            </fieldset>
+
+            {{#if (eq selected.type "talent")}}
+                <fieldset>
+                    <legend>{{localize "COSMERE.Item.TalentTree.Node.Prerequisites.Label"}}</legend>
+
+                    {{app-talent-tree-node-prerequisites
+                        node=selected
+                    }}
+                </fieldset>
             {{/if}}
         {{/if}}
     </div>

--- a/src/templates/item/talent-tree/components/prerequisites.hbs
+++ b/src/templates/item/talent-tree/components/prerequisites.hbs
@@ -1,69 +1,72 @@
-<ul class="prerequisites-list">
-    <li class="rule header">
-        <div class="col type">
-            <span>{{localize "COSMERE.Item.Sheet.Talent.Prerequisites.Type"}}</span>
-        </div>
-        <div class="col description">
-            <span>{{localize "COSMERE.Item.Sheet.Talent.Prerequisites.Description"}}</span>
-        </div>
-        <div class="col controls flexrow">
-            {{#if editable}}
-            <div></div>
-            <a data-action="create-prerequisite"
-                data-tooltip="COSMERE.Item.Sheet.Talent.Prerequisites.Create"
-            >
-                <i class="fa-solid fa-plus"></i>
-            </a>
-            {{/if}}
-        </div>
+<ul class="item-list prerequisites-list">
+    <li class="item rule header">
+        <section class="details">
+            <span class="subtitle detail wide">{{localize "COSMERE.Item.Sheet.Talent.Prerequisites.Type"}}</span>
+            <span class="title">{{localize "COSMERE.Item.Sheet.Talent.Prerequisites.Description"}}</span>
+            <div class="controls icon flexrow active">
+                {{#if editable}}
+                <div></div>
+                <a data-action="create-prerequisite"
+                    data-tooltip="COSMERE.Item.Sheet.Talent.Prerequisites.Create"
+                >
+                    <i class="fa-solid fa-plus"></i>
+                </a>
+                {{else}}
+                <div></div>
+                <div></div>
+                {{/if}}
+            </div>
+        </section>
     </li>
 
     {{#each prerequisites as |rule|}}
-    <li class="rule" data-id="{{rule.id}}">
-        <div class="col type">
-            <span>{{localize rule.typeLabel}}</span>
-        </div>
-        <div class="col description">
-            {{#if (eq rule.type "talent")}}
-                {{#if (gt rule.talents.length 1)}}
-                    <span>{{localize "COSMERE.Item.TalentTree.Node.Prerequisites.OneOf"}}:</span>
-                {{/if}}
-                {{#each rule.talents as |ref|}}
-                    {{{ref.link}}}
-                    {{#if (not @last)}}
-                        <span>,</span>
+    <li class="item rule" data-id="{{rule.id}}">
+        <section class="details">
+            <div class="detail wide">
+                <span>{{localize rule.typeLabel}}</span>
+            </div>
+            <div class="name inline">
+                {{#if (eq rule.type "talent")}}
+                    {{#if (gt rule.talents.length 1)}}
+                        <span>{{localize "COSMERE.Item.TalentTree.Node.Prerequisites.OneOf"}}:</span>
                     {{/if}}
-                {{/each}}
-            {{else if (eq rule.type "attribute")}}
-                <span>{{localize (concat "COSMERE.Attribute." rule.attribute)}}</span>
-                <span>{{rule.value}}+</span>
-            {{else if (eq rule.type "skill")}}
-                <span>{{localize (concat "COSMERE.Skill." rule.skill)}}</span>
-                <span>{{rule.rank}}+</span>
-            {{else if (eq rule.type "connection")}}
-                <span>{{rule.description}}</span>
-            {{else if (eq rule.type "level")}}
-                <span>{{rule.level}}+</span>
-            {{/if}}
-        </div>
-        <div class="col controls flexrow">
-            {{#if @root.editable}}
-                {{#if (not rule.managed)}}
-                    <a data-action="edit-prerequisite"
-                        data-tooltip="COSMERE.Item.Sheet.Talent.Prerequisites.Edit"
-                    >
-                        <i class="fa-solid fa-pen-to-square"></i>
-                    </a>
-                    <a data-action="delete-prerequisite"
-                        data-tooltip="COSMERE.Item.Sheet.Talent.Prerequisites.Delete"
-                    >
-                        <i class="fa-solid fa-trash"></i>
-                    </a>
-                {{else}}
-                    <i data-tooltip="COSMERE.Item.TalentTree.Node.Prerequisites.CannotEditManaged" class="fa-solid fa-lock"></i>
+                    {{#each rule.talents as |ref|}}
+                        {{{ref.link}}}
+                        {{#if (not @last)}}
+                            <span>,</span>
+                        {{/if}}
+                    {{/each}}
+                {{else if (eq rule.type "attribute")}}
+                    <span>{{localize (concat "COSMERE.Attribute." rule.attribute)}}</span>
+                    <span>{{rule.value}}+</span>
+                {{else if (eq rule.type "skill")}}
+                    <span>{{localize (concat "COSMERE.Skill." rule.skill)}}</span>
+                    <span>{{rule.rank}}+</span>
+                {{else if (eq rule.type "connection")}}
+                    <span>{{rule.description}}</span>
+                {{else if (eq rule.type "level")}}
+                    <span>{{rule.level}}+</span>
                 {{/if}}
-            {{/if}}
-        </div>
+            </div>
+            <div class="controls icon faded flexrow">
+                {{#if @root.editable}}
+                    {{#if (not rule.managed)}}
+                        <a data-action="edit-prerequisite"
+                            data-tooltip="COSMERE.Item.Sheet.Talent.Prerequisites.Edit"
+                        >
+                            <i class="fa-solid fa-pen-to-square"></i>
+                        </a>
+                        <a data-action="delete-prerequisite"
+                            data-tooltip="COSMERE.Item.Sheet.Talent.Prerequisites.Delete"
+                        >
+                            <i class="fa-solid fa-trash"></i>
+                        </a>
+                    {{else}}
+                        <i data-tooltip="COSMERE.Item.TalentTree.Node.Prerequisites.CannotEditManaged" class="fa-solid fa-lock"></i>
+                    {{/if}}
+                {{/if}}
+            </div>
+        </section>
     </li>
     {{/each}}
 </ul>


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR updates the styling of the talent tree editor side menu to be up-to-date with the latest styling (and no longer a broken mess).

**Related Issue**  
Partially addresses #359 

**How Has This Been Tested?**  
1. Open talent tree in edit mode
2. Click talent -> check styling side menu
3. Open talent tree with nested talent trees
4. Click nested talent tree -> check styling side menu

**Screenshots (if applicable)** 
No selection: 
![image](https://github.com/user-attachments/assets/5cb486b9-7a07-47a6-83e9-53db0fefb84d)  

Talent selected:
![image](https://github.com/user-attachments/assets/be89ae20-13b6-400c-b18e-85ed91d7eee0)  

Nested tree selected:
![image](https://github.com/user-attachments/assets/fa3df22c-ac9d-4de2-b243-f58249646e22)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343