### PR TITLE
Fixes bug by making the maximum index the last index

### DIFF
--- a/src/system/data/actor/character.ts
+++ b/src/system/data/actor/character.ts
@@ -125,6 +125,6 @@ export const RECOVERY_DICE = ['d4', 'd6', 'd8', 'd10', 'd12', 'd20'];
 function willpowerToRecoveryDie(attr: AttributeData) {
     const willpower = attr.value + attr.bonus;
     return RECOVERY_DICE[
-        Math.min(Math.ceil(willpower / 2), RECOVERY_DICE.length)
+        Math.min(Math.ceil(willpower / 2), RECOVERY_DICE.length - 1)
     ];
 }

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -748,7 +748,7 @@ const SENSES_RANGES = [5, 10, 20, 50, 100, Number.MAX_VALUE];
 function awarenessToSensesRange(attr: AttributeData) {
     const awareness = attr.value + attr.bonus;
     return SENSES_RANGES[
-        Math.min(Math.ceil(awareness / 2), SENSES_RANGES.length)
+        Math.min(Math.ceil(awareness / 2), SENSES_RANGES.length - 1)
     ];
 }
 
@@ -756,7 +756,7 @@ const MOVEMENT_RATES = [20, 25, 30, 40, 60, 80];
 function speedToMovementRate(attr: AttributeData) {
     const speed = attr.value + attr.bonus;
     return MOVEMENT_RATES[
-        Math.min(Math.ceil(speed / 2), MOVEMENT_RATES.length)
+        Math.min(Math.ceil(speed / 2), MOVEMENT_RATES.length - 1)
     ];
 }
 
@@ -764,7 +764,7 @@ const LIFTING_CAPACITIES = [100, 200, 500, 1000, 5000, 10000];
 function strengthToLiftingCapacity(attr: AttributeData) {
     const strength = attr.value + attr.bonus;
     return LIFTING_CAPACITIES[
-        Math.min(Math.ceil(strength / 2), LIFTING_CAPACITIES.length)
+        Math.min(Math.ceil(strength / 2), LIFTING_CAPACITIES.length - 1)
     ];
 }
 
@@ -772,6 +772,6 @@ const CARRYING_CAPACITIES = [50, 100, 250, 500, 2500, 5000];
 function strengthToCarryingCapacity(attr: AttributeData) {
     const strength = attr.value + attr.bonus;
     return CARRYING_CAPACITIES[
-        Math.min(Math.ceil(strength / 2), CARRYING_CAPACITIES.length)
+        Math.min(Math.ceil(strength / 2), CARRYING_CAPACITIES.length - 1)
     ];
 }


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes the issue of calculated values becoming NaN upon stat exceeding 10

**Related Issue**  
Closes #684 

**How Has This Been Tested?**  
Yes. I've tested the values to go beyond 10 and the calculated values remain at their maximum.

**Screenshots (if applicable)**  
Before fix:
<img width="779" height="432" alt="image" src="https://github.com/user-attachments/assets/3340104d-05c3-4a29-9bf3-8a1b5c7ed7f5" />

After fix:
<img width="781" height="427" alt="image" src="https://github.com/user-attachments/assets/4a63c0ab-6bbb-44c7-90d6-62db8fbb9847" />


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas. (Not needed)
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: 2.0.5.

**Additional context**  
Related to a review I got for my PR #649 
