### PR TITLE
Fix: Turn Speed Styling for Combat Tracker No Longer Inherits From Global Class of Same Name

### DIFF
--- a/src/style/sidebar/combat.scss
+++ b/src/style/sidebar/combat.scss
@@ -12,7 +12,7 @@
     --combat-turn-done-svg: url('assets/icons/svg/combat/icon_combat_turn_done.svg');
 
     overflow-x: hidden;
-    
+
     .combat-phase {
         padding: 0.5rem 0px;
         display: flex;
@@ -21,11 +21,11 @@
         border-top: 1px solid var(--color-border-dark-1);
         border-bottom: 1px solid var(--color-border-dark-1);
 
-        &.fast {
+        &.turn-fast {
             background-color: var(--cosmere-color-turn-fast);
         }
 
-        &.slow {
+        &.turn-slow {
             background-color: var(--cosmere-color-turn-slow);
         }
 
@@ -49,13 +49,13 @@
             }
         }
     }
-    
-    .combatant-name {        
+
+    .combatant-name {
         font-family: var(--cosmere-font-normal);
         font-size: var(--font-size-15);
         font-weight: 600;
     }
-    
+
     .combatant-turn-controls {
         display: flex;
         text-align: center;
@@ -63,7 +63,7 @@
         flex: 0;
         margin-right: 0.25rem;
     }
-    
+
     .combatant-turn-speed-control,
     .combatant-turn-finish-control {
         cursor: pointer;
@@ -79,9 +79,9 @@
             filter: var(--cosmere-shadow-svg);
         }
     }
-    
+
     .combatant-turn-speed-control {
-        &.fast {
+        &.turn-fast {
             background-image: var(--combat-fast-turn-svg);
 
             &:hover {
@@ -89,7 +89,7 @@
             }
         }
 
-        &.slow {
+        &.turn-slow {
             background-image: var(--combat-slow-turn-svg);
 
             &:hover {
@@ -97,9 +97,9 @@
             }
         }
     }
-    
+
     .combatant-turn-finish-control {
-        &:not(.done) {            
+        &:not(.done) {
             background-image: var(--combat-turn-pending-svg);
 
             &:hover {
@@ -108,7 +108,7 @@
             }
         }
 
-        &.done {            
+        &.done {
             background-image: var(--combat-turn-done-svg);
             opacity: 0.4;
         }

--- a/src/templates/combat/combat-tracker.hbs
+++ b/src/templates/combat/combat-tracker.hbs
@@ -1,24 +1,24 @@
 <ol class="combat-tracker">
     {{#if fastPlayers}}
-    <li class="combat-phase fast"><span class="title">{{localize 'COSMERE.Combat.FastPlayers'}}</span></li>
+    <li class="combat-phase turn-fast"><span class="title">{{localize 'COSMERE.Combat.FastPlayers'}}</span></li>
     {{#each fastPlayers}}
     {{> combatant this}}
     {{/each}}
     {{/if}}
     {{#if fastNPC}}
-    <li class="combat-phase fast"><span class="title">{{localize 'COSMERE.Combat.FastAdversaries'}}</span></li>
+    <li class="combat-phase turn-fast"><span class="title">{{localize 'COSMERE.Combat.FastAdversaries'}}</span></li>
     {{#each fastNPC}}
     {{> combatant}}
     {{/each}}
     {{/if}}
     {{#if slowPlayers}}
-    <li class="combat-phase slow"><span class="title">{{localize 'COSMERE.Combat.SlowPlayers'}}</span></li>
+    <li class="combat-phase turn-slow"><span class="title">{{localize 'COSMERE.Combat.SlowPlayers'}}</span></li>
     {{#each slowPlayers}}
     {{> combatant}}
     {{/each}}
     {{/if}}
     {{#if slowNPC}}
-    <li class="combat-phase slow"><span class="title">{{localize 'COSMERE.Combat.SlowAdversaries'}}</span></li>
+    <li class="combat-phase turn-slow"><span class="title">{{localize 'COSMERE.Combat.SlowAdversaries'}}</span></li>
     {{#each slowNPC}}
     {{> combatant}}
     {{/each}}

--- a/src/templates/combat/combatant.hbs
+++ b/src/templates/combat/combatant.hbs
@@ -1,4 +1,4 @@
-<li class="combatant flexrow {{css}} {{turnSpeed}} {{#if hidden}}hide{{/if}} {{#if isDefeated}}defeated{{/if}}" data-phase="{{turnSpeed}}" data-combatant-id="{{id}}">
+<li class="combatant flexrow {{css}} turn-{{turnSpeed}} {{#if hidden}}hide{{/if}} {{#if isDefeated}}defeated{{/if}}" data-phase="turn-{{turnSpeed}}" data-combatant-id="{{id}}">
     <img class="token-image" src="{{img}}" alt="{{name}}" />
     <div class="token-name flexcol">
         <h4 class="combatant-name">{{name}}</h4>
@@ -37,9 +37,9 @@
     <div class="combatant-turn-controls">
         {{#if isOwner}}
             {{#unless isBoss}}
-                <a class="combatant-turn-speed-control {{turnSpeed}}" role="button" data-tooltip="COSMERE.Combat.ToggleTurn" data-action="toggleSpeed"></a>
-            {{/unless}} 
+                <a class="combatant-turn-speed-control turn-{{turnSpeed}}" role="button" data-tooltip="COSMERE.Combat.ToggleTurn" data-action="toggleSpeed"></a>
+            {{/unless}}
         {{/if}}
-        <a class="combatant-turn-finish-control {{#if (getCombatActedState this)}}done{{/if}}" data-tooltip="COSMERE.Combat.Activate" {{#if isOwner}}data-action="activateCombatant"{{/if}}></a>    
+        <a class="combatant-turn-finish-control {{#if (getCombatActedState this)}}done{{/if}}" data-tooltip="COSMERE.Combat.Activate" {{#if isOwner}}data-action="activateCombatant"{{/if}}></a>
     </div>
 </li>


### PR DESCRIPTION
… to prevent overlap with other global classes

<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Basically all this does is append `turn-` in front of the turn speed classes used in the combat tracker. Specifically, the old `fast` class was inheriting styling from a global class somewhere either in foundry or one of its included libraries. This bypasses that problem and resolves the linked issue. Though it was only super noticeable with the resource styling, this was actually causing the entirety of the fast turn section to inherit a font-weight of 100.

**Related Issue**  
fixes #638 

**How Has This Been Tested?**  
- Create a combat with several tokens both player and adversary
- set at least one token to each category
- observe with eyes that they look the same now
- also check the style rules using console on the relevant elements

**Screenshots (if applicable)**  
<img width="363" height="782" alt="image" src="https://github.com/user-attachments/assets/aed056d3-44c1-48ad-8baa-718541c4aa34" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
N/A