### PR TITLE
fix(actor): fix issue causing AEs to get applied twice

### DIFF
--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -274,10 +274,12 @@ export class CosmereActor<
          */
         /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 
-        // Grab the Actor's parent class' prepareEmbeddedDocuments method
+        // Grab the Base Actor class' prepareEmbeddedDocuments method
         const parentProto = Object.getPrototypeOf(Object.getPrototypeOf(this));
         const grandparentProto = Object.getPrototypeOf(parentProto);
-        const f = grandparentProto.prepareEmbeddedDocuments as () => void;
+        const greatGrandparentProto = Object.getPrototypeOf(grandparentProto);
+
+        const f = greatGrandparentProto.prepareEmbeddedDocuments as () => void;
 
         /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue of Active Effects getting applied twice in the V13 build. Seems to have been related to something about the Actor's inheritance stack changing.

**Related Issue**  
Closes #575 

**How Has This Been Tested?**  
1. Create actor
2. Create item on actor
3. Add effect with: key `system.attributes.str.value`, mode: `Add`, value: `1`
4. Ensure strength is 1

**Screenshots (if applicable)**  
<img width="887" height="657" alt="image" src="https://github.com/user-attachments/assets/8bb24866-ef44-49f6-8cca-168b9475f155" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.350