### PR TITLE
Added generic "Equippable Item"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,10 @@ Hooks.once('init', async () => {
     );
     registerItemSheet(ItemType.Loot, applications.item.LootItemSheet as any);
     registerItemSheet(ItemType.Armor, applications.item.ArmorItemSheet as any);
+    registerItemSheet(
+        ItemType.GenericEquippable,
+        applications.item.GenericEquippableItemSheet as any,
+    );
     registerItemSheet(ItemType.Trait, applications.item.TraitItemSheet as any);
     registerItemSheet(
         ItemType.Action,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -337,6 +337,13 @@
                     "desc_placeholder": "Edit this to describe what this armor is & how it looks.",
                     "New": "New Armor"
                 },
+                "GenericEquippable": {
+                    "label": "Equippable Item",
+                    "label_plural": "Equippable Items",
+                    "label_action": "Equippable Item Action",
+                    "desc_placeholder": "Edit this to describe what this equippable item is & how it looks.",
+                    "New": "New Equippable Item"
+                },
                 "Equipment": {
                     "label": "Equipment",
                     "label_plural": "Equipment",
@@ -689,6 +696,9 @@
                     },
                     "Hold": {
                         "Label": "Held"
+                    },
+                    "Equip": {
+                        "Label": "Equipped"
                     }
                 },
                 "Hold": {
@@ -1658,7 +1668,8 @@
             "equipment": "Equipment",
             "weapon": "Weapon",
             "power": "Power",
-            "talent_tree": "Talent Tree"
+            "talent_tree": "Talent Tree",
+            "generic_equippable": "Equippable Item"
         }
     },
     "UNITS": {

--- a/src/system.json
+++ b/src/system.json
@@ -29,6 +29,7 @@
             "armor": {},
             "equipment": {},
             "loot": {},
+            "generic_equippable": {},
             "ancestry": {},
             "culture": {},
             "path": {},

--- a/src/system/applications/actor/components/equipment-list.ts
+++ b/src/system/applications/actor/components/equipment-list.ts
@@ -262,6 +262,7 @@ any> {
         this.sections = [
             this.prepareSection(ItemType.Weapon),
             this.prepareSection(ItemType.Armor),
+            this.prepareSection(ItemType.GenericEquippable),
             this.prepareSection(ItemType.Equipment),
             this.prepareSection(ItemType.Loot),
         ];

--- a/src/system/applications/actor/components/equipment-list.ts
+++ b/src/system/applications/actor/components/equipment-list.ts
@@ -296,7 +296,8 @@ any> {
                     {
                         type,
                         name: game.i18n.localize(
-                            `COSMERE.Item.Type.${type.capitalize()}.New`,
+                            CONFIG.COSMERE.items.types[type].new ??
+                                `COSMERE.Item.Type.${type.capitalize()}.New`,
                         ),
                     },
                     { parent },

--- a/src/system/applications/item/generic-equippable-sheet.ts
+++ b/src/system/applications/item/generic-equippable-sheet.ts
@@ -1,0 +1,57 @@
+import { GenericEquippableItem } from '@system/documents/item';
+import { DeepPartial } from '@system/types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
+import { TEMPLATES } from '@src/system/utils/templates';
+
+// Base
+import { BaseItemSheet } from './base';
+
+export class GenericEquippableItemSheet extends BaseItemSheet {
+    declare item: GenericEquippableItem;
+
+    static DEFAULT_OPTIONS = {
+        classes: [SYSTEM_ID, 'sheet', 'item', 'generic-equippable'],
+        position: {
+            width: 550,
+        },
+        window: {
+            resizable: false,
+            positioned: true,
+        },
+    };
+
+    static TABS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.TABS),
+        {
+            details: {
+                label: 'COSMERE.Item.Sheet.Tabs.Details',
+                icon: '<i class="fa-solid fa-circle-info"></i>',
+                sortIndex: 15,
+            },
+            actions: {
+                label: 'COSMERE.Item.Sheet.Tabs.Actions',
+                icon: '<i class="cosmere-icon">3</i>',
+                sortIndex: 19,
+            },
+        },
+    );
+
+    static PARTS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.PARTS),
+        {
+            content: {
+                template: `systems/${SYSTEM_ID}/templates/${TEMPLATES.ITEM_GENERIC_EQUIPPABLE_CONTENT}`,
+            },
+        },
+    );
+
+    /* --- Context --- */
+
+    public async _prepareContext(
+        options: DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions>,
+    ) {
+        return {
+            ...(await super._prepareContext(options)),
+        };
+    }
+}

--- a/src/system/applications/item/index.ts
+++ b/src/system/applications/item/index.ts
@@ -15,3 +15,4 @@ export * from './weapon-sheet';
 export * from './goal-sheet';
 export * from './power-sheet';
 export * from './talent-tree-sheet';
+export * from './generic-equippable-sheet';

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -722,28 +722,33 @@ const COSMERE: CosmereRPGConfig = {
                 label: 'COSMERE.Item.Type.Weapon.label',
                 labelPlural: 'COSMERE.Item.Type.Weapon.label_plural',
                 desc_placeholder: 'COSMERE.Item.Type.Weapon.desc_placeholder',
+                new: 'COSMERE.Item.Type.Weapon.New',
             },
             [ItemType.Armor]: {
                 label: 'COSMERE.Item.Type.Armor.label',
                 labelPlural: 'COSMERE.Item.Type.Armor.label_plural',
                 desc_placeholder: 'COSMERE.Item.Type.Armor.desc_placeholder',
+                new: 'COSMERE.Item.Type.Armor.New',
             },
             [ItemType.Equipment]: {
                 label: 'COSMERE.Item.Type.Equipment.label',
                 labelPlural: 'COSMERE.Item.Type.Equipment.label_plural',
                 desc_placeholder:
                     'COSMERE.Item.Type.Equipment.desc_placeholder',
+                new: 'COSMERE.Item.Type.Equipment.New',
             },
             [ItemType.Loot]: {
                 label: 'COSMERE.Item.Type.Loot.label',
                 labelPlural: 'COSMERE.Item.Type.Loot.label_plural',
                 desc_placeholder: 'COSMERE.Item.Type.Loot.desc_placeholder',
+                new: 'COSMERE.Item.Type.Loot.New',
             },
             [ItemType.GenericEquippable]: {
                 label: 'COSMERE.Item.Type.GenericEquippable.label',
                 labelPlural: 'COSMERE.Item.Type.GenericEquippable.label_plural',
                 desc_placeholder:
                     'COSMERE.Item.Type.GenericEquippable.desc_placeholder',
+                new: 'COSMERE.Item.Type.GenericEquippable.New',
             },
             [ItemType.Ancestry]: {
                 label: 'COSMERE.Item.Type.Ancestry.label',
@@ -764,16 +769,19 @@ const COSMERE: CosmereRPGConfig = {
                 label: 'COSMERE.Item.Type.Talent.label',
                 labelPlural: 'COSMERE.Item.Type.Talent.label_plural',
                 desc_placeholder: 'COSMERE.Item.Type.Talent.desc_placeholder',
+                new: 'COSMERE.Item.Type.Talent.New',
             },
             [ItemType.Action]: {
                 label: 'COSMERE.Item.Type.Action.label',
                 labelPlural: 'COSMERE.Item.Type.Action.label_plural',
                 desc_placeholder: 'COSMERE.Item.Type.Action.desc_placeholder',
+                new: 'COSMERE.Item.Type.Action.New',
             },
             [ItemType.Trait]: {
                 label: 'COSMERE.Item.Type.Trait.label',
                 labelPlural: 'COSMERE.Item.Type.Trait.label_plural',
                 desc_placeholder: 'COSMERE.Item.Type.Trait.desc_placeholder',
+                new: 'COSMERE.Item.Type.Trait.New',
             },
             [ItemType.Injury]: {
                 label: 'COSMERE.Item.Type.Injury.label',
@@ -795,6 +803,7 @@ const COSMERE: CosmereRPGConfig = {
                 label: 'COSMERE.Item.Type.Power.label',
                 labelPlural: 'COSMERE.Item.Type.Power.label_plural',
                 desc_placeholder: 'COSMERE.Item.Type.Power.desc_placeholder',
+                new: 'COSMERE.Item.Type.Power.New',
             },
             [ItemType.TalentTree]: {
                 label: 'COSMERE.Item.Type.TalentTree.label',

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -739,6 +739,12 @@ const COSMERE: CosmereRPGConfig = {
                 labelPlural: 'COSMERE.Item.Type.Loot.label_plural',
                 desc_placeholder: 'COSMERE.Item.Type.Loot.desc_placeholder',
             },
+            [ItemType.GenericEquippable]: {
+                label: 'COSMERE.Item.Type.GenericEquippable.label',
+                labelPlural: 'COSMERE.Item.Type.GenericEquippable.label_plural',
+                desc_placeholder:
+                    'COSMERE.Item.Type.GenericEquippable.desc_placeholder',
+            },
             [ItemType.Ancestry]: {
                 label: 'COSMERE.Item.Type.Ancestry.label',
                 labelPlural: 'COSMERE.Item.Type.Ancestry.label_plural',
@@ -803,6 +809,9 @@ const COSMERE: CosmereRPGConfig = {
                 },
                 [EquipType.Hold]: {
                     label: 'COSMERE.Item.Equip.Types.Hold.Label',
+                },
+                [EquipType.Equip]: {
+                    label: 'COSMERE.Item.Equip.Types.Equip.Label',
                 },
             },
             hold: {

--- a/src/system/data/item/generic-equippable.ts
+++ b/src/system/data/item/generic-equippable.ts
@@ -1,0 +1,85 @@
+import { EquipType } from '@system/types/cosmere';
+import { CosmereItem } from '@src/system/documents';
+import { EmptyObject } from '@system/types/utils';
+
+// Mixins
+import { DataModelMixin } from '../mixins';
+import { IdItemMixin, IdItemDataSchema } from './mixins/id';
+import {
+    DescriptionItemMixin,
+    DescriptionItemDataSchema,
+} from './mixins/description';
+import { ResourcesItemMixin } from './mixins/resources';
+import {
+    EquippableItemMixin,
+    EquippableItemDataSchema,
+} from './mixins/equippable';
+import {
+    TraitsItemMixin,
+    TraitsItemDataSchema,
+    TraitsItemDerivedData,
+} from './mixins/traits';
+import { DeflectItemMixin, DeflectItemDataSchema } from './mixins/deflect';
+import {
+    PhysicalItemMixin,
+    PhysicalItemDataSchema,
+    PhysicalItemDerivedData,
+} from './mixins/physical';
+import { EventsItemMixin, EventsItemDataSchema } from './mixins/events';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemDataSchema,
+} from './mixins/linked-skills';
+import {
+    RelationshipsMixin,
+    RelationshipsItemDataSchema,
+} from './mixins/relationships';
+import { ModalityItemMixin, ModalityItemDataSchema } from './mixins/modality';
+
+export type GenericEquippableItemDataSchema = IdItemDataSchema &
+    DescriptionItemDataSchema &
+    EquippableItemDataSchema<{
+        equipType: {
+            initial: EquipType.Wear;
+            choices: [EquipType.Wear, EquipType.Equip];
+        };
+    }> &
+    ResourcesItemMixin.Schema &
+    // TraitsItemDataSchema &
+    DeflectItemDataSchema &
+    PhysicalItemDataSchema &
+    EventsItemDataSchema &
+    LinkedSkillsItemDataSchema &
+    RelationshipsItemDataSchema &
+    ModalityItemDataSchema;
+
+export type GenericEquippableItemDerivedData = PhysicalItemDerivedData; //&
+// TraitsItemDerivedData;
+
+export class GenericEquippableItemDataModel extends DataModelMixin<
+    GenericEquippableItemDataSchema,
+    foundry.abstract.Document.Any,
+    EmptyObject,
+    GenericEquippableItemDerivedData
+>(
+    IdItemMixin({
+        initial: 'none',
+    }),
+    DescriptionItemMixin({
+        value: 'COSMERE.Item.Type.GenericEquippable.desc_placeholder',
+    }),
+    EquippableItemMixin({
+        equipType: {
+            initial: EquipType.Equip,
+            choices: [EquipType.Wear, EquipType.Equip],
+        },
+    }),
+    ResourcesItemMixin(),
+    // TraitsItemMixin(),
+    DeflectItemMixin(),
+    PhysicalItemMixin(),
+    EventsItemMixin(),
+    LinkedSkillsMixin(),
+    RelationshipsMixin(),
+    ModalityItemMixin(),
+) {}

--- a/src/system/data/item/index.ts
+++ b/src/system/data/item/index.ts
@@ -5,6 +5,7 @@ import { WeaponItemDataModel } from './weapon';
 import { ArmorItemDataModel } from './armor';
 import { EquipmentItemDataModel } from './equipment';
 import { LootItemDataModel } from './loot';
+import { GenericEquippableItemDataModel } from './generic-equippable';
 
 import { AncestryItemDataModel } from './ancestry';
 import { CultureItemDataModel } from './culture';
@@ -27,6 +28,7 @@ export const config = {
     [ItemType.Armor]: ArmorItemDataModel,
     [ItemType.Equipment]: EquipmentItemDataModel,
     [ItemType.Loot]: LootItemDataModel,
+    [ItemType.GenericEquippable]: GenericEquippableItemDataModel,
 
     [ItemType.Ancestry]: AncestryItemDataModel,
     [ItemType.Culture]: CultureItemDataModel,
@@ -49,6 +51,7 @@ export * from './weapon';
 export * from './armor';
 export * from './equipment';
 export * from './loot';
+export * from './generic-equippable';
 export * from './ancestry';
 export * from './culture';
 export * from './path';
@@ -68,6 +71,7 @@ declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
             [ItemType.Armor]: typeof foundry.abstract.TypeDataModel;
             [ItemType.Equipment]: typeof foundry.abstract.TypeDataModel;
             [ItemType.Loot]: typeof foundry.abstract.TypeDataModel;
+            [ItemType.GenericEquippable]: typeof foundry.abstract.TypeDataModel;
 
             [ItemType.Ancestry]: typeof foundry.abstract.TypeDataModel;
             [ItemType.Culture]: typeof foundry.abstract.TypeDataModel;

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -30,6 +30,7 @@ import {
     TraitItemDataModel,
     LootItemDataModel,
     EquipmentItemDataModel,
+    GenericEquippableItemDataModel,
     GoalItemDataModel,
     PowerItemDataModel,
     TalentTreeItemDataModel,
@@ -240,6 +241,10 @@ export class CosmereItem<
 
     public isEquipment(): this is CosmereItem<EquipmentItemDataModel> {
         return this.type === ItemType.Equipment;
+    }
+
+    public isGenericEquippable(): this is CosmereItem<GenericEquippableItemDataModel> {
+        return this.type === ItemType.GenericEquippable;
     }
 
     public isGoal(): this is GoalItem {
@@ -1735,6 +1740,7 @@ export type ConnectionItem = CosmereItem<ConnectionItemDataModel>;
 export type InjuryItem = CosmereItem<InjuryItemDataModel>;
 export type LootItem = CosmereItem<LootItemDataModel>;
 export type ArmorItem = CosmereItem<ArmorItemDataModel>;
+export type GenericEquippableItem = CosmereItem<GenericEquippableItemDataModel>;
 export type TraitItem = CosmereItem<TraitItemDataModel>;
 export type ActionItem = CosmereItem<ActionItemDataModel>;
 export type TalentItem = CosmereItem<TalentItemDataModel>;

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -239,6 +239,7 @@ export interface ItemTypeConfig {
     label: string;
     labelPlural: string;
     desc_placeholder?: string;
+    new?: string;
 }
 
 export interface EquipTypeConfig {

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -223,6 +223,7 @@ export const enum ItemResourceRechargeType {
 export const enum EquipType {
     Hold = 'hold', // Item that you equip by holding it (either in one or two hands)
     Wear = 'wear', // Item that you equip by wearing it
+    Equip = 'equip', // Item that you equip generically
 }
 
 export const enum HoldType {
@@ -293,6 +294,7 @@ export const enum ItemType {
     Weapon = 'weapon',
     Armor = 'armor',
     Equipment = 'equipment',
+    GenericEquippable = 'generic_equippable',
     Loot = 'loot',
 
     Ancestry = 'ancestry',

--- a/src/system/utils/embed/item/index.ts
+++ b/src/system/utils/embed/item/index.ts
@@ -14,6 +14,7 @@ const EMBEDDERS: Record<ItemType, EmbedHelpers | null> = {
     [ItemType.Armor]: null,
     [ItemType.Equipment]: null,
     [ItemType.Loot]: null,
+    [ItemType.GenericEquippable]: null,
 
     [ItemType.Ancestry]: ancestryEmbed,
     [ItemType.Culture]: null,

--- a/src/system/utils/templates.ts
+++ b/src/system/utils/templates.ts
@@ -92,6 +92,8 @@ export const TEMPLATES = {
     ITEM_POWER_CONTENT: 'item/power/parts/content.hbs',
     ITEM_SPECIALTY_CONTENT: 'item/specialty/parts/content.hbs',
     ITEM_TALENT_CONTENT: 'item/talent/parts/content.hbs',
+    ITEM_GENERIC_EQUIPPABLE_CONTENT:
+        'item/generic-equippable/parts/content.hbs',
 
     ITEM_DESCRIPTION_TAB: 'item/partials/item-description-tab.hbs',
     ITEM_EFFECTS_TAB: 'item/partials/item-effects-tab.hbs',
@@ -106,6 +108,8 @@ export const TEMPLATES = {
         'item/specialty/partials/specialty-details-tab.hbs',
     ITEM_LOOT_DETAILS_TAB: 'item/loot/partials/loot-details-tab.hbs',
     ITEM_ARMOR_DETAILS_TAB: 'item/armor/partials/armor-details-tab.hbs',
+    ITEM_GENERIC_EQUIPPABLE_DETAILS_TAB:
+        'item/generic-equippable/partials/generic-equippable-details-tab.hbs',
     ITEM_ANCESTRY_DETAILS_TAB:
         'item/ancestry/partials/ancestry-details-tab.hbs',
     ITEM_TALENT_DETAILS_TAB: 'item/talent/partials/talent-details-tab.hbs',

--- a/src/templates/item/generic-equippable/partials/generic-equippable-details-tab.hbs
+++ b/src/templates/item/generic-equippable/partials/generic-equippable-details-tab.hbs
@@ -1,0 +1,15 @@
+{{#with (lookup tabsMap "details") as |tab|}}
+
+<div class="tab tab-content {{tab.cssClass}}" data-tab="details" data-group="primary">
+    <fieldset>
+        <legend>{{localize "COSMERE.Item.Sheet.Basics"}}</legend>
+        {{app-item-details-id}}
+        {{app-item-details-linked-skills}}
+    </fieldset>
+    {{!-- {{app-item-details-equip}} --}}
+    {{app-item-details-activation}}
+    {{app-item-details-deflect}}
+    {{app-item-details-modality}}
+</div>
+
+{{/with}}

--- a/src/templates/item/generic-equippable/parts/content.hbs
+++ b/src/templates/item/generic-equippable/parts/content.hbs
@@ -1,0 +1,13 @@
+<section class="sheet-content">
+    {{app-item-header}}
+    {{> tabs tabs=tabs ignoreLabel=false}}
+    <div class="scroll-container">
+        <section class="tab-body">
+            {{> item-description-tab}}
+            {{> generic-equippable-details-tab}}
+            {{> item-actions-tab}}
+            {{> item-events-tab}}
+            {{> item-effects-tab}}
+        </section>
+    </div>
+</section>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds a generic "Equippable Item" for items that are equippable but not armor/weapons

**Related Issue**  
Closes #703 

**How Has This Been Tested?**  
Created a new "Equippable Item" on a character, verified that section appears, verified that details tabs appear correctly.

**Screenshots (if applicable)**  
<img width="785" height="578" alt="image" src="https://github.com/user-attachments/assets/384c98af-88c2-4ff9-b8b1-ca5bd9865514" />
Note: Styling broken on the item screen- I'd like this to be out of scope for now because this is blocking data entry. I believe it's because "Equippable Item" is just longer than any of the other item types we have.
<img width="547" height="290" alt="image" src="https://github.com/user-attachments/assets/72f29be2-774d-4a9f-869b-483eb48629b8" />
<img width="546" height="502" alt="image" src="https://github.com/user-attachments/assets/e13513de-b0b1-4e69-a480-6609825ad51d" />


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 351.
