### PR TITLE
fix: Adversary Action/Equipment sections not collapsible

### DIFF
--- a/src/system/applications/actor/components/adversary/actions-list.ts
+++ b/src/system/applications/actor/components/adversary/actions-list.ts
@@ -137,6 +137,9 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
             .filter(section.filter)
             .filter((i) => i.name.toLowerCase().includes(searchText));
 
+        // Prepare "Is section empty" data
+        this.sectionState[section.id].hasItems = sectionItems.length > 0;
+
         if (sort === SortMode.Alphabetic) {
             sectionItems = sectionItems.sort(
                 (a, b) => a.name.compare(b.name) * -1,


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes Adversary action/equipment sections having wrong styling and being non-collapsible.

**Related Issue**  
Closes #715 

**How Has This Been Tested?**  
Opened an adversary sheet, observed that the sections were collapsible. Observed that broken styling has disappeared.

**Screenshots (if applicable)**  
<img width="795" height="775" alt="image" src="https://github.com/user-attachments/assets/4ab5517e-a4a1-49bf-aed4-908b66cd42f4" />


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351.
