### PR TITLE
feat: All equipment items are optionally "equippable"

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -689,6 +689,9 @@
                     },
                     "Hold": {
                         "Label": "Held"
+                    },
+                    "Equip": {
+                        "Label": "Equipped"
                     }
                 },
                 "Hold": {
@@ -1109,6 +1112,8 @@
                 },
                 "Equip": {
                     "Title": "Equipment Details",
+                    "IsEquippable": "Is Equippable",
+                    "EquipType": "Equip Type",
                     "AlwaysEquipped": "Always Equipped",
                     "Traits": "Traits",
                     "ExpertTraits": "Expert Traits",

--- a/src/system/applications/item/components/details-equip.ts
+++ b/src/system/applications/item/components/details-equip.ts
@@ -52,18 +52,21 @@ any> {
 
     public _prepareContext(params: never, context: BaseItemSheetRenderContext) {
         const item = this.application.item; // TEMP: Workaround
-        const isEquippable = item.isEquippable();
+        const isEquippableItem = item.isEquippableItem();
+        const hasTraits = item.hasTraits();
 
-        if (!isEquippable) {
+        if (!isEquippableItem) {
             return Promise.resolve({
                 ...context,
-                isEquippable,
+                isEquippableItem,
             });
         }
 
         return Promise.resolve({
             ...context,
-            isEquippable,
+            alwaysEquippable: item.system.alwaysEquippable,
+            isEquippableItem,
+            isEquippable: item.isEquippable(),
             equipTypes: Object.entries(CONFIG.COSMERE.items.equip.types).reduce(
                 (acc, [key, type]) => ({
                     ...acc,
@@ -74,6 +77,7 @@ any> {
             holdTypeLabel: item.system.equip.hold
                 ? CONFIG.COSMERE.items.equip.hold[item.system.equip.hold].label
                 : '—',
+            hasTraits,
             normalTraitsCollapsed: this.normalTraitsCollapsed,
             expertTraitsCollapsed: this.expertTraitsCollapsed,
             normalTraits: this.prepareTraitsData(false),

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -804,6 +804,9 @@ const COSMERE: CosmereRPGConfig = {
                 [EquipType.Hold]: {
                     label: 'COSMERE.Item.Equip.Types.Hold.Label',
                 },
+                [EquipType.Equip]: {
+                    label: 'COSMERE.Item.Equip.Types.Equip.Label',
+                },
             },
             hold: {
                 [HoldType.OneHanded]: {

--- a/src/system/data/item/armor.ts
+++ b/src/system/data/item/armor.ts
@@ -69,6 +69,7 @@ export class ArmorItemDataModel extends DataModelMixin<
         value: 'COSMERE.Item.Type.Armor.desc_placeholder',
     }),
     EquippableItemMixin({
+        alwaysEquippable: true,
         equipType: {
             initial: EquipType.Wear,
             choices: [EquipType.Wear],

--- a/src/system/data/item/equipment.ts
+++ b/src/system/data/item/equipment.ts
@@ -24,13 +24,18 @@ import {
     RelationshipsMixin,
     RelationshipsItemDataSchema,
 } from './mixins/relationships';
+import {
+    EquippableItemMixin,
+    EquippableItemDataSchema,
+} from './mixins/equippable';
 
 export type EquipmentItemDataSchema = TypedItemDataSchema<EquipmentType> &
     DescriptionItemDataSchema &
     ResourcesItemMixin.Schema &
     PhysicalItemDataSchema &
     EventsItemDataSchema &
-    RelationshipsItemDataSchema;
+    RelationshipsItemDataSchema &
+    EquippableItemDataSchema;
 
 export type EquipmentItemDerivedData = TypedItemDerivedData &
     PhysicalItemDerivedData;
@@ -59,4 +64,5 @@ export class EquipmentItemDataModel extends DataModelMixin<
     PhysicalItemMixin(),
     EventsItemMixin(),
     RelationshipsMixin(),
+    EquippableItemMixin(),
 ) {}

--- a/src/system/data/item/mixins/equippable.ts
+++ b/src/system/data/item/mixins/equippable.ts
@@ -2,12 +2,17 @@ import { EquipType, HoldType, EquipHand } from '@system/types/cosmere';
 import { CosmereItem } from '@system/documents';
 
 interface EquippableMixinOptions {
+    // If true, the item type we're adding this mixin to will always be
+    // categorized as equippable, and will not display a checkbox to
+    // enable/disable the possibility of equipping it
+    alwaysEquippable?: boolean;
+
     equipType?: {
         initial?: EquipType | (() => EquipType);
         choices?:
-        | EquipType[]
-        | Record<EquipType, string>
-        | (() => EquipType[] | Record<EquipType, string>);
+            | EquipType[]
+            | Record<EquipType, string>
+            | (() => EquipType[] | Record<EquipType, string>);
     };
 }
 
@@ -21,9 +26,21 @@ function SCHEMA<TOptions extends EquippableMixinOptions>(options: TOptions) {
         typeof options.equipType?.choices === 'function'
             ? options.equipType.choices()
             : (options.equipType?.choices ??
-                Object.keys(CONFIG.COSMERE.items.equip.types) as EquipType[]);
+              (Object.keys(CONFIG.COSMERE.items.equip.types) as EquipType[]));
 
     return {
+        // If true, don't allow changes to "equippableEnabled"
+        alwaysEquippable: new foundry.data.fields.BooleanField({
+            required: true,
+            nullable: false,
+            initial: options.alwaysEquippable ?? false,
+        }),
+        // Whether this item is currently marked in GUI as "Equippable"
+        equippableEnabled: new foundry.data.fields.BooleanField({
+            required: true,
+            nullable: false,
+            initial: options.alwaysEquippable ?? false,
+        }),
         equipped: new foundry.data.fields.BooleanField({
             required: true,
             nullable: false,
@@ -53,23 +70,29 @@ function SCHEMA<TOptions extends EquippableMixinOptions>(options: TOptions) {
                 ) as EquipHand[],
             }),
         }),
-    }
-};
+    };
+}
 
-export type EquippableItemDataSchema<TOptions extends EquippableMixinOptions = EquippableMixinOptions> = ReturnType<typeof SCHEMA<TOptions>>;
+export type EquippableItemDataSchema<
+    TOptions extends EquippableMixinOptions = EquippableMixinOptions,
+> = ReturnType<typeof SCHEMA<TOptions>>;
 
 export function EquippableItemMixin<
     TParent extends foundry.abstract.Document.Any,
     TOptions extends EquippableMixinOptions = EquippableMixinOptions,
->(
-    options: TOptions = {} as TOptions,
-) {
+>(options: TOptions = {} as TOptions) {
     return (
-        base: typeof foundry.abstract.TypeDataModel<EquippableItemDataSchema<TOptions>, TParent>,
+        base: typeof foundry.abstract.TypeDataModel<
+            EquippableItemDataSchema<TOptions>,
+            TParent
+        >,
     ) => {
         return class mixin extends base {
             static defineSchema() {
-                return foundry.utils.mergeObject(super.defineSchema(), SCHEMA(options));
+                return foundry.utils.mergeObject(
+                    super.defineSchema(),
+                    SCHEMA(options),
+                );
             }
 
             public prepareDerivedData() {

--- a/src/system/data/item/weapon.ts
+++ b/src/system/data/item/weapon.ts
@@ -103,6 +103,7 @@ export class WeaponItemDataModel extends DataModelMixin<
     }),
     ResourcesItemMixin(),
     EquippableItemMixin({
+        alwaysEquippable: true,
         equipType: {
             initial: EquipType.Hold,
             choices: [EquipType.Hold],

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -304,10 +304,17 @@ export class CosmereItem<
     }
 
     /**
+     * Does this item have equippable data?
+     */
+    public isEquippableItem(): this is EquippableItem {
+        return 'equipped' in this.system;
+    }
+
+    /**
      * Can this item be equipped?
      */
     public isEquippable(): this is EquippableItem {
-        return 'equipped' in this.system;
+        return this.isEquippableItem() && this.system.equippableEnabled;
     }
 
     /**

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -223,6 +223,7 @@ export const enum ItemResourceRechargeType {
 export const enum EquipType {
     Hold = 'hold', // Item that you equip by holding it (either in one or two hands)
     Wear = 'wear', // Item that you equip by wearing it
+    Equip = 'equip', // Item that you equip generically
 }
 
 export const enum HoldType {

--- a/src/system/utils/handlebars/types.ts
+++ b/src/system/utils/handlebars/types.ts
@@ -26,6 +26,7 @@ export interface ItemContext {
 
     isWeapon: boolean;
 
+    isEquippableItem: boolean;
     isEquippable: boolean;
     equipped: boolean;
     equip: Partial<{

--- a/src/templates/actors/components/equipment-list.hbs
+++ b/src/templates/actors/components/equipment-list.hbs
@@ -23,7 +23,7 @@
                     {{/if}}
                 {{/if}}
             </div>
-        </section>        
+        </section>
     </li>
 
     {{#each section.items as |item|}}
@@ -31,13 +31,13 @@
     {{#with (itemContext item) as |ctx|}}
     {{#with (lookup section.itemData item.id) as |data|}}
 
-    <li class="item {{#if ctx.hasActivation}}usable{{/if}} collapsible {{#if state.expanded}}expanded{{/if}}" 
+    <li class="item {{#if ctx.hasActivation}}usable{{/if}} collapsible {{#if state.expanded}}expanded{{/if}}"
         data-item-id="{{item.id}}"
         {{#if @root.editable}}data-drag="true"{{/if}}
     >
         <section class="details">
             {{!-- Image --}}
-            <div class="img" 
+            <div class="img"
                 {{#if ctx.hasActivation}}
                 data-action="use-item"
                 data-tooltip="COSMERE.Actor.Sheet.Actions.Strike"
@@ -104,7 +104,7 @@
                         {{/if}}
                     >
                         <div class="hold-2h {{#if ctx.equipped}}equipped{{/if}}"></div>
-                    </a>                
+                    </a>
                     {{else}}
                     {{!-- One handed item --}}
                     <a role="button"
@@ -117,7 +117,7 @@
                     >
                         <div class="hold-1h main-hand {{#if ctx.equipped}}{{#if (eq ctx.equip.hand 'main_hand')}}equipped{{/if}}{{/if}}"></div>
                         <div class="hold-1h off-hand {{#if ctx.equipped}}{{#if (eq ctx.equip.hand 'off_hand')}}equipped{{/if}}{{/if}}"></div>
-                    </a>                
+                    </a>
                     {{/if}}
 
                 {{else}}
@@ -167,7 +167,7 @@
             <div class="wrapper">
                 {{{default data.descriptionHTML '<p>—</p>'}}}
             </div>
-        </section>        
+        </section>
     </li>
     {{/with}}
     {{/with}}

--- a/src/templates/item/components/details-equip.hbs
+++ b/src/templates/item/components/details-equip.hbs
@@ -1,22 +1,57 @@
-{{#if isEquippable}}
+{{#if isEquippableItem}}
 <fieldset>
     <legend>{{localize "COSMERE.Item.Sheet.Equip.Title"}}</legend>
 
+    {{!-- Is currently equippable --}}
+    {{#if (not alwaysEquippable)}}
+    <div class="form-group">
+        <div class="form-fields">
+            <label>{{localize "COSMERE.Item.Sheet.Equip.IsEquippable"}}</label>
+            <input type="checkbox"
+                name="system.equippableEnabled"
+                {{#if item.system.equippableEnabled}}
+                checked
+                {{/if}}
+                {{#if (not editable)}}
+                readonly
+                {{/if}}
+            >
+        </div>
+    </div>
+    {{/if}}
+
+    {{#if isEquippable}}
+
+    {{!-- Equip type --}}
+    {{#if (not alwaysEquippable)}}
+    <div class="form-group">
+        <div class="form-fields">
+            <label>{{localize "COSMERE.Item.Sheet.Equip.EquipType"}}</label>
+            <select name="system.equip.type" {{#if (not editable)}}disabled{{/if}}>
+                {{selectOptions equipTypes selected=item.system.equip.type localize=true}}
+            </select>
+        </div>
+    </div>
+    {{/if}}
+
     {{!-- Is always equipped --}}
     <div class="form-group">
-        <label>{{localize "COSMERE.Item.Sheet.Equip.AlwaysEquipped"}}</label>
-        <input type="checkbox" 
-            name="system.alwaysEquipped" 
-            {{#if item.system.alwaysEquipped}}
-            checked
-            {{/if}}
-            {{#if (not editable)}}
-            readonly
-            {{/if}}
-        >
+        <div class="form-fields">
+            <label>{{localize "COSMERE.Item.Sheet.Equip.AlwaysEquipped"}}</label>
+            <input type="checkbox"
+                name="system.alwaysEquipped"
+                {{#if item.system.alwaysEquipped}}
+                checked
+                {{/if}}
+                {{#if (not editable)}}
+                readonly
+                {{/if}}
+            >
+        </div>
     </div>
 
     {{!-- Traits --}}
+    {{#if hasTraits}}
     <div class="form-group-stacked collapsible {{#unless normalTraitsCollapsed}}expanded{{/unless}}">
         <div class="header" data-action="toggle-traits-collapsed" data-trait="normal">
             <label>{{localize "COSMERE.Item.Sheet.Equip.Traits"}}</label>
@@ -32,8 +67,8 @@
                 <div class="traits-list">
                     {{#each normalTraits as |trait|}}
                     <div class="trait">
-                        <input type="checkbox" 
-                            name="{{concat "system.traits." trait.id ".defaultActive"}}" 
+                        <input type="checkbox"
+                            name="{{concat "system.traits." trait.id ".defaultActive"}}"
                             {{#if trait.active}}
                             checked
                             {{/if}}
@@ -43,11 +78,11 @@
                         >
                         <label>{{localize trait.label}}</label>
                         {{#if trait.hasValue}}
-                        <input 
+                        <input
                             class="trait-value"
-                            name="{{concat "system.traits." trait.id ".defaultValue"}}" 
+                            name="{{concat "system.traits." trait.id ".defaultValue"}}"
                             {{#if trait.active}}
-                            type="number" 
+                            type="number"
                             min="0"
                             value="{{trait.value}}"
                             {{else}}
@@ -76,17 +111,17 @@
                     <i class="fa-solid fa-chevron-down"></i>
                 </a>
             </div>
-        </div>        
+        </div>
         <div class="collapsible-content">
             <div class="wrapper">
                 <div class="traits-list">
                     {{#each expertTraits as |trait|}}
                     <div class="trait">
-                        <input type="checkbox" 
+                        <input type="checkbox"
                             {{#if (eq trait.type "modify-trait-value")}}
                             name="{{concat "system.traits." trait.id ".expertise.modifyValue"}}"
                             {{else}}
-                            name="{{concat "system.traits." trait.id ".expertise.toggleActive"}}" 
+                            name="{{concat "system.traits." trait.id ".expertise.toggleActive"}}"
                             {{/if}}
                             {{#if trait.active}}
                             checked
@@ -97,11 +132,11 @@
                         >
                         <label>{{localize trait.label}}</label>
                         {{#if (eq trait.type "modify-trait-value")}}
-                        <input 
+                        <input
                             class="trait-value"
-                            name="{{concat "system.traits." trait.id ".expertise.value"}}" 
+                            name="{{concat "system.traits." trait.id ".expertise.value"}}"
                             {{#if trait.active}}
-                            type="number" 
+                            type="number"
                             min="0"
                             value="{{trait.value}}"
                             {{else}}
@@ -119,5 +154,8 @@
             </div>
         </div>
     </div>
-</fieldset>    
+    {{/if}}
+
+    {{/if}}
+</fieldset>
 {{/if}}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR makes all equipment items have "equippable" data, and changes the equippable mixin to take in an "AlwaysEquippable" boolean parameter. If "AlwaysEquippable" is true, the display will not include any options to toggle the "equippable" property, or how the item is equipped (e.g. worn, held, etc.)

**Related Issue**  
Closes #710 

**How Has This Been Tested?**  
Opened an existing weapon, verified that none of the display has changed
Created a new weapon, verified the display is identical
Opened an existing armor, verified that none of the display has changed
Created a new armor, verified the display is identical
Opened an existing equipment item, verified that it now includes the optional "Equippable" data
Created a new equipment item, verified that it now includes the optional "Equippable" data
Added an "Equipped" triggered event handler, verified functionality
Added an "Unequipped" triggered event handler, verified functionality

**Screenshots (if applicable)**  
Character sheet equipment list, with "Alcohol" and "New Equipment" marked as equippable
<img width="545" height="526" alt="image" src="https://github.com/user-attachments/assets/3ab51d71-4dd1-45ea-8142-37cc25f3797a" />

Existing weapon: 
<img width="544" height="563" alt="image" src="https://github.com/user-attachments/assets/90c12d12-7db8-417e-b0fd-4b5b1b874b3c" />

New weapon: 
<img width="545" height="567" alt="image" src="https://github.com/user-attachments/assets/d9449a2a-3ebf-44c5-b60e-0bb7e7d93f5e" />

Existing armor:
<img width="545" height="518" alt="image" src="https://github.com/user-attachments/assets/fef19772-4282-4fe1-b51d-9f3f9dad65ad" />

New armor:
<img width="549" height="518" alt="image" src="https://github.com/user-attachments/assets/3d9e2517-fbf7-4e07-92dc-4612e3d09559" />

Existing equipment:
<img width="545" height="315" alt="image" src="https://github.com/user-attachments/assets/e9ba9b89-b2e8-490c-ba40-6c20c0448bde" />

Existing equipment: (Equippable)
<img width="545" height="384" alt="image" src="https://github.com/user-attachments/assets/85ecff13-0687-4c17-807e-8ff0352c1b42" />

New equipment:
<img width="545" height="315" alt="image" src="https://github.com/user-attachments/assets/5f1c7583-b9ae-44e4-b7e6-6a5663bbeac7" />

New Equipment: (Equippable)
<img width="545" height="385" alt="image" src="https://github.com/user-attachments/assets/73d034cb-59bc-49e3-b9bb-344d082df03a" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 351.

**Additional context**  
This is mutually exclusive with the "Generic equippable item" PR, and I think this is a better solution.