### PR TITLE
fix(actor data model): fix issues with certain derived fields not properly updating when AEs modify their dependencies

### DIFF
--- a/src/system/data/actor/character.ts
+++ b/src/system/data/actor/character.ts
@@ -2,7 +2,7 @@
 import { Resource } from '@system/types/cosmere';
 import { DeepPartial, AnyObject } from '@system/types/utils';
 
-import { CommonActorDataModel, CommonActorData } from './common';
+import { CommonActorDataModel, CommonActorData, AttributeData } from './common';
 
 // Utils
 import * as Advancement from '@system/utils/advancement';
@@ -145,9 +145,7 @@ export class CharacterActorDataModel extends CommonActorDataModel<CharacterActor
         );
 
         // Derive the recovery die based on the character's willpower
-        this.recovery.die.derived = willpowerToRecoveryDie(
-            this.attributes.wil.value,
-        );
+        this.recovery.die.derived = willpowerToRecoveryDie(this.attributes.wil);
 
         // Derive resource max
         (Object.keys(this.resources) as Resource[]).forEach((key) => {
@@ -181,7 +179,8 @@ export class CharacterActorDataModel extends CommonActorDataModel<CharacterActor
 }
 
 export const RECOVERY_DICE = ['d4', 'd6', 'd8', 'd10', 'd12', 'd20'];
-function willpowerToRecoveryDie(willpower: number) {
+function willpowerToRecoveryDie(attr: AttributeData) {
+    const willpower = attr.value + attr.bonus;
     return RECOVERY_DICE[
         Math.min(Math.ceil(willpower / 2), RECOVERY_DICE.length)
     ];

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -779,7 +779,7 @@ export class CommonActorDataModel<
 
 const SENSES_RANGES = [5, 10, 20, 50, 100, Number.MAX_VALUE];
 function awarenessToSensesRange(attr: AttributeData) {
-    const awareness = attr.value;
+    const awareness = attr.value + attr.bonus;
     return SENSES_RANGES[
         Math.min(Math.ceil(awareness / 2), SENSES_RANGES.length)
     ];
@@ -787,7 +787,7 @@ function awarenessToSensesRange(attr: AttributeData) {
 
 const MOVEMENT_RATES = [20, 25, 30, 40, 60, 80];
 function speedToMovementRate(attr: AttributeData) {
-    const speed = attr.value;
+    const speed = attr.value + attr.bonus;
     return MOVEMENT_RATES[
         Math.min(Math.ceil(speed / 2), MOVEMENT_RATES.length)
     ];
@@ -795,7 +795,7 @@ function speedToMovementRate(attr: AttributeData) {
 
 const LIFTING_CAPACITIES = [100, 200, 500, 1000, 5000, 10000];
 function strengthToLiftingCapacity(attr: AttributeData) {
-    const strength = attr.value;
+    const strength = attr.value + attr.bonus;
     return LIFTING_CAPACITIES[
         Math.min(Math.ceil(strength / 2), LIFTING_CAPACITIES.length)
     ];
@@ -803,7 +803,7 @@ function strengthToLiftingCapacity(attr: AttributeData) {
 
 const CARRYING_CAPACITIES = [50, 100, 250, 500, 2500, 5000];
 function strengthToCarryingCapacity(attr: AttributeData) {
-    const strength = attr.value;
+    const strength = attr.value + attr.bonus;
     return CARRYING_CAPACITIES[
         Math.min(Math.ceil(strength / 2), CARRYING_CAPACITIES.length)
     ];


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR moves the derivation of a number of fields that depend on other fields (typically attributes) on the actor to the second derivation stage (after AEs are applied) so that they properly reflect all changes. The following fields were moved:
- sense range
- movement rate
- lifting capacity
- carrying capacity
- recovery dice
- defenses
- deflect (when natural deflect is used)
- resource max

I've added a full list of derived actor fields, their dependencies, and during which stage they are derived, at the bottom of this PR for review.

**Related Issue**  
Closes #388 

**How Has This Been Tested?**  
1. Create a new character actor
2. Set attributes to: 1,2,1,2,1,2
3. Add an item and add a new Active Effect to that item
4. Add the following changes: `system.attributes.str.value` add 2 & `system.attributes.spd.value` add 3
5. Ensure max health has gone from 11 to 13
6. Ensure movement rate has gone from 25 to 40
7. Ensure physical defense has gone from 13 to 18
8. Ensure lifting capacity has gone from 200 to 500 (have to use console)
9. Ensure carrying capacity has gone from 100 to 250 (have to use console)
10. Ensure all skill modifiers match their respective attribute
11. Remove all changes from the effect
12. Add the following: `system.attributes.str.bonus` add 2 & `system.attributes.spd.bonus` add 3
13. Ensure max health and physical defense have returned to their original values
14. Ensure movement rate, lifting capacity, and carrying capacity have not changed
15. Ensure all skill modifiers are still increased
16. Remove all changes from the effect
17. Add the following changes:  `system.attributes.int.value` add 2 & `system.attributes.wil.value` add 3
18. Ensure max focus has gone from 4 to 7
19. Ensure recovery die has gone from d6 to d10
20. Ensure cognitive defense has gone from 13 to 18
21. Ensure all skill modifiers match their respective attribute
22. Remove all changes from the effect
23. Add the following: `system.attributes.int.bonus` add 2 & `system.attributes.wil.bonus` add 3
24. Ensure max focus and cognitive defense have returned to their original values
25. Ensure recovery die has not changed
26. Ensure all skill modifiers are still increased
27. Remove all changes from the effect
28. Add the following changes:  `system.attributes.awa.value` add 2 & `system.attributes.pre.value` add 3
29. Ensure senses range has gone from 10ft to 20ft
30. Ensure spiritual defense has gone from 13 to 18
31. Ensure all skill modifiers match their respective attribute
32. Remove all changes from the effect
33. Add the following changes:  `system.attributes.awa.bonus` add 2 & `system.attributes.pre.bonus` add 3
34. Ensure spiritual defense has returned to its original values
35. Ensure senses range has not changed
36. Ensure all skill modifiers are still increased
37. Remove all changes from the effect
38. Add the following change: `system.deflect.natural` add 2
39. Ensure deflect has gone from 0 to 2

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343

---

## Primary derivation
These are available to AEs but their derivation cannot be modified by them (e.g. increase the level using an AE will not increase the tier).

### Common
- skill unlocked — `system.skills.<skill>.unlocked` depends on powers
- injury count — `system.injuries.[value|derived]` depends on injury items
- currency totals — `system.currency.<currency>.total.[value|derived]` depends on loot items

### Character
- tier — `system.tier` depends on level (`system.level`) & advancement rules
- max skill rank — `system.maxSkillRank` depends on depends on level (`system.level`) & advancement rules

## Secondary derivation
These are not available to be used by AEs but can be modified by them.

### Common
- senses range — `system.senses.range.[value|derived]` depends on awareness value (`system.attributes.awa.value`)
- lifting capacity — `system.encumbrance.lift.[value|derived]` depends on strength value (`system.attributes.str.value`)
- carrying capacity — `system.encumbrance.carry.[value|derived]` depends on strength value (`system.attributes.str.value`)
- movement rate — `system.movement.walk.rate.[value|derived]` depends on speed value (`system.attributes.spd.value`)
- defenses — `system.defenses.[phy|cog|spi].[value|derived]` depends on associated attribute values (`system.attributes.<attr>.value`)
- skill modifiers — `system.skills.<skill>.mod.[value|derived]` depends on associated attribute (`system.attributes.<attr>.[value|bonus]`) & skill rank
- deflect types — `system.deflect.types.<type>` depends on armour
- deflect value — `system.deflect.[value|derived]` depends on armour & natural deflect (`system.deflect.natural`)

### Character
- recovery die — `system.recovery.die.[value|derived]` depends on willpower value (`system.attributes.wil.value`)
- health max — `system.resources.hea.max.[value|derived]` depends on strength value (`system.attributes.str.value`) & level (`system.level`) & advancement rules
- focus max — `system.resources.foc.max.[value|derived]` depends on willpower value (`system.attributes.wil.value`)