### PR TITLE
fix(adversaries): remove check preventing skill changes

### DIFF
--- a/src/system/applications/actor/components/skill.ts
+++ b/src/system/applications/actor/components/skill.ts
@@ -69,8 +69,6 @@ export class ActorSkillComponent extends HandlebarsApplicationComponent<
     ) {
         event.preventDefault();
 
-        if (!this.application.isEditable) return;
-
         // Check if click is left or right mouse button
         const isLeftClick: boolean = event.type === 'click' ? true : false;
         // Check if the legacy behavior is toggled on


### PR DESCRIPTION

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adversary skills were not editable at all. There was an extraneous check (the conditions are already handled through handlebars) that didn't work properly with the way the skill config dialog is set up.

**Related Issue**  
N/A

**How Has This Been Tested?**  
1. Attempt to edit adversary skills; confirm that dialog can only open when edit mode is on, and that the skills update
2. Regression testing: Attempt to edit character skills (should work if edit toggle is on, shouldn't work if edit toggle is false or if in a locked compendium)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343.
