### PR TITLE
fix(event system): update update-item handler to no longer require an item to be configured if target is equipped weapon or armour

### DIFF
--- a/src/templates/item/event-system/handlers/update-item.hbs
+++ b/src/templates/item/event-system/handlers/update-item.hbs
@@ -13,7 +13,7 @@
 </div>
 
 {{!-- UUID --}}
-{{#if (not (eq handler.target "self"))}}
+{{#if (or (eq handler.target "sibling") (eq handler.target "global"))}}
     <div class="form-group">
         <label>
             {{localize handler.schema.fields.uuid.label}}


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR fixes an issue with the update-item handler which caused it to require some item to be configured to use the "Equipped Weapon" and "Equipped Armor" options, even though this setting has no impact on handler execution.

**Related Issue**  
Closes #572 

**How Has This Been Tested?**  
1. Create actor
2. Add weapon & equip
3. Add action
4. Add event to action
5. Set trigger to "Used"
6. Set handler type to "Update Item"
7. Set handler target to "Equipped Weapon"
8. Add change (+)
9. Set change attribute key to `system.equipped`
10. Set change value to `false`
11. Click update
12. Use the item from the actor sheet
13. Ensure weapon is unequipped

**Screenshots (if applicable)**  
<img width="758" height="633" alt="image" src="https://github.com/user-attachments/assets/e0103dea-5bbf-4f5d-aa9a-0a518a1b8533" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.350