### PR TITLE
Fix duplicate header controls on sheets

### DIFF
--- a/src/system/applications/actor/adversary-sheet.ts
+++ b/src/system/applications/actor/adversary-sheet.ts
@@ -18,22 +18,19 @@ export type AdversarySheetRenderContext = Omit<
 export class AdversarySheet extends BaseActorSheet<AdversarySheetRenderContext> {
     declare actor: AdversaryActor;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'actor', 'adversary'],
-            position: {
-                width: 850,
-                height: 850,
-            },
-            dragDrop: [
-                {
-                    dropSelector: '*',
-                },
-            ],
-            actions: {},
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'actor', 'adversary'],
+        position: {
+            width: 850,
+            height: 850,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        dragDrop: [
+            {
+                dropSelector: '*',
+            },
+        ],
+        actions: {},
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/base.ts
+++ b/src/system/applications/actor/base.ts
@@ -55,26 +55,23 @@ export class BaseActorSheet<
     declare actor: CosmereActor;
 
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.mergeObject({}, super.DEFAULT_OPTIONS),
-        {
-            actions: {
-                'toggle-mode': this.onToggleMode,
-                'edit-html-field': this.editHtmlField,
-                save: this.onSave,
-            },
-            form: {
-                handler: this.onFormEvent,
-                submitOnChange: true,
-            } as unknown,
-            dragDrop: [
-                {
-                    dragSelector: '[data-drag]',
-                    dropSelector: '*',
-                },
-            ],
+    static DEFAULT_OPTIONS = {
+        actions: {
+            'toggle-mode': this.onToggleMode,
+            'edit-html-field': this.editHtmlField,
+            save: this.onSave,
         },
-    ) as foundry.applications.api.DocumentSheetV2.DefaultOptions;
+        form: {
+            handler: this.onFormEvent,
+            submitOnChange: true,
+        } as unknown,
+        dragDrop: [
+            {
+                dragSelector: '[data-drag]',
+                dropSelector: '*',
+            },
+        ],
+    } as foundry.applications.api.DocumentSheetV2.DefaultOptions;
     /* eslint-enable @typescript-eslint/unbound-method */
 
     static PARTS = foundry.utils.mergeObject(super.PARTS, {

--- a/src/system/applications/actor/character-sheet.ts
+++ b/src/system/applications/actor/character-sheet.ts
@@ -16,16 +16,13 @@ const enum CharacterSheetTab {
 export class CharacterSheet extends BaseActorSheet {
     declare actor: CharacterActor;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'actor', 'character'] as string[],
-            position: {
-                width: 850,
-                height: 1000,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'actor', 'character'] as string[],
+        position: {
+            width: 850,
+            height: 1000,
         },
-    );
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/dialogs/configure-defense.ts
+++ b/src/system/applications/actor/dialogs/configure-defense.ts
@@ -17,23 +17,20 @@ export class ConfigureDefenseDialog extends HandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'configure-defense'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                'update-defense': this.onUpdateDefense,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'configure-defense'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            'update-defense': this.onUpdateDefense,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/dialogs/configure-deflect.ts
+++ b/src/system/applications/actor/dialogs/configure-deflect.ts
@@ -17,23 +17,20 @@ export class ConfigureDeflectDialog extends HandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'configure-deflect'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                'update-deflect': this.onUpdateDeflect,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'configure-deflect'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            'update-deflect': this.onUpdateDeflect,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/dialogs/configure-movement-rate.ts
+++ b/src/system/applications/actor/dialogs/configure-movement-rate.ts
@@ -17,23 +17,20 @@ export class ConfigureMovementRateDialog extends HandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'configure-movement-rate'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                'update-movement': this.onUpdateMovementRate,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'configure-movement-rate'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            'update-movement': this.onUpdateMovementRate,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/dialogs/configure-recovery-die.ts
+++ b/src/system/applications/actor/dialogs/configure-recovery-die.ts
@@ -19,23 +19,20 @@ export class ConfigureRecoveryDieDialog extends HandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'configure-recovery-die'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                'update-recovery': this.onUpdateRecoveryDie,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'configure-recovery-die'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            'update-recovery': this.onUpdateRecoveryDie,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/dialogs/configure-resource.ts
+++ b/src/system/applications/actor/dialogs/configure-resource.ts
@@ -17,23 +17,20 @@ export class ConfigureResourceDialog extends HandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'configure-resource'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                'update-resource': this.onUpdateResource,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'configure-resource'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            'update-resource': this.onUpdateResource,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/dialogs/configure-senses-range.ts
+++ b/src/system/applications/actor/dialogs/configure-senses-range.ts
@@ -16,23 +16,20 @@ export class ConfigureSensesRangeDialog extends HandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'configure-senses-range'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                'update-sense': this.onUpdateSensesRange,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'configure-senses-range'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            'update-sense': this.onUpdateSensesRange,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/dialogs/configure-skills.ts
+++ b/src/system/applications/actor/dialogs/configure-skills.ts
@@ -11,21 +11,18 @@ const { ApplicationV2 } = foundry.applications.api;
 export class ConfigureSkillsDialog extends ComponentHandlebarsApplicationMixin(
     ApplicationV2<AnyObject>,
 ) {
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                title: 'COSMERE.Actor.Sheet.ConfigureSkills',
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'configure-skills'],
-            tag: 'dialog',
-            position: {
-                width: 300,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            title: 'COSMERE.Actor.Sheet.ConfigureSkills',
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'configure-skills'],
+        tag: 'dialog',
+        position: {
+            width: 300,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/actor/dialogs/edit-creature-type.ts
+++ b/src/system/applications/actor/dialogs/edit-creature-type.ts
@@ -19,24 +19,21 @@ export class EditCreatureTypeDialog extends HandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                title: 'COSMERE.Actor.Sheet.EditType',
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'edit-creature-type'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                'update-type': this.onUpdateType,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            title: 'COSMERE.Actor.Sheet.EditType',
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'edit-creature-type'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            'update-type': this.onUpdateType,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),
@@ -76,7 +73,7 @@ export class EditCreatureTypeDialog extends HandlebarsApplicationMixin(
         void this.actor.update({
             system: {
                 type: this.type,
-            }
+            },
         });
         void this.close();
     }

--- a/src/system/applications/actor/dialogs/edit-immunities.ts
+++ b/src/system/applications/actor/dialogs/edit-immunities.ts
@@ -9,22 +9,19 @@ const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 export class EditImmunitiesDialog extends HandlebarsApplicationMixin(
     ApplicationV2<AnyObject>,
 ) {
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                title: 'COSMERE.Actor.Sheet.EditImmunities',
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['edit-immunities', 'dialog'],
-            tag: 'dialog',
-            position: {
-                width: 300,
-                height: 800,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            title: 'COSMERE.Actor.Sheet.EditImmunities',
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['edit-immunities', 'dialog'],
+        tag: 'dialog',
+        position: {
+            width: 300,
+            height: 800,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/combat/combat-tracker.ts
+++ b/src/system/applications/combat/combat-tracker.ts
@@ -34,15 +34,12 @@ export class CosmereCombatTracker extends foundry.applications.sidebar.tabs
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            actions: {
-                toggleSpeed: this._onClickToggleTurnSpeed,
-                activateCombatant: this._onActivateCombatant,
-            },
+    static DEFAULT_OPTIONS = {
+        actions: {
+            toggleSpeed: this._onClickToggleTurnSpeed,
+            activateCombatant: this._onActivateCombatant,
         },
-    );
+    };
     /* eslint-enable @typescript-eslint/unbound-method */
 
     static PARTS = foundry.utils.mergeObject(

--- a/src/system/applications/component-system/mixin.ts
+++ b/src/system/applications/component-system/mixin.ts
@@ -281,6 +281,12 @@ export function ComponentHandlebarsApplicationMixin<
                 this.dispatchRenderEventRecursive(childRef),
             );
         }
+
+        public _getHeaderControls() {
+            const controls = super._getHeaderControls();
+            console.log('Getting header controls for mixin', controls);
+            return controls;
+        }
     } as unknown as typeof ComponentHandlebarsApplication;
 }
 

--- a/src/system/applications/dialogs/attack-configuration.ts
+++ b/src/system/applications/dialogs/attack-configuration.ts
@@ -141,24 +141,21 @@ export class AttackConfigurationDialog extends ComponentHandlebarsApplicationMix
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                resizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'roll-configuration'],
-            tag: 'dialog',
-            position: {
-                width: 500,
-            },
-            actions: {
-                submit: this.onSubmit,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            resizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'roll-configuration'],
+        tag: 'dialog',
+        position: {
+            width: 500,
+        },
+        actions: {
+            submit: this.onSubmit,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/dialogs/edit-expertises.ts
+++ b/src/system/applications/dialogs/edit-expertises.ts
@@ -126,33 +126,30 @@ type EditExpertisesDialogConfig =
 export class EditExpertisesDialog extends HandlebarsApplicationMixin(
     ApplicationV2<AnyObject>,
 ) {
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                positioned: true,
-            },
-            classes: ['edit-expertises', 'dialog'],
-            tag: 'dialog',
-            position: {
-                width: 300,
-                height: 800,
-            },
-
-            /**
-             * NOTE: Unbound methods is the standard for defining actions and forms
-             * within ApplicationV2
-             */
-            /* eslint-disable @typescript-eslint/unbound-method */
-            actions: {
-                'add-custom-expertise': this.onAddCustomExpertise,
-                'remove-custom-expertise': this.onRemoveCustomExpertise,
-                'update-expertises': this.onSave,
-            },
-            /* eslint-enable @typescript-eslint/unbound-method */
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['edit-expertises', 'dialog'],
+        tag: 'dialog',
+        position: {
+            width: 300,
+            height: 800,
+        },
+
+        /**
+         * NOTE: Unbound methods is the standard for defining actions and forms
+         * within ApplicationV2
+         */
+        /* eslint-disable @typescript-eslint/unbound-method */
+        actions: {
+            'add-custom-expertise': this.onAddCustomExpertise,
+            'remove-custom-expertise': this.onRemoveCustomExpertise,
+            'update-expertises': this.onSave,
+        },
+        /* eslint-enable @typescript-eslint/unbound-method */
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/dialogs/pick-dialog.ts
+++ b/src/system/applications/dialogs/pick-dialog.ts
@@ -37,21 +37,18 @@ export class PickDialog extends ComponentHandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                resizable: false,
-                title: 'DIALOG.PickDialog.Title',
-            },
-            classes: ['dialog', 'pick-dialog'],
-            tag: 'dialog',
-            position: {
-                width: 300,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            resizable: false,
+            title: 'DIALOG.PickDialog.Title',
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'pick-dialog'],
+        tag: 'dialog',
+        position: {
+            width: 300,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/dialogs/pick-dice-result.ts
+++ b/src/system/applications/dialogs/pick-dice-result.ts
@@ -32,25 +32,22 @@ export class PickDiceResultDialog extends ComponentHandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                resizable: false,
-                title: 'DIALOG.PickDiceResult.Title',
-            },
-            classes: ['dialog', 'pick-dice-result'],
-            tag: 'dialog',
-            position: {
-                width: 300,
-            },
-            actions: {
-                'select-result': this.onSelectResult,
-                submit: this.onSubmit,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            resizable: false,
+            title: 'DIALOG.PickDiceResult.Title',
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'pick-dice-result'],
+        tag: 'dialog',
+        position: {
+            width: 300,
+        },
+        actions: {
+            'select-result': this.onSelectResult,
+            submit: this.onSubmit,
+        },
+    };
     /* eslint-enable @typescript-eslint/unbound-method */
 
     static PARTS = foundry.utils.mergeObject(

--- a/src/system/applications/dialogs/release-notes.ts
+++ b/src/system/applications/dialogs/release-notes.ts
@@ -12,18 +12,15 @@ interface ReleaseNotesDialogOptions {
 export class ReleaseNotesDialog extends HandlebarsApplicationMixin(
     ApplicationV2<AnyObject>,
 ) {
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                resizable: true,
-            },
-            position: {
-                width: 800,
-            },
-            classes: ['cosmere', 'dialog', 'release-notes'],
+    static DEFAULT_OPTIONS = {
+        window: {
+            resizable: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        position: {
+            width: 800,
+        },
+        classes: ['cosmere', 'dialog', 'release-notes'],
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/dialogs/roll-configuration.ts
+++ b/src/system/applications/dialogs/roll-configuration.ts
@@ -97,24 +97,21 @@ export class RollConfigurationDialog extends ComponentHandlebarsApplicationMixin
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                minimizable: false,
-                resizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'roll-configuration'],
-            tag: 'dialog',
-            position: {
-                width: 500,
-            },
-            actions: {
-                submit: this.onSubmit,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            resizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'roll-configuration'],
+        tag: 'dialog',
+        position: {
+            width: 500,
+        },
+        actions: {
+            submit: this.onSubmit,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/item/action-sheet.ts
+++ b/src/system/applications/item/action-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class ActionItemSheet extends BaseItemSheet {
     declare item: ActionItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'action'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'action'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/ancestry-sheet.ts
+++ b/src/system/applications/item/ancestry-sheet.ts
@@ -15,19 +15,16 @@ import { TEMPLATES } from '@src/system/utils/templates';
 export class AncestrySheet extends TalentsTabMixin(BaseItemSheet) {
     declare item: AncestryItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'ancestry'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'ancestry'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/armor-sheet.ts
+++ b/src/system/applications/item/armor-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class ArmorItemSheet extends BaseItemSheet {
     declare item: ArmorItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'armor'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'armor'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -46,19 +46,16 @@ export class BaseItemSheet extends TabsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            form: {
-                handler: this.onFormEvent,
-                submitOnChange: true,
-            } as unknown,
-            actions: {
-                'edit-description': this.editDescription,
-                save: this.onSave,
-            },
+    static DEFAULT_OPTIONS = {
+        form: {
+            handler: this.onFormEvent,
+            submitOnChange: true,
+        } as unknown,
+        actions: {
+            'edit-description': this.editDescription,
+            save: this.onSave,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+    } as foundry.applications.api.ApplicationV2.DefaultOptions;
     /* eslint-enable @typescript-eslint/unbound-method */
 
     static TABS = foundry.utils.mergeObject(

--- a/src/system/applications/item/connection-sheet.ts
+++ b/src/system/applications/item/connection-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class ConnectionItemSheet extends BaseItemSheet {
     declare item: ConnectionItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'connection'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'connection'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/item/culture-sheet.ts
+++ b/src/system/applications/item/culture-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class CultureItemSheet extends BaseItemSheet {
     declare item: CultureItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'culture'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'culture'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/item/dialogs/edit-event-rule.ts
+++ b/src/system/applications/item/dialogs/edit-event-rule.ts
@@ -24,25 +24,22 @@ export class ItemEditEventRuleDialog extends ComponentHandlebarsApplicationMixin
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                title: 'DIALOG.EditEventRule.Title',
-                minimizable: false,
-                resizable: false,
-                positioned: true,
-            },
-            classes: ['dialog', 'edit-event-rule'],
-            tag: 'dialog',
-            position: {
-                width: 500,
-            },
-            actions: {
-                update: this.onUpdateRule,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            title: 'DIALOG.EditEventRule.Title',
+            minimizable: false,
+            resizable: false,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'edit-event-rule'],
+        tag: 'dialog',
+        position: {
+            width: 500,
+        },
+        actions: {
+            update: this.onUpdateRule,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/item/dialogs/talent-tree/edit-node-prerequisite.ts
+++ b/src/system/applications/item/dialogs/talent-tree/edit-node-prerequisite.ts
@@ -17,25 +17,22 @@ export class EditNodePrerequisiteDialog extends ComponentHandlebarsApplicationMi
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                title: 'DIALOG.EditTalentPrerequisite.Title',
-                minimizable: false,
-                resizable: true,
-                positioned: true,
-            },
-            classes: ['dialog', 'edit-talent-prerequisite'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                update: this.onUpdatePrerequisite,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            title: 'DIALOG.EditTalentPrerequisite.Title',
+            minimizable: false,
+            resizable: true,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'edit-talent-prerequisite'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            update: this.onUpdatePrerequisite,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/item/dialogs/talent/edit-bonus-talents-rule.ts
+++ b/src/system/applications/item/dialogs/talent/edit-bonus-talents-rule.ts
@@ -14,25 +14,22 @@ export class EditBonusTalentsRuleDialog extends (HandlebarsApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            window: {
-                title: 'DIALOG.EditBonusTalentsRule.Title',
-                minimizable: false,
-                resizable: true,
-                positioned: true,
-            },
-            classes: ['dialog', 'edit-bonus-talents-rule'],
-            tag: 'dialog',
-            position: {
-                width: 350,
-            },
-            actions: {
-                update: this.onSubmit,
-            },
+    static DEFAULT_OPTIONS = {
+        window: {
+            title: 'DIALOG.EditBonusTalentsRule.Title',
+            minimizable: false,
+            resizable: true,
+            positioned: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        classes: ['dialog', 'edit-bonus-talents-rule'],
+        tag: 'dialog',
+        position: {
+            width: 350,
+        },
+        actions: {
+            update: this.onSubmit,
+        },
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),

--- a/src/system/applications/item/embeds/talent-tree-embed.ts
+++ b/src/system/applications/item/embeds/talent-tree-embed.ts
@@ -42,21 +42,18 @@ export class TalentTreeEmbed extends ComponentHandlebarsApplicationMixin(
 ) {
     declare readonly id: string; //TEMP: Workaround
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'embed', 'talent-tree'],
-            position: {
-                width: 600,
-                top: 0,
-                left: 0,
-            },
-            window: {
-                frame: false,
-            },
-            tag: 'div',
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'embed', 'talent-tree'],
+        position: {
+            width: 600,
+            top: 0,
+            left: 0,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            frame: false,
+        },
+        tag: 'div',
+    };
 
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),
@@ -80,7 +77,7 @@ export class TalentTreeEmbed extends ComponentHandlebarsApplicationMixin(
 
         // Get configured width
         const width = (options.position?.width ??
-            TalentTreeEmbed.DEFAULT_OPTIONS.position!.width!) as number;
+            TalentTreeEmbed.DEFAULT_OPTIONS.position.width) as number;
 
         // Calculate height based on aspect ratio
         const height = width / aspectRatio;

--- a/src/system/applications/item/equipment-sheet.ts
+++ b/src/system/applications/item/equipment-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class EquipmentItemSheet extends BaseItemSheet {
     declare item: EquipmentItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'equipment'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'equipment'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/goal-sheet.ts
+++ b/src/system/applications/item/goal-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class GoalItemSheet extends BaseItemSheet {
     declare item: GoalItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'armor'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'armor'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/injury-sheet.ts
+++ b/src/system/applications/item/injury-sheet.ts
@@ -10,19 +10,16 @@ import { BaseItemSheet } from './base';
 export class InjuryItemSheet extends BaseItemSheet {
     declare item: InjuryItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'injury'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'injury'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/loot-sheet.ts
+++ b/src/system/applications/item/loot-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class LootItemSheet extends BaseItemSheet {
     declare item: LootItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'loot'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'loot'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/path-sheet.ts
+++ b/src/system/applications/item/path-sheet.ts
@@ -15,19 +15,16 @@ import { TEMPLATES } from '@src/system/utils/templates';
 export class PathItemSheet extends TalentsTabMixin(BaseItemSheet) {
     declare item: PathItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'path'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'path'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/power-sheet.ts
+++ b/src/system/applications/item/power-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class PowerItemSheet extends BaseItemSheet {
     declare item: PowerItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'armor'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'armor'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/talent-sheet.ts
+++ b/src/system/applications/item/talent-sheet.ts
@@ -15,22 +15,19 @@ export class TalentItemSheet extends BaseItemSheet {
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'talent'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
-            form: {
-                handler: this.onFormEvent,
-            } as unknown,
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'talent'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+        form: {
+            handler: this.onFormEvent,
+        },
+    };
     /* eslint-enable @typescript-eslint/unbound-method */
 
     static TABS = foundry.utils.mergeObject(

--- a/src/system/applications/item/talent-tree-sheet.ts
+++ b/src/system/applications/item/talent-tree-sheet.ts
@@ -33,23 +33,20 @@ export class TalentTreeItemSheet extends EditModeApplicationMixin(
      * within ApplicationV2
      */
     /* eslint-disable @typescript-eslint/unbound-method */
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'talent-tree'],
-            window: {
-                positioned: true,
-                resizable: true,
-            },
-            actions: {
-                // configure: this.onConfigure,
-            },
-            form: {
-                handler: this.onFormEvent,
-                submitOnChange: true,
-            } as unknown,
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'talent-tree'],
+        window: {
+            positioned: true,
+            resizable: true,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        actions: {
+            // configure: this.onConfigure,
+        },
+        form: {
+            handler: this.onFormEvent,
+            submitOnChange: true,
+        },
+    };
     /* eslint-enable @typescript-eslint/unbound-method */
 
     static PARTS = foundry.utils.mergeObject(

--- a/src/system/applications/item/trait-sheet.ts
+++ b/src/system/applications/item/trait-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class TraitItemSheet extends BaseItemSheet {
     declare item: TraitItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'trait'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'trait'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),

--- a/src/system/applications/item/weapon-sheet.ts
+++ b/src/system/applications/item/weapon-sheet.ts
@@ -9,19 +9,16 @@ import { BaseItemSheet } from './base';
 export class WeaponItemSheet extends BaseItemSheet {
     declare item: WeaponItem;
 
-    static DEFAULT_OPTIONS = foundry.utils.mergeObject(
-        foundry.utils.deepClone(super.DEFAULT_OPTIONS),
-        {
-            classes: [SYSTEM_ID, 'sheet', 'item', 'weapon'],
-            position: {
-                width: 550,
-            },
-            window: {
-                resizable: false,
-                positioned: true,
-            },
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'weapon'],
+        position: {
+            width: 550,
         },
-    ) as foundry.applications.api.ApplicationV2.DefaultOptions;
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
 
     static TABS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.TABS),


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the duplicate header controls appearing on sheets. This issue was caused because we manually merged the DEFAULT_OPTIONS. On the backend Foundry walks the inheritance chain of the sheet class and merges the DEFAULT_OPTIONS itself, so they were getting merged twice. This wasn't an issue before because the merge logic happened to merge the arrays correctly. Something was changed about how the default options get merged in V13, causing it to break.

**Related Issue**  
Closes #585 

**How Has This Been Tested?**  
1. Open character sheet
2. Click the "Toggle Controls" button
3. Verify only the expected options appear
4. Open adversary sheet
5. Click the "Toggle Controls" button
6. Verify only the expected options appear

Because this PR also corrects the way the DEFAULT_OPTIONS are set for every AppV2 in the system, I've also clicked through a fair number of dialogs to verify they're configured right (correct size/position, etc.)

**Screenshots (if applicable)**  
<img width="1305" height="295" alt="image" src="https://github.com/user-attachments/assets/cb2e2324-3bf7-442c-8ba0-226931361293" />

**Checklist:**  
- ~~[ ] I have commented on my code, particularly in hard-to-understand areas.~~ N/A
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.350