### PR TITLE
Fix AE changes persisting when prose-mirror fields are updated

### DIFF
--- a/src/system/applications/actor/base.ts
+++ b/src/system/applications/actor/base.ts
@@ -278,20 +278,24 @@ export class BaseActorSheet<
         form: HTMLFormElement,
         formData: FormDataExtended,
     ) {
-        // Handle notes fields separately
-        if ((event.target as HTMLElement).className.includes('prosemirror')) {
-            await this.saveHtmlField();
-            void this.actor.update(formData.object);
-            return;
-        }
-
         if (
             !(event.target instanceof HTMLInputElement) &&
             !(event.target instanceof HTMLTextAreaElement) &&
-            !(event.target instanceof HTMLSelectElement)
+            !(event.target instanceof HTMLSelectElement) &&
+            !(
+                event.target instanceof
+                foundry.applications.elements.HTMLProseMirrorElement
+            )
         )
             return;
         if (!event.target.name) return;
+
+        // Handle prose-mirror fields separately
+        if (
+            event.target instanceof
+            foundry.applications.elements.HTMLProseMirrorElement
+        )
+            await this.saveHtmlField();
 
         Object.keys(this.actor.system.resources).forEach((resourceId) => {
             let resourceValue = formData.object[
@@ -545,7 +549,6 @@ export class BaseActorSheet<
      * Helper to update the prose mirror edit state
      */
     private async saveHtmlField() {
-        console.log('Saving HTML Field');
         // Switches back from prose mirror
         this.updatingHtmlField = false;
         await this.render(true);


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Resolves the issue causing changes from Active Effects to actor properties (like attributes) to become permanent when a prose-mirror field gets updated.

This issue was caused by the independent handling of the prose-mirror field updates calling `actor.update` with the whole `formData.object`, instead of only targeting the specific field. Resolved by no longer handling the update logic separately for prose-mirror fields.

**Related Issue**  
Closes #584 

**How Has This Been Tested?**  
1. Create character
2. Create item on character
3. Add effect to item configured as follows: Attribute key `system.attributes.str.value`, Change Mode `Add`, Value `1`
4. Open notes tab of character sheet
5. Edit biography, appearances, and notes fields
6. Ensure STR remains 1
7. Create adversary
8. Drag item from character onto adversary
9. Open notes tab of adversary sheet
10. Edit biography, appearance, and notes fields
11. Ensure STR remains 1

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.350