### PR TITLE
Fix: Remove Null Attribute Value on Activation Fields for Talents with Skill Tests 603

### DIFF
--- a/src/packs/actions/basic/grapple.json
+++ b/src/packs/actions/basic/grapple.json
@@ -23,7 +23,6 @@
             "plotDie": false,
             "uses": null,
             "skill": "ath",
-            "attribute": null,
             "modifierFormula": ""
         },
         "damage": {

--- a/src/packs/heroic-paths/agent/thief/talents/cheap-shot.json
+++ b/src/packs/heroic-paths/agent/thief/talents/cheap-shot.json
@@ -32,7 +32,6 @@
             "flavor": "",
             "uses": null,
             "skill": "thv",
-            "attribute": null,
             "plotDie": true,
             "opportunity": null,
             "complication": null,

--- a/src/packs/heroic-paths/agent/thief/talents/shadow-step.json
+++ b/src/packs/heroic-paths/agent/thief/talents/shadow-step.json
@@ -33,7 +33,6 @@
             "plotDie": false,
             "uses": null,
             "skill": "thv",
-            "attribute": null,
             "opportunity": null,
             "complication": null,
             "modifierFormula": ""

--- a/src/packs/heroic-paths/envoy/diplomat/talents/steadfast-challenge.json
+++ b/src/packs/heroic-paths/envoy/diplomat/talents/steadfast-challenge.json
@@ -33,7 +33,6 @@
             "plotDie": false,
             "uses": null,
             "skill": "dis",
-            "attribute": null,
             "opportunity": null,
             "complication": null,
             "modifierFormula": ""

--- a/src/packs/heroic-paths/leader/champion/talents/valiant-intervention.json
+++ b/src/packs/heroic-paths/leader/champion/talents/valiant-intervention.json
@@ -33,7 +33,6 @@
             "plotDie": false,
             "uses": null,
             "skill": "ath",
-            "attribute": null,
             "opportunity": null,
             "complication": null,
             "modifierFormula": ""

--- a/src/packs/heroic-paths/leader/officer/talents/synchronized-assault.json
+++ b/src/packs/heroic-paths/leader/officer/talents/synchronized-assault.json
@@ -33,7 +33,6 @@
             "plotDie": false,
             "uses": null,
             "skill": "lea",
-            "attribute": null,
             "opportunity": null,
             "complication": null,
             "modifierFormula": ""

--- a/src/packs/heroic-paths/scholar/strategist/talents/strategize.json
+++ b/src/packs/heroic-paths/scholar/strategist/talents/strategize.json
@@ -33,7 +33,6 @@
             "plotDie": false,
             "uses": null,
             "skill": "ded",
-            "attribute": null,
             "opportunity": null,
             "complication": null,
             "modifierFormula": ""

--- a/src/packs/heroic-paths/scholar/strategist/talents/turning-point.json
+++ b/src/packs/heroic-paths/scholar/strategist/talents/turning-point.json
@@ -36,7 +36,6 @@
                 "recharge": "per_scene"
             },
             "skill": "ded",
-            "attribute": null,
             "opportunity": null,
             "complication": null,
             "modifierFormula": ""

--- a/src/packs/heroic-paths/scholar/surgeon/talents/field-medicine.json
+++ b/src/packs/heroic-paths/scholar/surgeon/talents/field-medicine.json
@@ -33,7 +33,6 @@
             "plotDie": false,
             "uses": null,
             "skill": "med",
-            "attribute": null,
             "opportunity": null,
             "complication": null,
             "modifierFormula": ""

--- a/src/packs/heroic-paths/scholar/surgeon/talents/ongoing-care.json
+++ b/src/packs/heroic-paths/scholar/surgeon/talents/ongoing-care.json
@@ -23,7 +23,6 @@
             "plotDie": false,
             "uses": null,
             "skill": "med",
-            "attribute": null,
             "opportunity": null,
             "complication": null,
             "modifierFormula": ""


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This removes the attribute value of talents which have a skill test where that attribute was set to null, allowing it to default to the attribute of the skill.

**Related Issue**  
#603 

**How Has This Been Tested?**  
Add affects talents to a sheet and roll them.

**Screenshots (if applicable)**  
N/A

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
N/A