### PR TITLE
Fix: Made Journal Entry Headers Editable

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1490,6 +1490,11 @@
         },
         "EditEventRule": {
             "Title": "Edit Event Rule"
+        },
+        "RenameDirectoryEntry": {
+            "Title": "Rename {type}",
+            "Label": "New Name",
+            "Hint": "Enter a new name for this {type}."
         }
     },
     "COMPONENT": {
@@ -1558,6 +1563,7 @@
         "Description": "Description",
         "Talent": "Talent",
         "Goal": "Goal",
+        "Rename": "Rename",
         "Button": {
             "Roll": "Roll",
             "Continue": "Continue",

--- a/src/style/starter-rules/journal-common.scss
+++ b/src/style/starter-rules/journal-common.scss
@@ -75,7 +75,7 @@
             padding-left: 0;
             padding-right: 0;
 
-            p, input {
+            p {
                 //Chapter name text
                 text-wrap: nowrap;
                 border-bottom-width: 3px;
@@ -86,14 +86,6 @@
                 font-weight: normal;
                 font-family: var(--cosmere-font-header-sc);
                 text-transform: uppercase;
-            }
-            input {
-                background: transparent;
-                border: none;
-                outline: none;
-                text-align: center;
-                width: auto;
-                height: 1rem;
             }
 
             &::before {

--- a/src/style/starter-rules/journal-common.scss
+++ b/src/style/starter-rules/journal-common.scss
@@ -75,22 +75,28 @@
             padding-left: 0;
             padding-right: 0;
 
-            p:nth-child(2) {
+            p, input {
                 //Chapter name text
                 text-wrap: nowrap;
-                //vertical-align: middle;
-                color: var(--cosmere-color-opportunity);
-                border-bottom-color: var(--stormlight-journal-yellow-1);
                 border-bottom-width: 3px;
                 margin-bottom: 12px;
                 margin-top: 0px;
-                padding: 0.5rem 0.5rem 0 0.5rem;
+                padding: 0.5rem 0.5rem 0;
                 font-size: 2rem;
                 font-weight: normal;
                 font-family: var(--cosmere-font-header-sc);
+                text-transform: uppercase;
+            }
+            input {
+                background: transparent;
+                border: none;
+                outline: none;
+                text-align: center;
+                width: auto;
+                height: 1rem;
             }
 
-            p:first-child {
+            &::before {
                 //Left side squiggle
                 flex: 1;
                 content: "";
@@ -101,7 +107,7 @@
                 margin: 0;
             }
 
-            p:last-child {
+            &::after {
                 //Right side squiggle
                 flex: 1;
                 content: "";
@@ -116,6 +122,7 @@
         div:nth-child(2) {
             //This is the underline beneath the text
             width: 100%;
+            height: 13px;
             background-image: url("assets/journal/header-line.webp");
             background-size: 90% auto;
             background-repeat: no-repeat;

--- a/src/system/applications/dialogs/rename-directory-entry.ts
+++ b/src/system/applications/dialogs/rename-directory-entry.ts
@@ -1,0 +1,126 @@
+import { AnyObject } from '@system/types/utils';
+import { SYSTEM_ID } from '@system/constants';
+import { TEMPLATES } from '@system/utils/templates';
+
+import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
+
+interface RenameDirectoryEntryDialogData {
+    /**
+     * The type of Document in the Directory.
+     */
+    documentType: string;
+
+    /**
+     * The original name of the entry
+     */
+    originalName: string;
+}
+
+const NOT_FOUND_NAME = 'Current Name Not Passed';
+const DEFAULT_DOCUMENT_TYPE = 'Entry';
+
+export class RenameDirectoryEntryDialog extends ComponentHandlebarsApplicationMixin(
+    foundry.applications.api.ApplicationV2<AnyObject>,
+) {
+    /**
+     * NOTE: Unbound methods is the standard for defining actions and forms
+     * within ApplicationV2
+     */
+    /* eslint-disable @typescript-eslint/unbound-method */
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            resizable: true,
+        },
+        position: {
+            width: 300,
+        },
+        tag: 'dialog',
+        classes: ['cosmere', 'dialog', 'rename-directory-entry'],
+    };
+
+    static PARTS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.PARTS),
+        {
+            form: {
+                template: `systems/${SYSTEM_ID}/templates/${TEMPLATES.DIALOG_DIRECTORY_ENTRY_RENAME}`,
+                forms: {
+                    form: {
+                        handler: this.onFormEvent,
+                    },
+                },
+            },
+        },
+    );
+    /* eslint-enable @typescript-eslint/unbound-method */
+
+    private submitted = false;
+
+    private constructor(
+        private data: RenameDirectoryEntryDialogData = {
+            documentType: DEFAULT_DOCUMENT_TYPE,
+            originalName: NOT_FOUND_NAME,
+        },
+        private resolve: (value: string | null) => void,
+    ) {
+        super({
+            window: {
+                title: game.i18n.format('DIALOG.RenameDirectoryEntry.Title', {
+                    type: data.documentType,
+                }),
+            },
+        });
+    }
+
+    /* --- Statics --- */
+
+    static async show(
+        data: RenameDirectoryEntryDialogData = {
+            documentType: DEFAULT_DOCUMENT_TYPE,
+            originalName: NOT_FOUND_NAME,
+        },
+    ): Promise<string | null> {
+        return new Promise((resolve) => {
+            const dialog = new this(data, resolve);
+            void dialog.render(true);
+        });
+    }
+
+    /* --- Actions --- */
+
+    private static onFormEvent(
+        this: RenameDirectoryEntryDialog,
+        event: Event,
+        form: HTMLFormElement,
+        formData: FormDataExtended,
+    ) {
+        if (!(event instanceof SubmitEvent)) return;
+        const newName = formData.get('name')?.toString().trim() ?? null;
+
+        this.resolve(newName);
+
+        this.submitted = true;
+
+        void this.close();
+    }
+
+    /* --- Lifecycle --- */
+
+    protected async _onRender(context: AnyObject, options: AnyObject) {
+        await super._onRender(context, options);
+
+        $(this.element).prop('open', true);
+    }
+
+    protected _onClose() {
+        if (!this.submitted) this.resolve(null);
+    }
+
+    /* --- Context --- */
+
+    public _prepareContext() {
+        return Promise.resolve({
+            ...this.data,
+        });
+    }
+}

--- a/src/system/hooks/context-menus/index.ts
+++ b/src/system/hooks/context-menus/index.ts
@@ -1,0 +1,5 @@
+import { registerHooks as registerJournalDirectoryContextMenuHooks } from './journal-directory';
+
+export function registerContextMenus() {
+    registerJournalDirectoryContextMenuHooks();
+}

--- a/src/system/hooks/context-menus/journal-directory.ts
+++ b/src/system/hooks/context-menus/journal-directory.ts
@@ -1,0 +1,74 @@
+import { NodePrerequisiteTalentListComponent } from '@src/system/applications/item/components/talent-tree/node-prerequisite-talent-list';
+import { RenameDirectoryEntryDialog } from '@system/applications/dialogs/rename-directory-entry';
+
+interface MenuEntry {
+    name: string;
+    icon: string;
+    condition: (li: HTMLElement) => boolean;
+    callback: (li: HTMLElement) => void;
+}
+
+type DocumentDirectory = foundry.applications.sidebar.DocumentDirectory;
+type EventArgs = DocumentDirectory | MenuEntry[];
+
+export function registerHooks() {
+    const sidebarContextMenuEvent = {
+        object: 'foundry.applications.sidebar.DocumentDirectory.prototype',
+        property: '_getEntryContextOptions',
+    };
+    const descriptor = Object.getOwnPropertyDescriptor(
+        sidebarContextMenuEvent.object,
+        sidebarContextMenuEvent.property,
+    );
+    if (descriptor) {
+        const original = descriptor.value as (...args: unknown[]) => unknown;
+        descriptor.value = function (...args: unknown[]) {
+            return function (...args: unknown[]) {
+                if (
+                    args[0] instanceof
+                    foundry.applications.sidebar.tabs.JournalDirectory
+                ) {
+                    insertRenameOption(args[1] as MenuEntry[]);
+                }
+                return original(...args);
+            }.call(this, original.bind(this), [], ...args);
+        };
+        Object.defineProperty(
+            sidebarContextMenuEvent.object,
+            sidebarContextMenuEvent.property,
+            descriptor,
+        );
+    }
+
+    // This definitely seems like the new Hook name for it, and would be much more comfortable using this,
+    // but fvtt types doesn't recognise this as a valid hook string literal...
+    // Hooks.on('getJournalEntrySheetContext', insertRenameOption);
+}
+
+// TODO: this could well be pulled out into a generic'ed utility for other document types
+function insertRenameOption(menuItems: MenuEntry[]): void {
+    menuItems.push({
+        name: 'GENERIC.Rename',
+        icon: '<i class="fas fa-pen-field fa-fw"></i>',
+        condition: (li) => {
+            const entry = game.journal.get(li.dataset.documentId ?? '');
+            return entry?.canUserModify(game.user, 'update') ?? false;
+        },
+        callback: async (li) => {
+            const journalEntry = game.journal.get(li.dataset.documentId ?? '');
+            if (!journalEntry) {
+                ui.notifications?.error(
+                    'Could not find the journal entry to rename.',
+                );
+                return;
+            }
+            const newName = await RenameDirectoryEntryDialog.show({
+                documentType: 'Journal Entry',
+                originalName: journalEntry.name,
+            });
+            if (newName) {
+                journalEntry.name = newName;
+            }
+        },
+    });
+}

--- a/src/system/hooks/index.ts
+++ b/src/system/hooks/index.ts
@@ -9,3 +9,4 @@ import './hotbar';
 
 export { register as registerItemEventSystem } from './item-event-system';
 export { register as registerStarterRulesConfig } from './starter-rules';
+export { registerContextMenus } from './context-menus';

--- a/src/system/hooks/journal.ts
+++ b/src/system/hooks/journal.ts
@@ -22,11 +22,7 @@ Hooks.on('renderJournalEntrySheet', (app, html) => {
             'beforeend',
             `<div class="sl-chapter-header">
                 <div>
-                    ${
-                        app.isEditable
-                            ? `<input type="text" name="name" value="${entry.name}" />`
-                            : `<p>${entry.name}</p>`
-                    }
+                    <p>${entry.name}</p>
                 </div>
                 <div>
                     <p></p>

--- a/src/system/hooks/journal.ts
+++ b/src/system/hooks/journal.ts
@@ -17,11 +17,21 @@ Hooks.on('renderJournalEntrySheet', (app, html) => {
         const header_node = html.getElementsByClassName('journal-header')[0];
 
         header_node.removeChild(header_node.children[0]);
+
         header_node.insertAdjacentHTML(
             'beforeend',
-            '<div class="sl-chapter-header"><div><p></p><p>' +
-                entry.name.toUpperCase() +
-                '</p><p></p></div><div><p></p></div></div>',
+            `<div class="sl-chapter-header">
+                <div>
+                    ${
+                        app.isEditable
+                            ? `<input type="text" name="name" value="${entry.name}" />`
+                            : `<p>${entry.name}</p>`
+                    }
+                </div>
+                <div>
+                    <p></p>
+                </div>
+            </div>`,
         );
     }
 });

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -160,6 +160,8 @@ export const TEMPLATES = {
     CHAT_OVERLAY_CRIT: 'chat/overlay-crit.hbs',
 
     //DIALOGS
+    DIALOG_DIRECTORY_ENTRY_RENAME: 'general/dialogs/rename-directory-entry.hbs',
+
     DIALOG_ACTOR_EDIT_EXPERTISES: 'actors/dialogs/edit-expertises.hbs',
     DIALOG_ACTOR_EDIT_IMMUNITIES: 'actors/dialogs/edit-immunities.hbs',
     DIALOG_ACTOR_CONFIGURE_RESOURCE: 'actors/dialogs/configure-resource.hbs',
@@ -218,7 +220,10 @@ export function renderSystemTemplate(
     template: string,
     data: AnyObject,
 ): Promise<string> {
-    return foundry.applications.handlebars.renderTemplate(`systems/${SYSTEM_ID}/templates/${template}`, data);
+    return foundry.applications.handlebars.renderTemplate(
+        `systems/${SYSTEM_ID}/templates/${template}`,
+        data,
+    );
 }
 
 export const THEME_TAG = 'cosmere-theme';

--- a/src/templates/general/dialogs/rename-directory-entry.hbs
+++ b/src/templates/general/dialogs/rename-directory-entry.hbs
@@ -1,0 +1,19 @@
+<form>
+    <div class="form-group-stacked"></div>
+        <div class="form-field">
+            <input type="text" name="name" value="{{originalName}}" id="name">
+            <label for="name">
+                {{localize "DIALOG.RenameDirectoryEntry.Label" type=documentType}}
+            </label>
+            <span class="hint">
+                {{localize "DIALOG.RenameDirectoryEntry.Hint" type=documentType}}
+            </span>
+        </div>
+    </div>
+
+    <div class="form-group submit">
+        <button type="submit" data-action="submit">
+            {{localize "GENERIC.Button.Save"}}
+        </button>
+    </div>
+</form>


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
The header section of any journal entry you are looking at that is editable will now allow re-naming inline.
I've spent a fair while trying a few things and I think this is about as good as we can get for an inline option seeing as HTML <input> doesn't really do resizing and so easy options here are going to be limited.
Other benefits though are that the structure of those headers is considerably more streamlined (and I think it could be pushed further to handle the divider)

**Related Issue**  
Partially Closes #565 
(will need to repeat this on the premium module repos if we go this way)

**How Has This Been Tested?**  
* Open the Starter Pack compendium and open one of the journals from there
* Confirm that the display hasn't broken and is as expected
* Import the journal into your world
* open the imported version
* see that the title is now interactable
* edit the title
* move focus out of the journal header
* observe that the title of the journal in your side-panel has updated

**Screenshots (if applicable)**  
... To Come ...

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.356.

**Additional context**  
Potentially we might need to look at the option to add a rename button to the side-panel as in the issue, because currently there is no easy way to resize an input control, therefore anything with a particularly long title will get cut off and short ones will leave whitespace between the text and the artwork (which will differ from the non-edit version)
