### PR TITLE
Resizeable character sheet

### DIFF
--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -2,9 +2,6 @@
     --border-level-svg: url('assets/icons/svg/sheet/border_level.svg');
     --mask-level-svg: url('assets/icons/svg/sheet/mask_level.svg');
 
-    max-width: 800px;
-    max-height: 900px;
-
     .sheet-header {
         .title {
             padding-left: 1.25rem;

--- a/src/system/applications/actor/character-sheet.ts
+++ b/src/system/applications/actor/character-sheet.ts
@@ -119,7 +119,8 @@ export class CharacterSheet extends BaseActorSheet {
 
         if (width === clampedWidth && height === clampedHeight) return;
 
-        this.isApplyingPositionConstraint = true; // Since we are setting the position, this will set off the _onPosition event. We ensure this code wont loop forever.
+        // Since we are setting the position, this will set off the _onPosition event. We ensure this code wont loop forever.
+        this.isApplyingPositionConstraint = true;
         this.setPosition({
             width: clampedWidth,
             height: clampedHeight,

--- a/src/system/applications/actor/character-sheet.ts
+++ b/src/system/applications/actor/character-sheet.ts
@@ -16,11 +16,25 @@ const enum CharacterSheetTab {
 export class CharacterSheet extends BaseActorSheet {
     declare actor: CharacterActor;
 
+    private static readonly MIN_WIDTH = 800;
+    private static readonly MAX_WIDTH = 800;
+    private static readonly MIN_HEIGHT = 728;
+    private static readonly MAX_HEIGHT = 900;
+
+    private isApplyingPositionConstraint = false;
+
     static DEFAULT_OPTIONS = {
         classes: [SYSTEM_ID, 'sheet', 'actor', 'character'] as string[],
+        window: {
+            positioned: true,
+            resizable: true,
+        },
         position: {
-            width: 850,
-            height: 1000,
+            width: CharacterSheet.MIN_WIDTH,
+            height: Math.max(
+                Math.min(CharacterSheet.MAX_HEIGHT, window.innerHeight),
+                CharacterSheet.MIN_HEIGHT,
+            ),
         },
     };
 
@@ -82,5 +96,34 @@ export class CharacterSheet extends BaseActorSheet {
                 ancestryItem?.name ??
                 game.i18n?.localize('COSMERE.Item.Type.Ancestry.label'),
         };
+    }
+
+    /* --- Lifecycle --- */
+
+    protected override _onPosition(options: unknown): void {
+        super._onPosition(options);
+
+        if (this.isApplyingPositionConstraint) return;
+
+        const width = this.position.width as number;
+        const height = this.position.height as number;
+
+        const clampedWidth = Math.min(
+            Math.max(width, CharacterSheet.MIN_WIDTH),
+            CharacterSheet.MAX_WIDTH,
+        );
+        const clampedHeight = Math.min(
+            Math.max(height, CharacterSheet.MIN_HEIGHT),
+            CharacterSheet.MAX_HEIGHT,
+        );
+
+        if (width === clampedWidth && height === clampedHeight) return;
+
+        this.isApplyingPositionConstraint = true; // Since we are setting the position, this will set off the _onPosition event. We ensure this code wont loop forever.
+        this.setPosition({
+            width: clampedWidth,
+            height: clampedHeight,
+        });
+        this.isApplyingPositionConstraint = false;
     }
 }


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR aims to fix the issue of shorter monitors not being able to view the entire character sheet. Can be resized by click and holding the bottom right corner.

**Related Issue**  
Closes #636 

**How Has This Been Tested?**  
Tried resizing it all over the place. The only real bug is the character sheet being pushed slightly when you try to resize it all the way to the edge of the screen, but this bug does not cause any issue, just an odd quirk.

**Screenshots (if applicable)**  
728px height:
<img width="940" height="805" alt="image" src="https://github.com/user-attachments/assets/8d747768-9c6b-4ce6-9293-904231c5b31f" />

900px height (max):
<img width="908" height="943" alt="image" src="https://github.com/user-attachments/assets/47ae4629-2e45-4025-983e-d2a757a891fd" />


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13 build 351.
