### PR TITLE
fix(style): fix issue causing character sheet scrolling to be blocked in perf mode low

### DIFF
--- a/src/style/sheets/actor/module.scss
+++ b/src/style/sheets/actor/module.scss
@@ -38,6 +38,7 @@
     }
 
     > .window-content {
+        z-index: 0; // Ensures stacking context is created even when performance mode is set to low (which removes backdrop-filter)
         padding: 0 1.875rem;
     }
 


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue of the character sheet scrolling becoming blocked when performance mode is set to low.
Caused by foundry no longer applying a `backdrop-filter` to the `.window-content` of the actor sheet, which meant it wasn't creating a stacking context anymore.
Fixed by applying `z-index: 0` to the `.window-content`, which doesn't affect styling, but causes a stacking context to be created, so it behaves the same.

**Related Issue**  
Closes #614 

**How Has This Been Tested?**  
1. Create actor
2. Add large number of actions
3. Set performance mode to low
4. Scroll on actor sheet

**Checklist:**  
- [ ] ~~I have commented on my code, particularly in hard-to-understand areas.~~ N/A
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351