### PR TITLE
Made power items talent providers

### DIFF
--- a/src/system/applications/item/power-sheet.ts
+++ b/src/system/applications/item/power-sheet.ts
@@ -6,11 +6,14 @@ import { TEMPLATES } from '@src/system/utils/templates';
 // Base
 import { BaseItemSheet } from './base';
 
-export class PowerItemSheet extends BaseItemSheet {
+// Mixins
+import { TalentsTabMixin } from './mixins/talents-tab';
+
+export class PowerItemSheet extends TalentsTabMixin(BaseItemSheet) {
     declare item: PowerItem;
 
     static DEFAULT_OPTIONS = {
-        classes: [SYSTEM_ID, 'sheet', 'item', 'armor'],
+        classes: [SYSTEM_ID, 'sheet', 'item', 'power'],
         position: {
             width: 550,
         },
@@ -50,6 +53,11 @@ export class PowerItemSheet extends BaseItemSheet {
     public async _prepareContext(
         options: DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions>,
     ) {
+        // Check if the power has a talent tree set
+        const hasTalentTree = this.item.system.talentTree !== null;
+
+        // Enable the talents tab if the power has a talent tree set
+        this.tabs.talents.enabled = hasTalentTree;
         return {
             ...(await super._prepareContext(options)),
         };

--- a/src/system/data/item/power.ts
+++ b/src/system/data/item/power.ts
@@ -20,6 +20,10 @@ import {
     RelationshipsMixin,
     RelationshipsItemDataSchema,
 } from './mixins/relationships';
+import {
+    TalentsProviderDataSchema,
+    TalentsProviderMixin,
+} from './mixins/talents-provider';
 
 const SCHEMA = () => ({
     customSkill: new foundry.data.fields.BooleanField({
@@ -55,7 +59,8 @@ export type PowerItemDataSchema = ReturnType<typeof SCHEMA> &
     DescriptionItemDataSchema &
     ResourcesItemMixin.Schema &
     EventsItemDataSchema &
-    RelationshipsItemDataSchema;
+    RelationshipsItemDataSchema &
+    TalentsProviderDataSchema;
 
 export type PowerItemDerivedData = TypedItemDerivedData;
 
@@ -90,6 +95,7 @@ export class PowerItemDataModel extends DataModelMixin<
     ResourcesItemMixin(),
     EventsItemMixin(),
     RelationshipsMixin(),
+    TalentsProviderMixin(),
 ) {
     static defineSchema() {
         return foundry.utils.mergeObject(super.defineSchema(), SCHEMA());

--- a/src/templates/item/power/partials/power-details-tab.hbs
+++ b/src/templates/item/power/partials/power-details-tab.hbs
@@ -20,9 +20,10 @@
             {{/if}}
         </div>
     </fieldset>
-    
+
     {{app-item-details-activation}}
     {{app-item-details-damage}}
+    {{app-item-details-talents-provider}}
 </div>
 
 {{/with}}

--- a/src/templates/item/power/parts/content.hbs
+++ b/src/templates/item/power/parts/content.hbs
@@ -4,10 +4,11 @@
     <div class="scroll-container">
         <section class="tab-body">
             {{> item-description-tab}}
+            {{> item-talents-tab}}
             {{> power-details-tab}}
             {{> item-actions-tab}}
             {{> item-events-tab}}
             {{> item-effects-tab}}
         </section>
-    </div>    
+    </div>
 </section>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR makes "Power" items into talent providers, for talent trees that are directly associated with powers. Also fixed a minor error with the power item application having an "armor" class instead of "power" incorrectly.

**Related Issue**  
Closes #700 

**How Has This Been Tested?**  
Created a new "Soulcasting" power on a local Foundry instance using the Stormlight handbook, and dragged/dropped the "Transformation" talent tree onto the power. Verified that the power contained the talent tree tab, and that the talent tree displayed correctly on the item.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
