### PR TITLE
fix(character sheet): resolve goal title input issue

### DIFF
--- a/src/system/applications/actor/components/character/goals-list.ts
+++ b/src/system/applications/actor/components/character/goals-list.ts
@@ -198,7 +198,7 @@ export class CharacterGoalsListComponent extends HandlebarsApplicationComponent<
         setTimeout(() => {
             // Edit the goal
             this.editGoal(goal.id);
-        });
+        }, 50);
     }
 
     /* --- Context --- */
@@ -233,19 +233,17 @@ export class CharacterGoalsListComponent extends HandlebarsApplicationComponent<
 
     private editGoal(id: string) {
         // Get goal element
-        const element = $(this.element!).find(`.goal[data-id="${id}"]`);
+        const element = $(this.element!).find(`.item[data-id="${id}"]`);
 
-        // Get span element
-        const span = element.find('span.title');
-
-        // Hide span title
-        span.addClass('inactive');
+        console.log('element', element);
 
         // Get input element
-        const input = element.find('input.title');
+        const input = element.find('input.name');
 
-        // Show
-        input.removeClass('inactive');
+        console.log('input', input);
+
+        // Set not readonly
+        input.prop('readonly', false);
 
         setTimeout(() => {
             // Focus input

--- a/src/templates/actors/character/components/goals-list.hbs
+++ b/src/templates/actors/character/components/goals-list.hbs
@@ -9,7 +9,7 @@
     <li class="item {{#if goal.achieved}}achieved{{/if}}" data-id="{{goal.id}}">
         <section class="details">
             <i class="bullet fade icon faded fa-solid fa-diamond"></i>
-            <input class="name fade" type="text" value="{{goal.name}}" {{#unless @root.isEditMode}}readonly{{/unless}}>
+            <input class="name fade" type="text" value="{{goal.name}}" readonly>
 
             <a class="fade" data-action="adjust-goal-progress"
                 {{#if @root.editable}}


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue where the goal title input would remain editable even though changing it didn't actually save to the goal. Adjusted back to original behaviour where creating a goal would allow you to set the title through the input the first time only.

**Related Issue**  
Closes #438 

**How Has This Been Tested?**  
1. Create character
2. Create goal
3. Ensure that goal title input gets focus 
4. Enter some title and either click out or hit enter
5. Close the sheet and open it again
6. Ensure the goal title was persisted
7. Click the goal title to try and edit -> is not be possible
8. Click the controls to open the context menu and select edit
9. Adjust name in item
10. Ensure goal title gets updated

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 12.343