### PR TITLE
fix(actor sheet): resolve issue causing black box to appear around portait

### DIFF
--- a/src/style/sheets/actor/module.scss
+++ b/src/style/sheets/actor/module.scss
@@ -401,6 +401,7 @@
             align-items: center;
 
             .portrait {
+                position: relative;
                 width: 100%;
                 aspect-ratio: 1 / 1;
                 overflow: hidden;


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue of a black box appearing around the actor portrait. The black box was the inset portrait shadow breaking its bounds due to a missing position relative on the portrait element. 

**Related Issue**  
Closes #592 

**Related Bugs Post**
https://discord.com/channels/1299110557689053264/1435066598145785967

**How Has This Been Tested?**  
1. Open character sheet
2. Ensure black box doesn't appear
3. Open adversary sheet
4. Ensure black box doesn't appear

**Screenshots (if applicable)**  
<img width="321" height="360" alt="image" src="https://github.com/user-attachments/assets/bc650ff1-11a2-4f6c-8dd1-f30de19bc9d5" />

**Checklist:**  
- [ ] ~~I have commented on my code, particularly in hard-to-understand areas.~~ N/A
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.350
