### PR TITLE
Item rolls not respecting selected roll mode

### DIFF
--- a/src/system/applications/dialogs/attack-configuration.ts
+++ b/src/system/applications/dialogs/attack-configuration.ts
@@ -291,7 +291,7 @@ export class AttackConfigurationDialog extends ComponentHandlebarsApplicationMix
             attribute: getNullableFromFormInput<Attribute>(
                 form.attribute.value,
             ),
-            rollMode: (form.rollMode?.value as RollMode) ?? 'roll',
+            rollMode: (form.rollMode?.value as RollMode) ?? 'publicroll',
             temporaryModifiers: form.temporaryMod.value,
             plotDie: form.raiseStakes.checked,
             advantageMode:

--- a/src/system/applications/dialogs/roll-configuration.ts
+++ b/src/system/applications/dialogs/roll-configuration.ts
@@ -218,7 +218,7 @@ export class RollConfigurationDialog extends ComponentHandlebarsApplicationMixin
             attribute: getNullableFromFormInput<Attribute>(
                 form.attribute.value,
             ),
-            rollMode: (form.rollMode?.value as RollMode) ?? 'roll',
+            rollMode: (form.rollMode?.value as RollMode) ?? 'publicroll',
             temporaryModifiers: form.temporaryMod.value,
             plotDie: form.raiseStakes.checked,
             advantageMode:

--- a/src/system/dice/d20-roll.ts
+++ b/src/system/dice/d20-roll.ts
@@ -293,7 +293,6 @@ export class D20Roll extends foundry.dice.Roll<D20RollData> {
     ): Promise<Roll.ToMessageReturn<Create>> {
         options ??= {};
         options.rollMode ??= this.options.rollMode;
-        if (options.rollMode === 'roll') options.rollMode = undefined;
         options.rollMode ??= game.settings.get('core', 'rollMode');
 
         return super.toMessage(messageData, options);

--- a/src/system/dice/types.ts
+++ b/src/system/dice/types.ts
@@ -1,1 +1,1 @@
-export type RollMode = keyof CONFIG.Dice.RollModes | 'roll';
+export type RollMode = keyof CONFIG.Dice.RollModes;

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -665,6 +665,7 @@ export class CosmereItem<
                 ? actor.system.skills[damageSkillId].attribute
                 : null);
 
+        options.rollMode ??= game.settings.get('core', 'rollMode');
         options.skillTest ??= {};
         options.skillTest.parts ??= this.system.activation.modifierFormula
             ? [this.system.activation.modifierFormula]
@@ -832,12 +833,17 @@ export class CosmereItem<
                 .replace('[item]', this.name);
 
             // Create chat message
-            const message = (await ChatMessage.create({
-                author: game.user.id,
-                speaker,
-                content: `<p>${flavor}</p>`,
-                rolls: [skillRoll, ...damageRolls],
-            })) as ChatMessage;
+            const message = (await ChatMessage.create(
+                {
+                    author: game.user.id,
+                    speaker,
+                    content: `<p>${flavor}</p>`,
+                    rolls: [skillRoll, ...damageRolls],
+                },
+                {
+                    rollMode: options.rollMode,
+                },
+            )) as ChatMessage;
         }
 
         // Return the rolls
@@ -871,6 +877,8 @@ export class CosmereItem<
             );
             return null;
         }
+
+        options.rollMode ??= game.settings.get('core', 'rollMode');
 
         const { fastForward, advantageMode, plotDie } =
             determineConfigurationMode(options);
@@ -1121,7 +1129,9 @@ export class CosmereItem<
             messageConfig.rolls = rolls;
 
             // Create chat message
-            await ChatMessage.create(messageConfig);
+            await ChatMessage.create(messageConfig, {
+                rollMode: options.rollMode,
+            });
 
             // Perform post roll actions
             postRoll.forEach((action) => action());
@@ -1136,10 +1146,9 @@ export class CosmereItem<
             const flavor = this.system.activation.flavor || undefined;
 
             // Create chat message
-            const message = (await ChatMessage.create(
-                messageConfig,
-            )) as ChatMessage;
-            message.applyRollMode('roll');
+            const message = (await ChatMessage.create(messageConfig, {
+                rollMode: options.rollMode,
+            })) as ChatMessage;
 
             // Perform post roll actions
             postRoll.forEach((action) => action());


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue of Item usage not respected the selected roll mode. It seems V12 was defaulting the roll mode to whatever the user has selected, and this is no longer the case in V13.

**Related Issue**  
Closes #589 

**How Has This Been Tested?**  
1. Create or open actor with an attack
2. Set roll mode to `Private GM Roll`
3. Use the attack from the actor sheet
4. Connect with a player account -> message contents should not be visible

**Screenshots (if applicable)**  
<img width="408" height="262" alt="image" src="https://github.com/user-attachments/assets/b0fe5041-89cc-409d-b825-f0bea75d6f3f" />

**Checklist:**  
- ~~[ ] I have commented on my code, particularly in hard-to-understand areas.~~ N/A
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.350