### PR TITLE
Feat: Move Erudition Talent Macro

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1398,6 +1398,23 @@
         },
         "Migration": {
             "DocumentMigrationFailed": "Failed to migrate {type} \"{name}\". {error}"
+        },
+        "Macro": {
+            "Talents": {
+                "Erudition": {
+                    "Dialog": {
+                        "Title": "{actor}: Erudition",
+                        "Skills": "Skills",
+                        "Expertises": "Expertises",
+                        "Expertise": "Expertise",
+                        "Warn": {
+                            "UniqueSkills": "Cannot select the same skill multiple times.",
+                            "UniqueExpertises": "Cannot select the same expertise multiple times."
+                        },
+                        "Confirm": "Confirm"
+                    }
+                }
+            }
         }
     },
     "DICE": {

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -11,6 +11,7 @@ import {
     Size,
     RestType,
     ImmunityType,
+    AttributeGroup,
 } from '@system/types/cosmere';
 import { Talent, TalentTree } from '@system/types/item';
 import {
@@ -56,6 +57,7 @@ import { containsExpertise } from '@system/utils/actor';
 import { SYSTEM_ID } from '@system/constants';
 import { HOOKS } from '@system/constants/hooks';
 import { AnyObject } from '@league-of-foundry-developers/foundry-vtt-types/utils';
+import { FLAGS } from '@system/utils/macros/talents/erudition';
 
 export type CharacterActor = CosmereActor<ActorType.Character>;
 export type AdversaryActor = CosmereActor<ActorType.Adversary>;
@@ -1431,6 +1433,14 @@ declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
                 'goals.hide-completed': boolean;
                 [key: `meta.update.mode.${string}`]: string;
                 [key: `mode.${string}`]: string;
+                [FLAGS.SKILLS_COUNT]: number;
+                [FLAGS.SKILLS_GROUPS]: AttributeGroup[];
+                [FLAGS.SKILLS_INCREASE]: number;
+                [FLAGS.SKILLS_SELECTED]: Skill[];
+                [FLAGS.EXPERTISES_COUNT]: number;
+                [FLAGS.EXPERTISES_TYPES]: ExpertiseType[];
+                [FLAGS.EXPERTISES_SELECTED]: Expertise[];
+                [key: `skills.${string}.temporaryRanks`]: number;
             };
         };
 

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -1436,7 +1436,10 @@ declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
 
                 /**
                  * The following keys belong to the Erudition macro
-                 * they were ported over from the Stormlight Handbook as is
+                 * they were ported over from the Stormlight Handbook as is.
+                 * Declaring them in erudition/index.ts was not allowing the Actor
+                 * definition to be merged and a proper way to merge them will need
+                 * to be researched to make this cleaner
                  */
                 [FLAGS.SKILLS_COUNT]: number;
                 [FLAGS.SKILLS_GROUPS]: AttributeGroup[];

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -1433,6 +1433,11 @@ declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
                 'goals.hide-completed': boolean;
                 [key: `meta.update.mode.${string}`]: string;
                 [key: `mode.${string}`]: string;
+
+                /**
+                 * The following keys belong to the Erudition macro
+                 * they were ported over from the Stormlight Handbook as is
+                 */
                 [FLAGS.SKILLS_COUNT]: number;
                 [FLAGS.SKILLS_GROUPS]: AttributeGroup[];
                 [FLAGS.SKILLS_INCREASE]: number;

--- a/src/system/utils/macros/index.ts
+++ b/src/system/utils/macros/index.ts
@@ -1,1 +1,2 @@
 export * as startingPath from './starting-path';
+export * as talents from './talents';

--- a/src/system/utils/macros/talents/erudition/dialog.ts
+++ b/src/system/utils/macros/talents/erudition/dialog.ts
@@ -4,6 +4,7 @@ import { EruditionConfig, EruditionSelections, PickedExpertise } from './types';
 import { Expertise } from '@src/system/data/actor/common';
 import { ExpertiseType, Skill } from '@src/system/types/cosmere';
 import { AnyObject } from '@league-of-foundry-developers/foundry-vtt-types/utils';
+import { SYSTEM_ID } from '@src/system/constants';
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -41,7 +42,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(
 
     static PARTS = {
         form: {
-            template: `modules/cosmere-rpg-stormlight-handbook/templates/dialogs/erudition.hbs`,
+            template: `systems/${SYSTEM_ID}/templates/general/dialogs/erudition.hbs`,
             forms: {
                 form: {
                     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/system/utils/macros/talents/erudition/dialog.ts
+++ b/src/system/utils/macros/talents/erudition/dialog.ts
@@ -1,5 +1,9 @@
 // Types
+import { CosmereActor } from '@src/system/documents/actor';
 import { EruditionConfig, EruditionSelections, PickedExpertise } from './types';
+import { Expertise } from '@src/system/data/actor/common';
+import { ExpertiseType, Skill } from '@src/system/types/cosmere';
+import { AnyObject } from '@league-of-foundry-developers/foundry-vtt-types/utils';
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -10,16 +14,16 @@ export interface EruditionDialogConfig {
 }
 
 interface EruditionDialogSelections {
-    skills: string[];
+    skills: Skill[];
     expertises: PickedExpertise[];
 }
 
 interface FormDataObject {
-    skills: { [index: string]: string };
-    expertises: { [index: string]: { type: string, id: string, label?: string } };
+    skills: Skill;
+    expertises: Record<ExpertiseType, Expertise>;
 }
 
-export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2)<any> {
+export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2)<AnyObject> {
     static DEFAULT_OPTIONS = {
         window: {
             minimizable: false,
@@ -80,7 +84,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         const selections: EruditionDialogSelections = {
             skills: config.selected.skills,
             expertises: config.selected.expertises
-                .map(exp => config.actor.system.expertises?.[exp])
+                .map(exp => config.actor.system.expertises?.[exp.id] as Expertise)
                 .filter(Boolean)
                 .map(exp => ({
                     type: exp!.type,
@@ -110,7 +114,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         formData: FormDataExtended,
     ) {
         const data = foundry.utils.expandObject(formData.object) as FormDataObject;
-        const skills = Object.values(data.skills);
+        const skills = Object.values(data.skills) as Skill[];
         const expertises = Object.values(data.expertises || {})
             .map(exp => ({
                 type: exp.type,
@@ -123,7 +127,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         // For each expertise, ensure the id is set correctly
         for (const exp of expertises.filter(exp => !exp.custom)) {
              // Look up the configured expertises for the type
-            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type].configRegistryKey;
+            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type].configRegistryKey as PropertyKey;
             const configuredExpertises = foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {};
 
             if (!foundry.utils.hasProperty(configuredExpertises, exp.id)) {
@@ -136,7 +140,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         // For each custom expertise, ensure it is valid
         for (const exp of expertises.filter(exp => exp.custom)) {
             // Look up the configured expertises for the type
-            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type].configRegistryKey;
+            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type].configRegistryKey as PropertyKey;
             const configuredExpertises = foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {};
 
             if (foundry.utils.hasProperty(configuredExpertises, exp.trueId)) {
@@ -148,7 +152,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         if (!(event instanceof SubmitEvent)) {
             // assign the skills and expertises to the selections
             this.selections.skills = skills;
-            this.selections.expertises = expertises;
+            this.selections.expertises = expertises as PickedExpertise[];
 
             // Re-render the dialog
             void this.render(true);
@@ -176,7 +180,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
                     label: exp.custom ? exp.label : undefined,
                     custom: exp.custom,
                     locked: true
-                }))
+                } as PickedExpertise))
             });
 
             // Mark submitted 
@@ -189,7 +193,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
 
     /* --- Lifecycle --- */
 
-    protected async _onRender(context: any, options: any) {
+    protected async _onRender(context: AnyObject, options: AnyObject) {
         await super._onRender(context, options);
 
         $(this.element).prop('open', true);
@@ -202,6 +206,8 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
 
     /* --- Context --- */
 
+    // Disabled this rule because AnyObject is not allowed to be passed to super._prepareContext
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     protected async _prepareContext(options: any) {
         return {
             ...(await super._prepareContext(options)),
@@ -209,7 +215,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
             config: this.config,
             selections: this.selections,
             skillSelectOptions: this.availableSkills.reduce((acc, skillId) => {
-                const skillConfig = CONFIG.COSMERE.skills[skillId];
+                const skillConfig = CONFIG.COSMERE.skills[skillId as Skill];
                 return {
                     ...acc,
                     [skillId]: skillConfig.label
@@ -225,10 +231,10 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
             }, {}),
             expertiseIdSelectOptionsByType: this.config.expertises.types.reduce((acc, type) => {
                 const expertiseTypeConfig = CONFIG.COSMERE.expertiseTypes[type];
-                const registryKey = expertiseTypeConfig.configRegistryKey;
+                const registryKey = expertiseTypeConfig.configRegistryKey  as PropertyKey;
 
                 // Look up the expertises registered for this type
-                const expertises = (foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {}) as Record<string, any>;
+                const expertises = (foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {}) as Record<string, Expertise>;
                 const selectOptions = {
                     ...Object.entries(expertises)
                         .filter(([id]) => !this.actor.hasExpertise(type, id) || this.selections.expertises.some(exp => exp.id === id && exp.type === type))

--- a/src/system/utils/macros/talents/erudition/dialog.ts
+++ b/src/system/utils/macros/talents/erudition/dialog.ts
@@ -94,7 +94,9 @@ export class EruditionDialog extends HandlebarsApplicationMixin(
             expertises: config.selected.expertises
                 .map(
                     (exp) =>
-                        config.actor.system.expertises?.[exp.id] as Expertise,
+                        config.actor.system.expertises?.[
+                            `${exp.type}:${exp.id}`
+                        ] as Expertise,
                 )
                 .filter(Boolean)
                 .map((exp) => ({

--- a/src/system/utils/macros/talents/erudition/dialog.ts
+++ b/src/system/utils/macros/talents/erudition/dialog.ts
@@ -1,0 +1,254 @@
+// Types
+import { EruditionConfig, EruditionSelections, PickedExpertise } from './types';
+
+const { HandlebarsApplicationMixin } = foundry.applications.api;
+
+export interface EruditionDialogConfig {
+    actor: CosmereActor;
+    config: EruditionConfig;
+    selected: EruditionSelections;
+}
+
+interface EruditionDialogSelections {
+    skills: string[];
+    expertises: PickedExpertise[];
+}
+
+interface FormDataObject {
+    skills: { [index: string]: string };
+    expertises: { [index: string]: { type: string, id: string, label?: string } };
+}
+
+export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2)<any> {
+    static DEFAULT_OPTIONS = {
+        window: {
+            minimizable: false,
+            resizable: false,
+            positioned: true,
+        },
+        classes: ['dialog', 'erudition'],
+        tag: 'dialog',
+        position: {
+            width: 500,
+        }
+    };
+
+    static PARTS = {
+        'form': {
+            template: `modules/cosmere-rpg-stormlight-handbook/templates/dialogs/erudition.hbs`,
+            forms: {
+                form: {
+                    handler: this.onFormEvent,
+                    submitOnChange: true,
+                    closeOnSubmit: false,
+                },
+            },
+        },
+    };
+
+    private submitted = false;
+
+    private availableSkills: string[] = [];
+
+    private constructor(
+        private actor: CosmereActor,
+        private config: EruditionConfig,
+        private selections: EruditionDialogSelections,
+        private resolve: (selections: EruditionDialogSelections | null) => void,
+    ) {
+        super({
+            id: `${actor.uuid}.talent.erudition.dialog`,
+            window: {
+                title: game.i18n!.format(
+                    'COSMERE.Macro.Talents.Erudition.Dialog.Title',
+                    {
+                        actor: actor.name,
+                    }
+                )
+            }
+        });
+
+        const attributeGroups = this.config.skills.groups;
+        const attributes = attributeGroups.flatMap(group => CONFIG.COSMERE.attributeGroups[group]?.attributes || []);
+        this.availableSkills = attributes.flatMap(attrId => CONFIG.COSMERE.attributes[attrId].skills || [])
+            .filter(skill => CONFIG.COSMERE.skills[skill]?.core);
+    }
+
+    /* --- Statics --- */
+
+    public static show(config: EruditionDialogConfig): Promise<EruditionDialogSelections | null> {
+        const selections: EruditionDialogSelections = {
+            skills: config.selected.skills,
+            expertises: config.selected.expertises
+                .map(exp => config.actor.system.expertises?.[exp])
+                .filter(Boolean)
+                .map(exp => ({
+                    type: exp!.type,
+                    id: exp!.id,
+                    label: exp!.label,
+                    custom: exp!.isCustom,
+                })) as PickedExpertise[]
+        };
+
+        return new Promise((resolve) => {
+            const dialog = new EruditionDialog(
+                config.actor,
+                foundry.utils.deepClone(config.config),
+                foundry.utils.deepClone(selections),
+                resolve
+            );
+            void dialog.render(true);
+        });
+    }
+
+    /* --- Form --- */
+
+    private static onFormEvent(
+        this: EruditionDialog,
+        event: Event,
+        form: HTMLFormElement,
+        formData: FormDataExtended,
+    ) {
+        const data = foundry.utils.expandObject(formData.object) as FormDataObject;
+        const skills = Object.values(data.skills);
+        const expertises = Object.values(data.expertises || {})
+            .map(exp => ({
+                type: exp.type,
+                id: exp.id, // Either the id or 'custom' for custom expertises
+                label: exp.label,
+                custom: exp.id === 'custom',
+                trueId: exp.id !== 'custom' ? exp.id : exp.label?.toLowerCase() ?? '<custom>'
+            }));
+
+        // For each expertise, ensure the id is set correctly
+        for (const exp of expertises.filter(exp => !exp.custom)) {
+             // Look up the configured expertises for the type
+            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type].configRegistryKey;
+            const configuredExpertises = foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {};
+
+            if (!foundry.utils.hasProperty(configuredExpertises, exp.id)) {
+                exp.custom = true; // Mark as custom if the id is not found
+                exp.id = 'custom';
+                exp.trueId = exp.label?.toLowerCase() ?? '<custom>';
+            }
+        }
+
+        // For each custom expertise, ensure it is valid
+        for (const exp of expertises.filter(exp => exp.custom)) {
+            // Look up the configured expertises for the type
+            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type].configRegistryKey;
+            const configuredExpertises = foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {};
+
+            if (foundry.utils.hasProperty(configuredExpertises, exp.trueId)) {
+                exp.id = exp.trueId;
+                exp.custom = false; // Mark as not custom anymore
+            }
+        }
+
+        if (!(event instanceof SubmitEvent)) {
+            // assign the skills and expertises to the selections
+            this.selections.skills = skills;
+            this.selections.expertises = expertises;
+
+            // Re-render the dialog
+            void this.render(true);
+        } else {
+            // Ensure the skills are unique
+            const uniqueSkills = new Set(skills);
+            if (uniqueSkills.size !== skills.length) {
+                ui.notifications.warn(game.i18n!.localize('COSMERE.Macro.Talents.Erudition.Dialog.Warn.UniqueSkills'));
+                return;
+            }
+
+            // Ensure the expertises are unique
+            const uniqueExpertises = new Set(expertises.map(exp => `${exp.type}:${exp.trueId}`));
+            if (uniqueExpertises.size !== expertises.length) {
+                ui.notifications.warn(game.i18n!.localize('COSMERE.Macro.Talents.Erudition.Dialog.Warn.UniqueExpertises'));
+                return;
+            }
+
+            // Resolve
+            this.resolve({
+                skills: skills,
+                expertises: expertises.map(exp => ({
+                    id: exp.custom ? exp.trueId : exp.id,
+                    type: exp.type,
+                    label: exp.custom ? exp.label : undefined,
+                    custom: exp.custom,
+                    locked: true
+                }))
+            });
+
+            // Mark submitted 
+            this.submitted = true;
+
+            // Close
+            void this.close();
+        }
+    }
+
+    /* --- Lifecycle --- */
+
+    protected async _onRender(context: any, options: any) {
+        await super._onRender(context, options);
+
+        $(this.element).prop('open', true);
+    }
+
+    protected _onClose() {
+        if (!this.submitted)
+            this.resolve(null);
+    }
+
+    /* --- Context --- */
+
+    protected async _prepareContext(options: any) {
+        return {
+            ...(await super._prepareContext(options)),
+            actor: this.actor,
+            config: this.config,
+            selections: this.selections,
+            skillSelectOptions: this.availableSkills.reduce((acc, skillId) => {
+                const skillConfig = CONFIG.COSMERE.skills[skillId];
+                return {
+                    ...acc,
+                    [skillId]: skillConfig.label
+                }
+            }, {}),
+            expertiseTypeSelectOptions: this.config.expertises.types.reduce((acc, type) => {
+                const expertiseTypeConfig = CONFIG.COSMERE.expertiseTypes[type];
+
+                return {
+                    ...acc,
+                    [type]: expertiseTypeConfig.label
+                };
+            }, {}),
+            expertiseIdSelectOptionsByType: this.config.expertises.types.reduce((acc, type) => {
+                const expertiseTypeConfig = CONFIG.COSMERE.expertiseTypes[type];
+                const registryKey = expertiseTypeConfig.configRegistryKey;
+
+                // Look up the expertises registered for this type
+                const expertises = (foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {}) as Record<string, any>;
+                const selectOptions = {
+                    ...Object.entries(expertises)
+                        .filter(([id]) => !this.actor.hasExpertise(type, id) || this.selections.expertises.some(exp => exp.id === id && exp.type === type))
+                        .reduce((acc, [id, expConfig]) => {
+                            return {
+                                ...acc,
+                                [id]: expConfig.label || id
+                            };
+                        }, {}),
+                    'custom': 'GENERIC.Custom'
+                };
+
+                return {
+                    ...acc,
+                    [type]: selectOptions
+                };
+            }, {}),
+            defaultExpertise: {
+                type: this.config.expertises.types[0],
+            },
+        };
+    }
+}

--- a/src/system/utils/macros/talents/erudition/dialog.ts
+++ b/src/system/utils/macros/talents/erudition/dialog.ts
@@ -23,7 +23,9 @@ interface FormDataObject {
     expertises: Record<ExpertiseType, Expertise>;
 }
 
-export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2)<AnyObject> {
+export class EruditionDialog extends HandlebarsApplicationMixin(
+    foundry.applications.api.ApplicationV2,
+)<AnyObject> {
     static DEFAULT_OPTIONS = {
         window: {
             minimizable: false,
@@ -34,14 +36,15 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         tag: 'dialog',
         position: {
             width: 500,
-        }
+        },
     };
 
     static PARTS = {
-        'form': {
+        form: {
             template: `modules/cosmere-rpg-stormlight-handbook/templates/dialogs/erudition.hbs`,
             forms: {
                 form: {
+                    // eslint-disable-next-line @typescript-eslint/unbound-method
                     handler: this.onFormEvent,
                     submitOnChange: true,
                     closeOnSubmit: false,
@@ -63,35 +66,43 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         super({
             id: `${actor.uuid}.talent.erudition.dialog`,
             window: {
-                title: game.i18n!.format(
+                title: game.i18n.format(
                     'COSMERE.Macro.Talents.Erudition.Dialog.Title',
                     {
                         actor: actor.name,
-                    }
-                )
-            }
+                    },
+                ),
+            },
         });
 
         const attributeGroups = this.config.skills.groups;
-        const attributes = attributeGroups.flatMap(group => CONFIG.COSMERE.attributeGroups[group]?.attributes || []);
-        this.availableSkills = attributes.flatMap(attrId => CONFIG.COSMERE.attributes[attrId].skills || [])
-            .filter(skill => CONFIG.COSMERE.skills[skill]?.core);
+        const attributes = attributeGroups.flatMap(
+            (group) => CONFIG.COSMERE.attributeGroups[group]?.attributes || [],
+        );
+        this.availableSkills = attributes
+            .flatMap((attrId) => CONFIG.COSMERE.attributes[attrId].skills || [])
+            .filter((skill) => CONFIG.COSMERE.skills[skill]?.core);
     }
 
     /* --- Statics --- */
 
-    public static show(config: EruditionDialogConfig): Promise<EruditionDialogSelections | null> {
+    public static show(
+        config: EruditionDialogConfig,
+    ): Promise<EruditionDialogSelections | null> {
         const selections: EruditionDialogSelections = {
             skills: config.selected.skills,
             expertises: config.selected.expertises
-                .map(exp => config.actor.system.expertises?.[exp.id] as Expertise)
+                .map(
+                    (exp) =>
+                        config.actor.system.expertises?.[exp.id] as Expertise,
+                )
                 .filter(Boolean)
-                .map(exp => ({
-                    type: exp!.type,
-                    id: exp!.id,
-                    label: exp!.label,
-                    custom: exp!.isCustom,
-                })) as PickedExpertise[]
+                .map((exp) => ({
+                    type: exp.type,
+                    id: exp.id,
+                    label: exp.label,
+                    custom: exp.isCustom,
+                })) as PickedExpertise[],
         };
 
         return new Promise((resolve) => {
@@ -99,7 +110,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
                 config.actor,
                 foundry.utils.deepClone(config.config),
                 foundry.utils.deepClone(selections),
-                resolve
+                resolve,
             );
             void dialog.render(true);
         });
@@ -113,22 +124,28 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         form: HTMLFormElement,
         formData: FormDataExtended,
     ) {
-        const data = foundry.utils.expandObject(formData.object) as FormDataObject;
+        const data = foundry.utils.expandObject(
+            formData.object,
+        ) as FormDataObject;
         const skills = Object.values(data.skills) as Skill[];
-        const expertises = Object.values(data.expertises || {})
-            .map(exp => ({
-                type: exp.type,
-                id: exp.id, // Either the id or 'custom' for custom expertises
-                label: exp.label,
-                custom: exp.id === 'custom',
-                trueId: exp.id !== 'custom' ? exp.id : exp.label?.toLowerCase() ?? '<custom>'
-            }));
+        const expertises = Object.values(data.expertises || {}).map((exp) => ({
+            type: exp.type,
+            id: exp.id, // Either the id or 'custom' for custom expertises
+            label: exp.label,
+            custom: exp.id === 'custom',
+            trueId:
+                exp.id !== 'custom'
+                    ? exp.id
+                    : (exp.label?.toLowerCase() ?? '<custom>'),
+        }));
 
         // For each expertise, ensure the id is set correctly
-        for (const exp of expertises.filter(exp => !exp.custom)) {
-             // Look up the configured expertises for the type
-            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type].configRegistryKey as PropertyKey;
-            const configuredExpertises = foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {};
+        for (const exp of expertises.filter((exp) => !exp.custom)) {
+            // Look up the configured expertises for the type
+            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type]
+                .configRegistryKey as PropertyKey;
+            const configuredExpertises =
+                foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {};
 
             if (!foundry.utils.hasProperty(configuredExpertises, exp.id)) {
                 exp.custom = true; // Mark as custom if the id is not found
@@ -138,10 +155,12 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
         }
 
         // For each custom expertise, ensure it is valid
-        for (const exp of expertises.filter(exp => exp.custom)) {
+        for (const exp of expertises.filter((exp) => exp.custom)) {
             // Look up the configured expertises for the type
-            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type].configRegistryKey as PropertyKey;
-            const configuredExpertises = foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {};
+            const registryKey = CONFIG.COSMERE.expertiseTypes[exp.type]
+                .configRegistryKey as PropertyKey;
+            const configuredExpertises =
+                foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {};
 
             if (foundry.utils.hasProperty(configuredExpertises, exp.trueId)) {
                 exp.id = exp.trueId;
@@ -160,30 +179,43 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
             // Ensure the skills are unique
             const uniqueSkills = new Set(skills);
             if (uniqueSkills.size !== skills.length) {
-                ui.notifications.warn(game.i18n!.localize('COSMERE.Macro.Talents.Erudition.Dialog.Warn.UniqueSkills'));
+                ui.notifications.warn(
+                    game.i18n.localize(
+                        'COSMERE.Macro.Talents.Erudition.Dialog.Warn.UniqueSkills',
+                    ),
+                );
                 return;
             }
 
             // Ensure the expertises are unique
-            const uniqueExpertises = new Set(expertises.map(exp => `${exp.type}:${exp.trueId}`));
+            const uniqueExpertises = new Set(
+                expertises.map((exp) => `${exp.type}:${exp.trueId}`),
+            );
             if (uniqueExpertises.size !== expertises.length) {
-                ui.notifications.warn(game.i18n!.localize('COSMERE.Macro.Talents.Erudition.Dialog.Warn.UniqueExpertises'));
+                ui.notifications.warn(
+                    game.i18n.localize(
+                        'COSMERE.Macro.Talents.Erudition.Dialog.Warn.UniqueExpertises',
+                    ),
+                );
                 return;
             }
 
             // Resolve
             this.resolve({
                 skills: skills,
-                expertises: expertises.map(exp => ({
-                    id: exp.custom ? exp.trueId : exp.id,
-                    type: exp.type,
-                    label: exp.custom ? exp.label : undefined,
-                    custom: exp.custom,
-                    locked: true
-                } as PickedExpertise))
+                expertises: expertises.map(
+                    (exp) =>
+                        ({
+                            id: exp.custom ? exp.trueId : exp.id,
+                            type: exp.type,
+                            label: exp.custom ? exp.label : undefined,
+                            custom: exp.custom,
+                            locked: true,
+                        }) as PickedExpertise,
+                ),
             });
 
-            // Mark submitted 
+            // Mark submitted
             this.submitted = true;
 
             // Close
@@ -200,8 +232,7 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
     }
 
     protected _onClose() {
-        if (!this.submitted)
-            this.resolve(null);
+        if (!this.submitted) this.resolve(null);
     }
 
     /* --- Context --- */
@@ -218,40 +249,59 @@ export class EruditionDialog extends HandlebarsApplicationMixin(foundry.applicat
                 const skillConfig = CONFIG.COSMERE.skills[skillId as Skill];
                 return {
                     ...acc,
-                    [skillId]: skillConfig.label
-                }
-            }, {}),
-            expertiseTypeSelectOptions: this.config.expertises.types.reduce((acc, type) => {
-                const expertiseTypeConfig = CONFIG.COSMERE.expertiseTypes[type];
-
-                return {
-                    ...acc,
-                    [type]: expertiseTypeConfig.label
+                    [skillId]: skillConfig.label,
                 };
             }, {}),
-            expertiseIdSelectOptionsByType: this.config.expertises.types.reduce((acc, type) => {
-                const expertiseTypeConfig = CONFIG.COSMERE.expertiseTypes[type];
-                const registryKey = expertiseTypeConfig.configRegistryKey  as PropertyKey;
+            expertiseTypeSelectOptions: this.config.expertises.types.reduce(
+                (acc, type) => {
+                    const expertiseTypeConfig =
+                        CONFIG.COSMERE.expertiseTypes[type];
 
-                // Look up the expertises registered for this type
-                const expertises = (foundry.utils.getProperty(CONFIG.COSMERE, registryKey) || {}) as Record<string, Expertise>;
-                const selectOptions = {
-                    ...Object.entries(expertises)
-                        .filter(([id]) => !this.actor.hasExpertise(type, id) || this.selections.expertises.some(exp => exp.id === id && exp.type === type))
-                        .reduce((acc, [id, expConfig]) => {
-                            return {
-                                ...acc,
-                                [id]: expConfig.label || id
-                            };
-                        }, {}),
-                    'custom': 'GENERIC.Custom'
-                };
+                    return {
+                        ...acc,
+                        [type]: expertiseTypeConfig.label,
+                    };
+                },
+                {},
+            ),
+            expertiseIdSelectOptionsByType: this.config.expertises.types.reduce(
+                (acc, type) => {
+                    const expertiseTypeConfig =
+                        CONFIG.COSMERE.expertiseTypes[type];
+                    const registryKey =
+                        expertiseTypeConfig.configRegistryKey as PropertyKey;
 
-                return {
-                    ...acc,
-                    [type]: selectOptions
-                };
-            }, {}),
+                    // Look up the expertises registered for this type
+                    const expertises = (foundry.utils.getProperty(
+                        CONFIG.COSMERE,
+                        registryKey,
+                    ) || {}) as Record<string, Expertise>;
+                    const selectOptions = {
+                        ...Object.entries(expertises)
+                            .filter(
+                                ([id]) =>
+                                    !this.actor.hasExpertise(type, id) ||
+                                    this.selections.expertises.some(
+                                        (exp) =>
+                                            exp.id === id && exp.type === type,
+                                    ),
+                            )
+                            .reduce((acc, [id, expConfig]) => {
+                                return {
+                                    ...acc,
+                                    [id]: expConfig.label ?? id,
+                                };
+                            }, {}),
+                        custom: 'GENERIC.Custom',
+                    };
+
+                    return {
+                        ...acc,
+                        [type]: selectOptions,
+                    };
+                },
+                {},
+            ),
             defaultExpertise: {
                 type: this.config.expertises.types[0],
             },

--- a/src/system/utils/macros/talents/erudition/index.ts
+++ b/src/system/utils/macros/talents/erudition/index.ts
@@ -8,7 +8,7 @@ import { EruditionConfig, EruditionSelections, PickedExpertise } from './types';
 import { SYSTEM_ID } from '@module/constants';
 
 // Define constants for flag keys
-const FLAGS = {
+export const FLAGS = {
     SKILLS_COUNT: "talent.erudition.skills.count",
     SKILLS_GROUPS: "talent.erudition.skills.groups",
     SKILLS_INCREASE: "talent.erudition.skills.increase",
@@ -292,21 +292,4 @@ function deselectExpertise(actor: CosmereActor, compositeId: string) {
         [`flags.${SYSTEM_ID}.${FLAGS.EXPERTISES_SELECTED}`]: updatedExpertises,
         [`system.expertises.-=${compositeId}`]: {}
     });
-}
-
-declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
-    interface FlagConfig {
-        Actor: {
-            [SYSTEM_ID]: {
-                [FLAGS.SKILLS_COUNT]: number;
-                [FLAGS.SKILLS_GROUPS]: string[];
-                [FLAGS.SKILLS_INCREASE]: number;
-                [FLAGS.SKILLS_SELECTED]: string[];
-                [FLAGS.EXPERTISES_COUNT]: number;
-                [FLAGS.EXPERTISES_TYPES]: string[];
-                [FLAGS.EXPERTISES_SELECTED]: string[];
-                [key: `skills.${string}.temporaryRanks`]: number;
-            };
-        };
-    }
 }

--- a/src/system/utils/macros/talents/erudition/index.ts
+++ b/src/system/utils/macros/talents/erudition/index.ts
@@ -5,28 +5,31 @@ import { EruditionDialog } from './dialog';
 // Types
 import { EruditionConfig, EruditionSelections, PickedExpertise } from './types';
 import { CosmereActor } from '@src/system/documents';
-import { AttributeGroup, ExpertiseType, Skill } from '@src/system/types/cosmere';
+import {
+    AttributeGroup,
+    ExpertiseType,
+    Skill,
+} from '@src/system/types/cosmere';
 
 // Constants
 import { SYSTEM_ID } from '@system/constants';
 
 // Define constants for flag keys
 export const FLAGS = {
-    SKILLS_COUNT: "talent.erudition.skills.count",
-    SKILLS_GROUPS: "talent.erudition.skills.groups",
-    SKILLS_INCREASE: "talent.erudition.skills.increase",
-    SKILLS_SELECTED: "talent.erudition.skills.selected",
-    EXPERTISES_COUNT: "talent.erudition.expertises.count",
-    EXPERTISES_TYPES: "talent.erudition.expertises.types",
-    EXPERTISES_SELECTED: "talent.erudition.expertises.selected",
+    SKILLS_COUNT: 'talent.erudition.skills.count',
+    SKILLS_GROUPS: 'talent.erudition.skills.groups',
+    SKILLS_INCREASE: 'talent.erudition.skills.increase',
+    SKILLS_SELECTED: 'talent.erudition.skills.selected',
+    EXPERTISES_COUNT: 'talent.erudition.expertises.count',
+    EXPERTISES_TYPES: 'talent.erudition.expertises.types',
+    EXPERTISES_SELECTED: 'talent.erudition.expertises.selected',
 } as const;
 
 const DEFAULT_SKILLS_COUNT = 2;
-const DEFAULT_SKILLS_ATTRIBUTE_GROUPS = ["cog"] as AttributeGroup[];
+const DEFAULT_SKILLS_ATTRIBUTE_GROUPS = ['cog'] as AttributeGroup[];
 const DEFAULT_SKILLS_INCREASE = 1; // Default increase for skills
 const DEFAULT_EXPERTISES_COUNT = 1;
-const DEFAULT_EXPERTISES_TYPES = ["cultural", "utility"] as ExpertiseType[];
-
+const DEFAULT_EXPERTISES_TYPES = ['cultural', 'utility'] as ExpertiseType[];
 
 /**
  * Applies the effects of a long rest for the Erudition talent.
@@ -49,7 +52,12 @@ export async function choose(actor: CosmereActor) {
 
     // Select the expertises
     for (const exp of result.expertises) {
-        await selectExpertise(actor, `${exp.type}:${exp.id}`, exp.label);
+        const expertise = new Expertise({
+            id: exp.id,
+            type: exp.type,
+            label: exp.label,
+        });
+        await selectExpertise(actor, expertise, exp.label);
     }
 }
 
@@ -72,7 +80,9 @@ export async function validate(actor: CosmereActor) {
     const selections = getSelections(actor);
 
     // Find all selected skills that are no longer valid
-    const invalidSkills = selections.skills.filter(skillId => !validSkills.includes(skillId));
+    const invalidSkills = selections.skills.filter(
+        (skillId) => !validSkills.includes(skillId),
+    );
 
     // Deselect invalid skills
     for (const skillId of invalidSkills) {
@@ -91,7 +101,9 @@ export async function validate(actor: CosmereActor) {
     }
 
     // Find all selected expertises that are no longer valid
-    const invalidExpertises = selections.expertises.filter(expertiseId => !config.expertises.types.includes(expertiseId.type));
+    const invalidExpertises = selections.expertises.filter(
+        (expertiseId) => !config.expertises.types.includes(expertiseId.type),
+    );
 
     // Deselect invalid expertises
     for (const expId of invalidExpertises) {
@@ -100,7 +112,8 @@ export async function validate(actor: CosmereActor) {
 
     // Check if the number of selected expertises exceeds the allowed count
     if (selections.expertises.length > config.expertises.count) {
-        const excessCount = selections.expertises.length - config.expertises.count;
+        const excessCount =
+            selections.expertises.length - config.expertises.count;
         const expertisesToDeselect = selections.expertises.slice(-excessCount);
 
         // Deselect the excess expertises
@@ -111,55 +124,99 @@ export async function validate(actor: CosmereActor) {
 }
 
 export async function modifySkillsCount(actor: CosmereActor, amount: number) {
-    const currentCount = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) as number ?? DEFAULT_SKILLS_COUNT;
+    const currentCount =
+        actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) ?? DEFAULT_SKILLS_COUNT;
     await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT, currentCount + amount);
 
     // Validate the selections after modifying the count
     await validate(actor);
 }
 
-export async function modifyExpertisesCount(actor: CosmereActor, amount: number) {
-    const currentCount = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) as number ?? DEFAULT_EXPERTISES_COUNT;
-    await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT, currentCount + amount);
+export async function modifyExpertisesCount(
+    actor: CosmereActor,
+    amount: number,
+) {
+    const currentCount =
+        actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) ??
+        DEFAULT_EXPERTISES_COUNT;
+    await actor.setFlag(
+        SYSTEM_ID,
+        FLAGS.EXPERTISES_COUNT,
+        currentCount + amount,
+    );
 
     // Validate the selections after modifying the count
     await validate(actor);
 }
 
-export async function addSkillsAttributeGroup(actor: CosmereActor, key: AttributeGroup) {
-    const currentGroups = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) as AttributeGroup[] || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+export async function addSkillsAttributeGroup(
+    actor: CosmereActor,
+    key: AttributeGroup,
+) {
+    const currentGroups =
+        actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) ||
+        DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
     if (!currentGroups.includes(key)) {
-        await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS, [...currentGroups, key]);
+        await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS, [
+            ...currentGroups,
+            key,
+        ]);
     }
 
     // Validate the selections after modifying the groups
     await validate(actor);
 }
 
-export async function removeSkillsAttributeGroup(actor: CosmereActor, key: AttributeGroup) {
-    const currentGroups: AttributeGroup[] = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) as AttributeGroup[] || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+export async function removeSkillsAttributeGroup(
+    actor: CosmereActor,
+    key: AttributeGroup,
+) {
+    const currentGroups: AttributeGroup[] =
+        actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) ||
+        DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
     if (currentGroups.includes(key)) {
-        await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS, currentGroups.filter(g => g !== key));
+        await actor.setFlag(
+            SYSTEM_ID,
+            FLAGS.SKILLS_GROUPS,
+            currentGroups.filter((g) => g !== key),
+        );
     }
 
     // Validate the selections after modifying the groups
     await validate(actor);
 }
 
-export async function addExpertisesType(actor: CosmereActor, type: ExpertiseType) {
-    const currentTypes = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) as ExpertiseType[] || DEFAULT_EXPERTISES_TYPES;
+export async function addExpertisesType(
+    actor: CosmereActor,
+    type: ExpertiseType,
+) {
+    const currentTypes =
+        actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) ||
+        DEFAULT_EXPERTISES_TYPES;
     if (!currentTypes.includes(type)) {
-        await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES, [...currentTypes, type]);
+        await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES, [
+            ...currentTypes,
+            type,
+        ]);
     }
 
     // Validate the selections after modifying the types
     await validate(actor);
 }
 
-export async function removeExpertisesType(actor: CosmereActor, type: ExpertiseType) {
-    const currentTypes: ExpertiseType[] = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) as ExpertiseType[] || DEFAULT_EXPERTISES_TYPES;
+export async function removeExpertisesType(
+    actor: CosmereActor,
+    type: ExpertiseType,
+) {
+    const currentTypes: ExpertiseType[] =
+        actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) ||
+        DEFAULT_EXPERTISES_TYPES;
     if (currentTypes.includes(type)) {
-        await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES, currentTypes.filter(t => t !== type));
+        await actor.setFlag(
+            SYSTEM_ID,
+            FLAGS.EXPERTISES_TYPES,
+            currentTypes.filter((t) => t !== type),
+        );
     }
 
     // Validate the selections after modifying the types
@@ -174,22 +231,34 @@ export async function removeExpertisesType(actor: CosmereActor, type: ExpertiseT
 function getConfig(actor: CosmereActor): EruditionConfig {
     return {
         skills: {
-            count: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) as number ?? DEFAULT_SKILLS_COUNT,
-            groups: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) as AttributeGroup[] || DEFAULT_SKILLS_ATTRIBUTE_GROUPS
+            count:
+                actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) ??
+                DEFAULT_SKILLS_COUNT,
+            groups:
+                actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) ||
+                DEFAULT_SKILLS_ATTRIBUTE_GROUPS,
         },
         expertises: {
-            count: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) as number ?? DEFAULT_EXPERTISES_COUNT,
-            types: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) as ExpertiseType[] || DEFAULT_EXPERTISES_TYPES
-        }
+            count:
+                actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) ??
+                DEFAULT_EXPERTISES_COUNT,
+            types:
+                actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) ||
+                DEFAULT_EXPERTISES_TYPES,
+        },
     };
 }
 
 function getValidSkills(actor: CosmereActor): string[] {
-    const attributeGroups: string[] = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) as AttributeGroup[] || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+    const attributeGroups: string[] =
+        actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) ||
+        DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
     return Object.values(CONFIG.COSMERE.attributeGroups)
-        .filter(group => attributeGroups.includes(group.key))
-        .flatMap(group => group.attributes)
-        .flatMap(attrId => CONFIG.COSMERE.attributes[attrId].skills) as string[];
+        .filter((group) => attributeGroups.includes(group.key))
+        .flatMap((group) => group.attributes)
+        .flatMap(
+            (attrId) => CONFIG.COSMERE.attributes[attrId].skills,
+        ) as string[];
 }
 
 /**
@@ -197,8 +266,8 @@ function getValidSkills(actor: CosmereActor): string[] {
  */
 function getSelections(actor: CosmereActor): EruditionSelections {
     return {
-        skills: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_SELECTED) as Skill[] || [],
-        expertises: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_SELECTED) as Expertise[] || []
+        skills: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_SELECTED) || [],
+        expertises: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_SELECTED) || [],
     };
 }
 
@@ -221,12 +290,18 @@ function selectSkill(actor: CosmereActor, skillId: Skill) {
     const selections = getSelections(actor);
 
     // Get amount to increase by
-    const increaseAmount = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_INCREASE) as number || DEFAULT_SKILLS_INCREASE;
+    const increaseAmount =
+        actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_INCREASE) ||
+        DEFAULT_SKILLS_INCREASE;
 
     return actor.update({
-        [`flags.${SYSTEM_ID}.${FLAGS.SKILLS_SELECTED}`]: [...selections.skills, skillId],
+        [`flags.${SYSTEM_ID}.${FLAGS.SKILLS_SELECTED}`]: [
+            ...selections.skills,
+            skillId,
+        ],
         [`flags.${SYSTEM_ID}.skills.${skillId}.temporaryRanks`]: increaseAmount,
-        [`system.skills.${skillId}.rank`]: actor.system.skills[skillId].rank + increaseAmount
+        [`system.skills.${skillId}.rank`]:
+            actor.system.skills[skillId].rank + increaseAmount,
     });
 }
 
@@ -235,43 +310,51 @@ function deselectSkill(actor: CosmereActor, skillId: Skill) {
     const selections = getSelections(actor);
 
     // Ensure the skill is in selections
-    if (!selections.skills.includes(skillId)) 
-        return Promise.resolve();
+    if (!selections.skills.includes(skillId)) return Promise.resolve();
 
     // Remove the skill from selections
-    const updatedSkills = selections.skills.filter(id => id !== skillId);
+    const updatedSkills = selections.skills.filter((id) => id !== skillId);
 
     // Get the amount of temporary ranks to reset
-    const temporaryRanks = actor.getFlag(SYSTEM_ID, `skills.${skillId}.temporaryRanks`) as number || 0;
+    const temporaryRanks =
+        actor.getFlag(SYSTEM_ID, `skills.${skillId}.temporaryRanks`) || 0;
 
     // Update actor with new selections
     return actor.update({
         [`flags.${SYSTEM_ID}.${FLAGS.SKILLS_SELECTED}`]: updatedSkills,
         [`flags.${SYSTEM_ID}.skills.${skillId}.temporaryRanks`]: 0,
-        [`system.skills.${skillId}.rank`]: actor.system.skills[skillId].rank - temporaryRanks
+        [`system.skills.${skillId}.rank`]:
+            actor.system.skills[skillId].rank - temporaryRanks,
     });
 }
 
-function selectExpertise(actor: CosmereActor, compositeId: string, label?: string) {
+function selectExpertise(
+    actor: CosmereActor,
+    compositeId: Expertise,
+    label?: string,
+) {
     // Get current selections
     const selections = getSelections(actor);
 
     // Split composite ID into type and id
-    const [type, id] = compositeId.split(':');
+    const [type, id] = [compositeId.type, compositeId.id];
 
     // Ensure the expertise is not already selected
-    if (selections.expertises.find(exp => exp.key === compositeId)) 
+    if (selections.expertises.find((exp) => exp.key === compositeId.key))
         return Promise.resolve();
 
     // Update actor with new selections
     return actor.update({
-        [`flags.${SYSTEM_ID}.${FLAGS.EXPERTISES_SELECTED}`]: [...selections.expertises, compositeId],
-        [`system.expertises.${compositeId}`]: {
+        [`flags.${SYSTEM_ID}.${FLAGS.EXPERTISES_SELECTED}`]: [
+            ...selections.expertises,
+            compositeId,
+        ],
+        [`system.expertises.${compositeId.key}`]: {
             id,
             type,
             label,
-            locked: true
-        }
+            locked: true,
+        },
     });
 }
 
@@ -279,16 +362,24 @@ function deselectExpertise(actor: CosmereActor, compositeId: Expertise) {
     // Get current selections
     const selections = getSelections(actor);
 
+    const [type, id] = [compositeId.type, compositeId.id];
+
     // Ensure the expertise is in selections
-    if (!selections.expertises.includes(compositeId)) 
+    // the key is undefined here for some reason, but comparing the id/type works
+    if (
+        !selections.expertises.find((exp) => exp.id === id && exp.type === type)
+    )
         return Promise.resolve();
 
     // Remove the expertise from selections
-    const updatedExpertises = selections.expertises.filter(exp => exp !== compositeId);
+    const updatedExpertises = selections.expertises.filter(
+        (exp) => exp.id !== id && exp.type !== type,
+    );
 
     // Update actor with new selections
     return actor.update({
         [`flags.${SYSTEM_ID}.${FLAGS.EXPERTISES_SELECTED}`]: updatedExpertises,
-        [`system.expertises.-=${compositeId.id}`]: {}
+        // gotta manually construct the key since it is undefined for some reason
+        [`system.expertises.-=${type}:${id}`]: {},
     });
 }

--- a/src/system/utils/macros/talents/erudition/index.ts
+++ b/src/system/utils/macros/talents/erudition/index.ts
@@ -1,0 +1,312 @@
+// Dialog
+import { EruditionDialog } from './dialog';
+
+// Types
+import { EruditionConfig, EruditionSelections, PickedExpertise } from './types';
+
+// Constants
+import { SYSTEM_ID } from '@module/constants';
+
+// Define constants for flag keys
+const FLAGS = {
+    SKILLS_COUNT: "talent.erudition.skills.count",
+    SKILLS_GROUPS: "talent.erudition.skills.groups",
+    SKILLS_INCREASE: "talent.erudition.skills.increase",
+    SKILLS_SELECTED: "talent.erudition.skills.selected",
+    EXPERTISES_COUNT: "talent.erudition.expertises.count",
+    EXPERTISES_TYPES: "talent.erudition.expertises.types",
+    EXPERTISES_SELECTED: "talent.erudition.expertises.selected",
+} as const;
+
+const DEFAULT_SKILLS_COUNT = 2;
+const DEFAULT_SKILLS_ATTRIBUTE_GROUPS = ["cog"];
+const DEFAULT_SKILLS_INCREASE = 1; // Default increase for skills
+const DEFAULT_EXPERTISES_COUNT = 1;
+const DEFAULT_EXPERTISES_TYPES = ["cultural", "utility"];
+
+interface AttributeGroup {
+    key: string;
+    attributes: string[];
+}
+
+/**
+ * Applies the effects of a long rest for the Erudition talent.
+ */
+export async function choose(actor: CosmereActor) {
+    const result = await EruditionDialog.show({
+        actor,
+        config: getConfig(actor),
+        selected: getSelections(actor),
+    });
+    if (!result) return;
+
+    // Clear current selections
+    await clearSelections(actor);
+
+    // Select the skills
+    for (const skillId of result.skills) {
+        await selectSkill(actor, skillId);
+    }
+
+    // Select the expertises
+    for (const exp of result.expertises) {
+        await selectExpertise(actor, `${exp.type}:${exp.id}`, exp.label);
+    }
+}
+
+export async function clear(actor: CosmereActor) {
+    // Clear all selections
+    await clearSelections(actor);
+}
+
+/**
+ * Validates the state of the Erudition talent.
+ */
+export async function validate(actor: CosmereActor) {
+    // Get the Erudition configuration
+    const config: EruditionConfig = getConfig(actor);
+
+    // Get the valid skills based on the flags
+    const validSkills = getValidSkills(actor);
+
+    // Get selections
+    const selections = getSelections(actor);
+
+    // Find all selected skills that are no longer valid
+    const invalidSkills = selections.skills.filter(skillId => !validSkills.includes(skillId));
+
+    // Deselect invalid skills
+    for (const skillId of invalidSkills) {
+        await deselectSkill(actor, skillId);
+    }
+
+    // Check if the number of selected skills exceeds the allowed count
+    if (selections.skills.length > config.skills.count) {
+        const excessCount = selections.skills.length - config.skills.count;
+        const skillsToDeselect = selections.skills.slice(-excessCount);
+
+        // Deselect the excess skills
+        for (const skillId of skillsToDeselect) {
+            await deselectSkill(actor, skillId);
+        }
+    }
+
+    // Find all selected expertises that are no longer valid
+    const invalidExpertises = selections.expertises.filter(expertiseId => !config.expertises.types.includes(expertiseId.split(':')[0]));
+
+    // Deselect invalid expertises
+    for (const expId of invalidExpertises) {
+        await deselectExpertise(actor, expId);
+    }
+
+    // Check if the number of selected expertises exceeds the allowed count
+    if (selections.expertises.length > config.expertises.count) {
+        const excessCount = selections.expertises.length - config.expertises.count;
+        const expertisesToDeselect = selections.expertises.slice(-excessCount);
+
+        // Deselect the excess expertises
+        for (const expId of expertisesToDeselect) {
+            await deselectExpertise(actor, expId);
+        }
+    }
+}
+
+export async function modifySkillsCount(actor: CosmereActor, amount: number) {
+    const currentCount = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) || DEFAULT_SKILLS_COUNT;
+    await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT, currentCount + amount);
+
+    // Validate the selections after modifying the count
+    await validate(actor);
+}
+
+export async function modifyExpertisesCount(actor: CosmereActor, amount: number) {
+    const currentCount = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) || DEFAULT_EXPERTISES_COUNT;
+    await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT, currentCount + amount);
+
+    // Validate the selections after modifying the count
+    await validate(actor);
+}
+
+export async function addSkillsAttributeGroup(actor: CosmereActor, key: string) {
+    const currentGroups = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+    if (!currentGroups.includes(key)) {
+        await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS, [...currentGroups, key]);
+    }
+
+    // Validate the selections after modifying the groups
+    await validate(actor);
+}
+
+export async function removeSkillsAttributeGroup(actor: CosmereActor, key: string) {
+    const currentGroups: string[] = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+    if (currentGroups.includes(key)) {
+        await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS, currentGroups.filter(g => g !== key));
+    }
+
+    // Validate the selections after modifying the groups
+    await validate(actor);
+}
+
+export async function addExpertisesType(actor: CosmereActor, type: string) {
+    const currentTypes = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) || DEFAULT_EXPERTISES_TYPES;
+    if (!currentTypes.includes(type)) {
+        await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES, [...currentTypes, type]);
+    }
+
+    // Validate the selections after modifying the types
+    await validate(actor);
+}
+
+export async function removeExpertisesType(actor: CosmereActor, type: string) {
+    const currentTypes: string[] = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) || DEFAULT_EXPERTISES_TYPES;
+    if (currentTypes.includes(type)) {
+        await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES, currentTypes.filter(t => t !== type));
+    }
+
+    // Validate the selections after modifying the types
+    await validate(actor);
+}
+
+/* --- Helpers --- */
+
+/**
+ * Utility function to get the Erudition configuration for the actor flags
+ */
+function getConfig(actor: CosmereActor): EruditionConfig {
+    return {
+        skills: {
+            count: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) || DEFAULT_SKILLS_COUNT,
+            groups: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) || DEFAULT_SKILLS_ATTRIBUTE_GROUPS
+        },
+        expertises: {
+            count: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) || DEFAULT_EXPERTISES_COUNT,
+            types: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) || DEFAULT_EXPERTISES_TYPES
+        }
+    };
+}
+
+function getValidSkills(actor: CosmereActor): string[] {
+    const attributeGroups: string[] = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+    return (Object.values(CONFIG.COSMERE.attributeGroups) as AttributeGroup[])
+        .filter(group => attributeGroups.includes(group.key))
+        .flatMap(group => group.attributes)
+        .flatMap(attrId => CONFIG.COSMERE.attributes[attrId].skills) as string[];
+}
+
+/**
+ * Utility function to get the selections of skills and expertises for the Erudition talent.
+ */
+function getSelections(actor: CosmereActor): EruditionSelections {
+    return {
+        skills: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_SELECTED) || [],
+        expertises: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_SELECTED) || []
+    };
+}
+
+async function clearSelections(actor: CosmereActor) {
+    // Get current selections
+    const selections = getSelections(actor);
+
+    // Clear skills and expertises selections
+    for (const skillId of selections.skills) {
+        await deselectSkill(actor, skillId);
+    }
+
+    for (const expertiseId of selections.expertises) {
+        await deselectExpertise(actor, expertiseId);
+    }
+}
+
+function selectSkill(actor: CosmereActor, skillId: string) {
+    // Get current selections
+    const selections = getSelections(actor);
+
+    // Get amount to increase by
+    const increaseAmount = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_INCREASE) || DEFAULT_SKILLS_INCREASE;
+
+    return actor.update({
+        [`flags.${SYSTEM_ID}.${FLAGS.SKILLS_SELECTED}`]: [...selections.skills, skillId],
+        [`flags.${SYSTEM_ID}.skills.${skillId}.temporaryRanks`]: increaseAmount,
+        [`system.skills.${skillId}.rank`]: actor.system.skills[skillId].rank + increaseAmount
+    });
+}
+
+function deselectSkill(actor: CosmereActor, skillId: string) {
+    // Get current selections
+    const selections = getSelections(actor);
+
+    // Ensure the skill is in selections
+    if (!selections.skills.includes(skillId)) 
+        return Promise.resolve();
+
+    // Remove the skill from selections
+    const updatedSkills = selections.skills.filter(id => id !== skillId);
+
+    // Get the amount of temporary ranks to reset
+    const temporaryRanks = actor.getFlag(SYSTEM_ID, `skills.${skillId}.temporaryRanks`) || 0;
+
+    // Update actor with new selections
+    return actor.update({
+        [`flags.${SYSTEM_ID}.${FLAGS.SKILLS_SELECTED}`]: updatedSkills,
+        [`flags.${SYSTEM_ID}.skills.${skillId}.temporaryRanks`]: 0,
+        [`system.skills.${skillId}.rank`]: actor.system.skills[skillId].rank - temporaryRanks
+    });
+}
+
+function selectExpertise(actor: CosmereActor, compositeId: string, label?: string) {
+    // Get current selections
+    const selections = getSelections(actor);
+
+    // Split composite ID into type and id
+    const [type, id] = compositeId.split(':');
+
+    // Ensure the expertise is not already selected
+    if (selections.expertises.includes(compositeId)) 
+        return Promise.resolve();
+
+    // Update actor with new selections
+    return actor.update({
+        [`flags.${SYSTEM_ID}.${FLAGS.EXPERTISES_SELECTED}`]: [...selections.expertises, compositeId],
+        [`system.expertises.${compositeId}`]: {
+            id,
+            type,
+            label,
+            locked: true
+        }
+    });
+}
+
+function deselectExpertise(actor: CosmereActor, compositeId: string) {
+    // Get current selections
+    const selections = getSelections(actor);
+
+    // Ensure the expertise is in selections
+    if (!selections.expertises.includes(compositeId)) 
+        return Promise.resolve();
+
+    // Remove the expertise from selections
+    const updatedExpertises = selections.expertises.filter(exp => exp !== compositeId);
+
+    // Update actor with new selections
+    return actor.update({
+        [`flags.${SYSTEM_ID}.${FLAGS.EXPERTISES_SELECTED}`]: updatedExpertises,
+        [`system.expertises.-=${compositeId}`]: {}
+    });
+}
+
+declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
+    interface FlagConfig {
+        Actor: {
+            [SYSTEM_ID]: {
+                [FLAGS.SKILLS_COUNT]: number;
+                [FLAGS.SKILLS_GROUPS]: string[];
+                [FLAGS.SKILLS_INCREASE]: number;
+                [FLAGS.SKILLS_SELECTED]: string[];
+                [FLAGS.EXPERTISES_COUNT]: number;
+                [FLAGS.EXPERTISES_TYPES]: string[];
+                [FLAGS.EXPERTISES_SELECTED]: string[];
+                [key: `skills.${string}.temporaryRanks`]: number;
+            };
+        };
+    }
+}

--- a/src/system/utils/macros/talents/erudition/index.ts
+++ b/src/system/utils/macros/talents/erudition/index.ts
@@ -1,11 +1,14 @@
 // Dialog
+import { Expertise } from '@src/system/data/actor/common';
 import { EruditionDialog } from './dialog';
 
 // Types
 import { EruditionConfig, EruditionSelections, PickedExpertise } from './types';
+import { CosmereActor } from '@src/system/documents';
+import { AttributeGroup, ExpertiseType, Skill } from '@src/system/types/cosmere';
 
 // Constants
-import { SYSTEM_ID } from '@module/constants';
+import { SYSTEM_ID } from '@system/constants';
 
 // Define constants for flag keys
 export const FLAGS = {
@@ -19,15 +22,11 @@ export const FLAGS = {
 } as const;
 
 const DEFAULT_SKILLS_COUNT = 2;
-const DEFAULT_SKILLS_ATTRIBUTE_GROUPS = ["cog"];
+const DEFAULT_SKILLS_ATTRIBUTE_GROUPS = ["cog"] as AttributeGroup[];
 const DEFAULT_SKILLS_INCREASE = 1; // Default increase for skills
 const DEFAULT_EXPERTISES_COUNT = 1;
-const DEFAULT_EXPERTISES_TYPES = ["cultural", "utility"];
+const DEFAULT_EXPERTISES_TYPES = ["cultural", "utility"] as ExpertiseType[];
 
-interface AttributeGroup {
-    key: string;
-    attributes: string[];
-}
 
 /**
  * Applies the effects of a long rest for the Erudition talent.
@@ -92,7 +91,7 @@ export async function validate(actor: CosmereActor) {
     }
 
     // Find all selected expertises that are no longer valid
-    const invalidExpertises = selections.expertises.filter(expertiseId => !config.expertises.types.includes(expertiseId.split(':')[0]));
+    const invalidExpertises = selections.expertises.filter(expertiseId => !config.expertises.types.includes(expertiseId.type));
 
     // Deselect invalid expertises
     for (const expId of invalidExpertises) {
@@ -112,7 +111,7 @@ export async function validate(actor: CosmereActor) {
 }
 
 export async function modifySkillsCount(actor: CosmereActor, amount: number) {
-    const currentCount = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) || DEFAULT_SKILLS_COUNT;
+    const currentCount = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) as number ?? DEFAULT_SKILLS_COUNT;
     await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT, currentCount + amount);
 
     // Validate the selections after modifying the count
@@ -120,15 +119,15 @@ export async function modifySkillsCount(actor: CosmereActor, amount: number) {
 }
 
 export async function modifyExpertisesCount(actor: CosmereActor, amount: number) {
-    const currentCount = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) || DEFAULT_EXPERTISES_COUNT;
+    const currentCount = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) as number ?? DEFAULT_EXPERTISES_COUNT;
     await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT, currentCount + amount);
 
     // Validate the selections after modifying the count
     await validate(actor);
 }
 
-export async function addSkillsAttributeGroup(actor: CosmereActor, key: string) {
-    const currentGroups = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+export async function addSkillsAttributeGroup(actor: CosmereActor, key: AttributeGroup) {
+    const currentGroups = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) as AttributeGroup[] || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
     if (!currentGroups.includes(key)) {
         await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS, [...currentGroups, key]);
     }
@@ -137,8 +136,8 @@ export async function addSkillsAttributeGroup(actor: CosmereActor, key: string) 
     await validate(actor);
 }
 
-export async function removeSkillsAttributeGroup(actor: CosmereActor, key: string) {
-    const currentGroups: string[] = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+export async function removeSkillsAttributeGroup(actor: CosmereActor, key: AttributeGroup) {
+    const currentGroups: AttributeGroup[] = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) as AttributeGroup[] || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
     if (currentGroups.includes(key)) {
         await actor.setFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS, currentGroups.filter(g => g !== key));
     }
@@ -147,8 +146,8 @@ export async function removeSkillsAttributeGroup(actor: CosmereActor, key: strin
     await validate(actor);
 }
 
-export async function addExpertisesType(actor: CosmereActor, type: string) {
-    const currentTypes = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) || DEFAULT_EXPERTISES_TYPES;
+export async function addExpertisesType(actor: CosmereActor, type: ExpertiseType) {
+    const currentTypes = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) as ExpertiseType[] || DEFAULT_EXPERTISES_TYPES;
     if (!currentTypes.includes(type)) {
         await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES, [...currentTypes, type]);
     }
@@ -157,8 +156,8 @@ export async function addExpertisesType(actor: CosmereActor, type: string) {
     await validate(actor);
 }
 
-export async function removeExpertisesType(actor: CosmereActor, type: string) {
-    const currentTypes: string[] = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) || DEFAULT_EXPERTISES_TYPES;
+export async function removeExpertisesType(actor: CosmereActor, type: ExpertiseType) {
+    const currentTypes: ExpertiseType[] = actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) as ExpertiseType[] || DEFAULT_EXPERTISES_TYPES;
     if (currentTypes.includes(type)) {
         await actor.setFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES, currentTypes.filter(t => t !== type));
     }
@@ -175,19 +174,19 @@ export async function removeExpertisesType(actor: CosmereActor, type: string) {
 function getConfig(actor: CosmereActor): EruditionConfig {
     return {
         skills: {
-            count: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) || DEFAULT_SKILLS_COUNT,
-            groups: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) || DEFAULT_SKILLS_ATTRIBUTE_GROUPS
+            count: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_COUNT) as number ?? DEFAULT_SKILLS_COUNT,
+            groups: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) as AttributeGroup[] || DEFAULT_SKILLS_ATTRIBUTE_GROUPS
         },
         expertises: {
-            count: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) || DEFAULT_EXPERTISES_COUNT,
-            types: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) || DEFAULT_EXPERTISES_TYPES
+            count: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_COUNT) as number ?? DEFAULT_EXPERTISES_COUNT,
+            types: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_TYPES) as ExpertiseType[] || DEFAULT_EXPERTISES_TYPES
         }
     };
 }
 
 function getValidSkills(actor: CosmereActor): string[] {
-    const attributeGroups: string[] = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
-    return (Object.values(CONFIG.COSMERE.attributeGroups) as AttributeGroup[])
+    const attributeGroups: string[] = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_GROUPS) as AttributeGroup[] || DEFAULT_SKILLS_ATTRIBUTE_GROUPS;
+    return Object.values(CONFIG.COSMERE.attributeGroups)
         .filter(group => attributeGroups.includes(group.key))
         .flatMap(group => group.attributes)
         .flatMap(attrId => CONFIG.COSMERE.attributes[attrId].skills) as string[];
@@ -198,8 +197,8 @@ function getValidSkills(actor: CosmereActor): string[] {
  */
 function getSelections(actor: CosmereActor): EruditionSelections {
     return {
-        skills: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_SELECTED) || [],
-        expertises: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_SELECTED) || []
+        skills: actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_SELECTED) as Skill[] || [],
+        expertises: actor.getFlag(SYSTEM_ID, FLAGS.EXPERTISES_SELECTED) as Expertise[] || []
     };
 }
 
@@ -217,12 +216,12 @@ async function clearSelections(actor: CosmereActor) {
     }
 }
 
-function selectSkill(actor: CosmereActor, skillId: string) {
+function selectSkill(actor: CosmereActor, skillId: Skill) {
     // Get current selections
     const selections = getSelections(actor);
 
     // Get amount to increase by
-    const increaseAmount = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_INCREASE) || DEFAULT_SKILLS_INCREASE;
+    const increaseAmount = actor.getFlag(SYSTEM_ID, FLAGS.SKILLS_INCREASE) as number || DEFAULT_SKILLS_INCREASE;
 
     return actor.update({
         [`flags.${SYSTEM_ID}.${FLAGS.SKILLS_SELECTED}`]: [...selections.skills, skillId],
@@ -231,7 +230,7 @@ function selectSkill(actor: CosmereActor, skillId: string) {
     });
 }
 
-function deselectSkill(actor: CosmereActor, skillId: string) {
+function deselectSkill(actor: CosmereActor, skillId: Skill) {
     // Get current selections
     const selections = getSelections(actor);
 
@@ -243,7 +242,7 @@ function deselectSkill(actor: CosmereActor, skillId: string) {
     const updatedSkills = selections.skills.filter(id => id !== skillId);
 
     // Get the amount of temporary ranks to reset
-    const temporaryRanks = actor.getFlag(SYSTEM_ID, `skills.${skillId}.temporaryRanks`) || 0;
+    const temporaryRanks = actor.getFlag(SYSTEM_ID, `skills.${skillId}.temporaryRanks`) as number || 0;
 
     // Update actor with new selections
     return actor.update({
@@ -261,7 +260,7 @@ function selectExpertise(actor: CosmereActor, compositeId: string, label?: strin
     const [type, id] = compositeId.split(':');
 
     // Ensure the expertise is not already selected
-    if (selections.expertises.includes(compositeId)) 
+    if (selections.expertises.find(exp => exp.key === compositeId)) 
         return Promise.resolve();
 
     // Update actor with new selections
@@ -276,7 +275,7 @@ function selectExpertise(actor: CosmereActor, compositeId: string, label?: strin
     });
 }
 
-function deselectExpertise(actor: CosmereActor, compositeId: string) {
+function deselectExpertise(actor: CosmereActor, compositeId: Expertise) {
     // Get current selections
     const selections = getSelections(actor);
 
@@ -290,6 +289,6 @@ function deselectExpertise(actor: CosmereActor, compositeId: string) {
     // Update actor with new selections
     return actor.update({
         [`flags.${SYSTEM_ID}.${FLAGS.EXPERTISES_SELECTED}`]: updatedExpertises,
-        [`system.expertises.-=${compositeId}`]: {}
+        [`system.expertises.-=${compositeId.id}`]: {}
     });
 }

--- a/src/system/utils/macros/talents/erudition/types.ts
+++ b/src/system/utils/macros/talents/erudition/types.ts
@@ -1,0 +1,22 @@
+export interface EruditionConfig {
+    skills: {
+        count: number;
+        groups: string[];
+    };
+    expertises: {
+        count: number;
+        types: string[];
+    };
+};
+
+export interface EruditionSelections {
+    skills: string[];
+    expertises: string[];
+}
+
+export interface PickedExpertise {
+    id: string;
+    type: string;
+    label?: string;
+    custom?: boolean;
+}

--- a/src/system/utils/macros/talents/erudition/types.ts
+++ b/src/system/utils/macros/talents/erudition/types.ts
@@ -1,22 +1,25 @@
+import { Expertise } from '@src/system/data/actor/common';
+import { AttributeGroup, ExpertiseType, Skill } from '@src/system/types/cosmere';
+
 export interface EruditionConfig {
     skills: {
         count: number;
-        groups: string[];
+        groups: AttributeGroup[];
     };
     expertises: {
         count: number;
-        types: string[];
+        types: ExpertiseType[];
     };
 };
 
 export interface EruditionSelections {
-    skills: string[];
-    expertises: string[];
+    skills: Skill[];
+    expertises: Expertise[];
 }
 
 export interface PickedExpertise {
     id: string;
-    type: string;
+    type: ExpertiseType;
     label?: string;
     custom?: boolean;
 }

--- a/src/system/utils/macros/talents/index.ts
+++ b/src/system/utils/macros/talents/index.ts
@@ -1,0 +1,1 @@
+export * as erudition from './erudition';

--- a/src/templates/general/dialogs/erudition.hbs
+++ b/src/templates/general/dialogs/erudition.hbs
@@ -1,0 +1,58 @@
+<form class="dialog-content standard-form">
+    <fieldset>
+        <legend>{{localize "COSMERE.Macro.Talents.Erudition.Dialog.Skills"}}</legend>
+
+        {{#times config.skills.count as |index|}}
+            <div class="form-group" data-index="{{index}}">
+                <label>{{localize "GENERIC.Skill"}} {{add index 1}}</label>
+                <div class="form-fields">
+                    <select name="skills.{{index}}">
+                        {{selectOptions @root.skillSelectOptions selected=(lookup @root.selections.skills index) localize=true}}
+                    </select>
+                </div>
+            </div>
+        {{/times}}
+    </fieldset>
+
+    <fieldset>
+        <legend>{{localize "COSMERE.Macro.Talents.Erudition.Dialog.Expertises"}}</legend>
+
+        {{#times config.expertises.count as |index|}}
+            {{#with (default (lookup @root.selections.expertises index) @root.defaultExpertise) as |expertise|}}
+                <div class="form-group" data-index="{{index}}">
+                    <label>{{localize "COSMERE.Macro.Talents.Erudition.Dialog.Expertise"}} {{add index 1}}</label>
+                    <div class="form-fields">
+                        <select name="expertises.{{index}}.type">
+                            {{selectOptions @root.expertiseTypeSelectOptions selected=expertise.type localize=true}}
+                        </select>
+
+                        <select name="expertises.{{index}}.id">
+                            {{selectOptions (lookup @root.expertiseIdSelectOptionsByType expertise.type) selected=expertise.id localize=true}}
+                        </select>
+
+                        {{log expertise}}
+
+                        {{#unless expertise.custom}}
+                            <input type="text" 
+                                value="—"
+                                readonly
+                            />
+                        {{else}}
+                            <input type="text" 
+                                name="expertises.{{index}}.label" 
+                                placeholder="{{localize "COSMERE.Macro.Talents.Erudition.Dialog.Expertise"}}" 
+                                value="{{expertise.label}}"
+                            />
+                        {{/unless}}
+                    </div>
+                </div>
+            {{/with}}
+        {{/times}}
+    </fieldset>
+
+    <div class="form-group submit">
+        <button type="submit">
+            {{localize "COSMERE.Macro.Talents.Erudition.Dialog.Confirm"}}
+        </button>
+    </div>
+</form>


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This moves the erudition talent macros to the core system from the stormlight handbook

**Related Issue**  
Closes #718 

**How Has This Been Tested?**  
Used each macro in foundry

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
I have a couple of concerns that I'm not sure whether they will affect the review. 
1. exporting the existing FLAGS const from erudition/index.ts, this does end up making it available in foundry as `cosmereRPG.utils.macros.talents.erudition.FLAGS` which is probably not ideal. if necessary I can put the keys directly into the actor.ts file rather than importing FLAGS there
2. I did need to use AnyObject in a couple of places that any was originally being used, but that was also not possible to use in one place that I actually ended up disabling the no-explicit-any linting for a line because it's not clear what object should be there (if i should declare some interface or whatever to be used in any of these places i can do that)
