### PR TITLE
Add Power talent tree prerequisite

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -518,7 +518,8 @@
                         "level": "Level",
                         "ancestry": "Ancestry",
                         "culture": "Culture",
-                        "goal": "Goal"
+                        "goal": "Goal",
+                        "power": "Power"
                     },
                     "Mode": {
                         "AnyOf": "Any of",
@@ -532,6 +533,9 @@
                     },
                     "Culture": {
                         "Label": "Culture"
+                    },
+                    "Power": {
+                        "Label": "Power"
                     }
                 },
                 "GrantRule": {

--- a/src/system/applications/item/components/talent-tree/node-prerequisites.ts
+++ b/src/system/applications/item/components/talent-tree/node-prerequisites.ts
@@ -194,6 +194,12 @@ export class NodePrerequisitesComponent extends HandlebarsApplicationComponent<
                       culture: await this.prepareRefContext(rule.culture),
                   }
                 : {}),
+
+            ...(rule.type === TalentTree.Node.Prerequisite.Type.Power
+                ? {
+                      power: await this.prepareRefContext(rule.power),
+                  }
+                : {}),
         };
     }
 

--- a/src/system/applications/item/dialogs/talent-tree/edit-node-prerequisite.ts
+++ b/src/system/applications/item/dialogs/talent-tree/edit-node-prerequisite.ts
@@ -248,6 +248,20 @@ export class EditNodePrerequisiteDialog extends ComponentHandlebarsApplicationMi
                     label: culture.name,
                 };
             }
+        } else if (
+            this.data.type === TalentTree.Node.Prerequisite.Type.Power &&
+            formData.has('power')
+        ) {
+            const powerUuid = formData.get('power') as string;
+            const power = (await fromUuid(powerUuid)) as unknown as CosmereItem;
+
+            if (power?.isPower()) {
+                this.data.power = {
+                    uuid: power.uuid,
+                    id: power.system.id,
+                    label: power.name,
+                };
+            }
         }
 
         // Render

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -878,6 +878,8 @@ const COSMERE: CosmereRPGConfig = {
                             'COSMERE.Item.Talent.Prerequisite.Type.culture',
                         [TalentTree.Node.Prerequisite.Type.Goal]:
                             'COSMERE.Item.Talent.Prerequisite.Type.goal',
+                        [TalentTree.Node.Prerequisite.Type.Power]:
+                            'COSMERE.Item.Talent.Prerequisite.Type.power',
                     },
                 },
             },

--- a/src/system/data/item/fields/talent-tree-node-collection.ts
+++ b/src/system/data/item/fields/talent-tree-node-collection.ts
@@ -9,7 +9,7 @@ import {
 } from '@system/data/fields';
 
 export class TalentTreeNodeCollectionField extends CollectionField<
-    TalentTreeNodeField, 
+    TalentTreeNodeField,
     CollectionFieldOptions,
     TalentTree.Node,
     TalentTree.Node
@@ -58,6 +58,7 @@ const SCHEMA = () => ({
             TalentTree.Node.Type.Talent,
             TalentTree.Node.Type.Tree,
             TalentTree.Node.Type.Text,
+            TalentTree.Node.Type.Power,
         ],
     }),
     position: new foundry.data.fields.SchemaField(
@@ -122,8 +123,7 @@ const SCHEMA = () => ({
                 nullable: false,
                 blank: false,
                 choices:
-                    CONFIG.COSMERE.items.talentTree.node
-                        .prerequisite.types,
+                    CONFIG.COSMERE.items.talentTree.node.prerequisite.types,
             }),
             managed: new foundry.data.fields.BooleanField({
                 required: true,
@@ -137,9 +137,7 @@ const SCHEMA = () => ({
             // Attribute
             attribute: new foundry.data.fields.StringField({
                 blank: false,
-                choices: Object.entries(
-                    CONFIG.COSMERE.attributes,
-                ).reduce(
+                choices: Object.entries(CONFIG.COSMERE.attributes).reduce(
                     (acc, [key, config]) => ({
                         ...acc,
                         [key]: config.label,
@@ -155,9 +153,7 @@ const SCHEMA = () => ({
             // Skill
             skill: new foundry.data.fields.StringField({
                 blank: false,
-                choices: Object.entries(
-                    CONFIG.COSMERE.skills,
-                ).reduce(
+                choices: Object.entries(CONFIG.COSMERE.skills).reduce(
                     (acc, [key, config]) => ({
                         ...acc,
                         [key]: config.label,
@@ -276,6 +272,32 @@ const SCHEMA = () => ({
                     nullable: true,
                 },
             ),
+
+            // Power
+            power: new foundry.data.fields.SchemaField(
+                {
+                    uuid: new foundry.data.fields.StringField({
+                        required: true,
+                        nullable: false,
+                        blank: false,
+                    }),
+                    id: new foundry.data.fields.StringField({
+                        required: true,
+                        nullable: false,
+                        blank: false,
+                    }),
+                    label: new foundry.data.fields.StringField({
+                        required: true,
+                        nullable: false,
+                        blank: false,
+                    }),
+                },
+                {
+                    nullable: true,
+                    initial: null,
+                    label: 'COSMERE.Item.Talent.Prerequisite.Power.Label',
+                },
+            ),
         }),
         {
             nullable: true,
@@ -290,12 +312,10 @@ const SCHEMA = () => ({
                 blank: false,
                 readonly: false,
             }),
-            prerequisiteId: new foundry.data.fields.DocumentIdField(
-                {
-                    required: true,
-                    nullable: false,
-                },
-            ),
+            prerequisiteId: new foundry.data.fields.DocumentIdField({
+                required: true,
+                nullable: false,
+            }),
             path: new foundry.data.fields.ArrayField(
                 new foundry.data.fields.SchemaField({
                     x: new foundry.data.fields.NumberField({
@@ -323,7 +343,10 @@ const SCHEMA = () => ({
     }),
 });
 
-class TalentTreeNodeField extends foundry.data.fields.SchemaField<ReturnType<typeof SCHEMA>, foundry.data.fields.DataField.Options.Any> {
+class TalentTreeNodeField extends foundry.data.fields.SchemaField<
+    ReturnType<typeof SCHEMA>,
+    foundry.data.fields.DataField.Options.Any
+> {
     constructor(
         options?: foundry.data.fields.DataField.Options.Any,
         context?: foundry.data.fields.DataField.ConstructionContext,
@@ -331,10 +354,6 @@ class TalentTreeNodeField extends foundry.data.fields.SchemaField<ReturnType<typ
         options ??= {};
         options.gmOnly = true;
 
-        super(
-            SCHEMA(),
-            options,
-            context,
-        );
+        super(SCHEMA(), options, context);
     }
 }

--- a/src/system/data/item/fields/talent-tree-node-collection.ts
+++ b/src/system/data/item/fields/talent-tree-node-collection.ts
@@ -58,7 +58,6 @@ const SCHEMA = () => ({
             TalentTree.Node.Type.Talent,
             TalentTree.Node.Type.Tree,
             TalentTree.Node.Type.Text,
-            TalentTree.Node.Type.Power,
         ],
     }),
     position: new foundry.data.fields.SchemaField(

--- a/src/system/types/item/talent-tree.ts
+++ b/src/system/types/item/talent-tree.ts
@@ -38,6 +38,7 @@ export namespace Node {
             Ancestry = 'ancestry',
             Culture = 'culture',
             Goal = 'goal',
+            Power = 'power',
         }
 
         export const enum Mode {

--- a/src/system/types/item/talent-tree.ts
+++ b/src/system/types/item/talent-tree.ts
@@ -4,7 +4,6 @@ import { TalentItem, TalentTreeItem } from '@system/documents/item';
 export namespace Node {
     export const enum Type {
         Talent = 'talent',
-        Power = 'power',
         Tree = 'tree',
         Text = 'text',
     }
@@ -219,11 +218,4 @@ export interface TextNode extends BaseNode<Node.Type.Text> {
     text: string;
 }
 
-export interface PowerNode extends BaseNode<Node.Type.Power> {
-    /**
-     * The UUID of the PowerItem the node refers to.
-     */
-    uuid: string;
-}
-
-export type Node = TalentNode | TreeNode | TextNode | PowerNode;
+export type Node = TalentNode | TreeNode | TextNode;

--- a/src/system/types/item/talent-tree.ts
+++ b/src/system/types/item/talent-tree.ts
@@ -4,6 +4,7 @@ import { TalentItem, TalentTreeItem } from '@system/documents/item';
 export namespace Node {
     export const enum Type {
         Talent = 'talent',
+        Power = 'power',
         Tree = 'tree',
         Text = 'text',
     }
@@ -121,6 +122,11 @@ export namespace Node {
         culture: Prerequisite.ItemRef;
     }
 
+    export interface PowerPrerequisite
+        extends BasePrerequisite<Prerequisite.Type.Power> {
+        power: Prerequisite.ItemRef;
+    }
+
     export type Prerequisite =
         | ConnectionPrerequisite
         | AttributePrerequisite
@@ -129,7 +135,8 @@ export namespace Node {
         | LevelPrerequisite
         | AncestryPrerequisite
         | CulturePrerequisite
-        | GoalPrerequisite;
+        | GoalPrerequisite
+        | PowerPrerequisite;
 }
 
 export interface BaseNode<Type extends Node.Type = Node.Type> {
@@ -212,4 +219,11 @@ export interface TextNode extends BaseNode<Node.Type.Text> {
     text: string;
 }
 
-export type Node = TalentNode | TreeNode | TextNode;
+export interface PowerNode extends BaseNode<Node.Type.Power> {
+    /**
+     * The UUID of the PowerItem the node refers to.
+     */
+    uuid: string;
+}
+
+export type Node = TalentNode | TreeNode | TextNode | PowerNode;

--- a/src/system/utils/talent-tree.ts
+++ b/src/system/utils/talent-tree.ts
@@ -287,6 +287,10 @@ export function characterMeetsPrerequisiteRule(
             );
         case TalentTree.Node.Prerequisite.Type.Connection:
             return true; // No way to check connections
+        case TalentTree.Node.Prerequisite.Type.Power:
+            return actor.powers.some(
+                (power) => power.system.id === prereq.power.id,
+            );
         default:
             return false;
     }

--- a/src/templates/item/talent-tree/components/prerequisites.hbs
+++ b/src/templates/item/talent-tree/components/prerequisites.hbs
@@ -57,6 +57,8 @@
                     {{{rule.ancestry.link}}}
                 {{else if (eq rule.type "culture")}}
                     {{{rule.culture.link}}}
+                {{else if (eq rule.type "power")}}
+                    {{{rule.power.link}}}
                 {{/if}}
             </div>
             <div class="controls icon faded flexrow">

--- a/src/templates/item/talent-tree/dialogs/edit-prerequisite.hbs
+++ b/src/templates/item/talent-tree/dialogs/edit-prerequisite.hbs
@@ -125,6 +125,17 @@
         }}
     {{/if}}
 
+    {{!-- Power --}}
+    {{#if (eq type "power")}}
+        {{app-document-reference-input
+            name="power"
+            label=(localize schema.fields.power.label)
+            value=power.uuid
+            type="Item"
+            subtype="power"
+        }}
+    {{/if}}
+
     {{!-- Submit --}}
     <br>
     <div class="form-group">

--- a/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
+++ b/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
@@ -49,7 +49,7 @@
                         <span>{{prereq.culture.label}}</span>
                         <span>{{localize "COSMERE.Item.Talent.Prerequisite.Type.culture"}}</span>
                     {{else if (eq prereq.type "power")}}
-                        <i class="fa-solid fa-globe"></i>
+                        <i class="fa-solid fa-bolt"></i>
                         <span>{{prereq.power.label}}</span>
                         <span>{{localize "COSMERE.Item.Talent.Prerequisite.Type.power"}}</span>
                     {{/if}}

--- a/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
+++ b/src/templates/item/talent-tree/partials/talent-tree-node-tooltip.hbs
@@ -48,6 +48,10 @@
                         <i class="fa-solid fa-globe"></i>
                         <span>{{prereq.culture.label}}</span>
                         <span>{{localize "COSMERE.Item.Talent.Prerequisite.Type.culture"}}</span>
+                    {{else if (eq prereq.type "power")}}
+                        <i class="fa-solid fa-globe"></i>
+                        <span>{{prereq.power.label}}</span>
+                        <span>{{localize "COSMERE.Item.Talent.Prerequisite.Type.power"}}</span>
                     {{/if}}
                 </div>
             {{/each}}

--- a/src/templates/item/talent/embed.hbs
+++ b/src/templates/item/talent/embed.hbs
@@ -23,7 +23,7 @@
                                 {{lower (localize "GENERIC.Talent")}}{{#unless (or (not @last) @../last)}};{{/unless}}
                             </span>
                             {{#if (not @last)}}
-                                <span>or</span>  
+                                <span>or</span>
                             {{/if}}
                         {{/each}}
                     {{else if (eq prereq.type "attribute")}}
@@ -51,6 +51,9 @@
                     {{else if (eq prereq.type "culture")}}
                         <span>{{prereq.culture.label}}</span>
                         <span>{{lower (localize "COSMERE.Item.Talent.Prerequisite.Type.culture")}}{{#unless @last}};{{/unless}}</span>
+                    {{else if (eq prereq.type "power")}}
+                        <span>{{prereq.power.label}}</span>
+                        <span>{{lower (localize "COSMERE.Item.Talent.Prerequisite.Type.power")}}{{#unless @last}};{{/unless}}</span>
                     {{/if}}
                 {{/each}}
             {{/if}}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds a new talent prerequisite type for "Power" items, very similarly to how we currently handle "Ancestry" or "Culture" prerequisites.

**Related Issue**  
Partially addresses #696 

**How Has This Been Tested?**  
Opened a world with Stormlight handbook. Opened the "Abrasion" talent tree, and added the "Abrasion" power as a prerequisite for the "Reverse Abrasion" talent. Created a test actor sheet, and added the "Dustbringer" path. Verified that the "Abrasion" power prerequisite was shown as red (unmet) on the talent tree. Then manually added the "Abrasion" power, without completing the "First Ideal" goal, and verified that the "Abrasion" power prerequisite was now shown as blue (met).

**Screenshots (if applicable)**
Had a screenshot here but it had bad info on it, removed it. 

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 351.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
