### PR TITLE
Fix: Error Rendering Item With Recharge Set to None 633

### DIFF
--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -397,7 +397,7 @@ Handlebars.registerHelper(
                     const max = item.system.activation.uses.max;
                     const recharge = item.system.activation.uses.recharge;
 
-                    const hasRecharge = recharge != null;
+                    const hasRecharge = recharge != null && recharge !== 'none';
 
                     // Get config
                     const config =


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds 'none' to the `hasRecharge` check so that it is considered false.

**Related Issue**  
fixes #633 

**How Has This Been Tested?**  
- Open an actor
- Add an item/edit an item
- Set up usage so that 'limited uses' is equal to 'charge'
- Swap 'recharge' from null to 'none'
- Close the item and actor
- Reopen actor
- Notice it works fine

**Screenshots (if applicable)**  
N/A

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
N/A
