### PR TITLE
fix(event system): fix issue causing handler data validation to always fail

### DIFF
--- a/src/system/data/fields/collection.ts
+++ b/src/system/data/fields/collection.ts
@@ -3,7 +3,7 @@ import {
     InferInitializedType,
     InferPersistedType,
 } from '../types';
-import { AnyObject } from '@system/types/utils';
+import { AnyObject, AnyMutableObject } from '@system/types/utils';
 
 export interface CollectionFieldOptions<T = AnyObject>
     extends foundry.data.fields.DataField.Options<AnyObject> {
@@ -376,6 +376,35 @@ export class CollectionField<
         ) as TAssignment;
 
         return result;
+    }
+
+    public override _addTypes(
+        source?: Record<string, AnyObject>,
+        changes?: Record<string, AnyMutableObject>,
+    ) {
+        if (!source || !changes) return super._addTypes(source, changes);
+
+        Object.entries(changes).forEach(([k, v]) => {
+            // @ts-expect-error foundry-vtt-types seem to be wrong here, _addTypes aren't used in a protected way within Foundry itself
+            this.model._addTypes(source[k], v);
+        });
+    }
+
+    public _updateDiff(
+        source: AnyMutableObject,
+        key: string,
+        value: Record<string, AnyMutableObject>,
+        difference: AnyMutableObject,
+        options?: foundry.abstract.DataModel.UpdateOptions,
+    ) {
+        const current = source[key] as Record<string, AnyMutableObject>;
+        if (!current)
+            return super._updateDiff(source, key, value, difference, options);
+
+        const schemaDiff = (difference[key] = {});
+        Object.entries(value).forEach(([k, v]) =>
+            this.model._updateDiff(current, k, v, schemaDiff, options),
+        );
     }
 
     public override getInitialValue() {


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue introduced in v13 which causes the handler validation to always fail. 

**Related Issue**  
Closes #581 

**Related Bugs Channel Post**
https://discord.com/channels/1299110557689053264/1432503348854259884

**How Has This Been Tested?**  
1. Create Item
2. Add new event
3. Change handler type to `Modify Attribute`
4. Change amount to `2`

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.350