### PR TITLE
feat: expand linked-skills support to connection, equipment, loot, talent (#404)

### DIFF
--- a/src/system/applications/item/connection-sheet.ts
+++ b/src/system/applications/item/connection-sheet.ts
@@ -20,6 +20,17 @@ export class ConnectionItemSheet extends BaseItemSheet {
         },
     };
 
+    static TABS = foundry.utils.mergeObject(
+        foundry.utils.deepClone(super.TABS),
+        {
+            details: {
+                label: 'COSMERE.Item.Sheet.Tabs.Details',
+                icon: '<i class="fa-solid fa-circle-info"></i>',
+                sortIndex: 15,
+            },
+        },
+    );
+
     static PARTS = foundry.utils.mergeObject(
         foundry.utils.deepClone(super.PARTS),
         {

--- a/src/system/data/item/connection.ts
+++ b/src/system/data/item/connection.ts
@@ -9,20 +9,23 @@ import {
 import { EventsItemMixin, EventsItemDataSchema } from './mixins/events';
 import {
     RelationshipsMixin,
-    RelationshipsItemDataSchema
+    RelationshipsItemDataSchema,
 } from './mixins/relationships';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemDataSchema,
+} from './mixins/linked-skills';
 
-export type ConnectionItemDataSchema = 
-    & DescriptionItemDataSchema
-    & EventsItemDataSchema
-    & RelationshipsItemDataSchema;
+export type ConnectionItemDataSchema = DescriptionItemDataSchema &
+    EventsItemDataSchema &
+    LinkedSkillsItemDataSchema &
+    RelationshipsItemDataSchema;
 
-export class ConnectionItemDataModel extends DataModelMixin<
-    ConnectionItemDataSchema
->(
+export class ConnectionItemDataModel extends DataModelMixin<ConnectionItemDataSchema>(
     DescriptionItemMixin({
         value: 'COSMERE.Item.Type.Connection.desc_placeholder',
     }),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
     RelationshipsMixin(),
 ) {}

--- a/src/system/data/item/equipment.ts
+++ b/src/system/data/item/equipment.ts
@@ -4,12 +4,20 @@ import { EmptyObject } from '@system/types/utils';
 
 // Mixins
 import { DataModelMixin } from '../mixins';
-import { TypedItemMixin, TypedItemDataSchema, TypedItemDerivedData } from './mixins/typed';
+import {
+    TypedItemMixin,
+    TypedItemDataSchema,
+    TypedItemDerivedData,
+} from './mixins/typed';
 import {
     DescriptionItemMixin,
     DescriptionItemDataSchema,
 } from './mixins/description';
-import { PhysicalItemMixin, PhysicalItemDataSchema, PhysicalItemDerivedData } from './mixins/physical';
+import {
+    PhysicalItemMixin,
+    PhysicalItemDataSchema,
+    PhysicalItemDerivedData,
+} from './mixins/physical';
 import {
     ActivatableItemMixin,
     ActivatableItemDataSchema,
@@ -20,19 +28,22 @@ import {
     RelationshipsMixin,
     RelationshipsItemDataSchema,
 } from './mixins/relationships';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemDataSchema,
+} from './mixins/linked-skills';
 
-export type EquipmentItemDataSchema = 
-    & TypedItemDataSchema<EquipmentType>
-    & DescriptionItemDataSchema
-    & PhysicalItemDataSchema
-    & ActivatableItemDataSchema
-    & DamagingItemDataSchema
-    & EventsItemDataSchema
-    & RelationshipsItemDataSchema;
+export type EquipmentItemDataSchema = TypedItemDataSchema<EquipmentType> &
+    DescriptionItemDataSchema &
+    PhysicalItemDataSchema &
+    ActivatableItemDataSchema &
+    DamagingItemDataSchema &
+    EventsItemDataSchema &
+    LinkedSkillsItemDataSchema &
+    RelationshipsItemDataSchema;
 
-export type EquipmentItemDerivedData = 
-    & TypedItemDerivedData 
-    & PhysicalItemDerivedData;
+export type EquipmentItemDerivedData = TypedItemDerivedData &
+    PhysicalItemDerivedData;
 
 export class EquipmentItemDataModel extends DataModelMixin<
     EquipmentItemDataSchema,
@@ -58,5 +69,6 @@ export class EquipmentItemDataModel extends DataModelMixin<
     ActivatableItemMixin(),
     DamagingItemMixin(),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
     RelationshipsMixin(),
 ) {}

--- a/src/system/data/item/loot.ts
+++ b/src/system/data/item/loot.ts
@@ -7,12 +7,20 @@ import {
     DescriptionItemMixin,
     DescriptionItemDataSchema,
 } from './mixins/description';
-import { PhysicalItemMixin, PhysicalItemDataSchema, PhysicalItemDerivedData } from './mixins/physical';
+import {
+    PhysicalItemMixin,
+    PhysicalItemDataSchema,
+    PhysicalItemDerivedData,
+} from './mixins/physical';
 import { EventsItemMixin, EventsItemDataSchema } from './mixins/events';
 import {
     RelationshipsMixin,
     RelationshipsItemDataSchema,
 } from './mixins/relationships';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemDataSchema,
+} from './mixins/linked-skills';
 
 const SCHEMA = () => ({
     isMoney: new foundry.data.fields.BooleanField({
@@ -23,12 +31,12 @@ const SCHEMA = () => ({
     }),
 });
 
-export type LootItemDataSchema = 
-    & ReturnType<typeof SCHEMA>
-    & DescriptionItemDataSchema
-    & PhysicalItemDataSchema
-    & EventsItemDataSchema
-    & RelationshipsItemDataSchema;
+export type LootItemDataSchema = ReturnType<typeof SCHEMA> &
+    DescriptionItemDataSchema &
+    PhysicalItemDataSchema &
+    EventsItemDataSchema &
+    LinkedSkillsItemDataSchema &
+    RelationshipsItemDataSchema;
 
 export type LootItemDerivedData = PhysicalItemDerivedData;
 
@@ -43,6 +51,7 @@ export class LootItemDataModel extends DataModelMixin<
     }),
     PhysicalItemMixin(),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
     RelationshipsMixin(),
 ) {
     static defineSchema() {

--- a/src/system/data/item/talent.ts
+++ b/src/system/data/item/talent.ts
@@ -5,7 +5,11 @@ import { EmptyObject } from '@system/types/utils';
 // Mixins
 import { DataModelMixin } from '../mixins';
 import { IdItemMixin, IdItemDataSchema } from './mixins/id';
-import { TypedItemMixin, TypedItemDataSchema, TypedItemDerivedData } from './mixins/typed';
+import {
+    TypedItemMixin,
+    TypedItemDataSchema,
+    TypedItemDerivedData,
+} from './mixins/typed';
 import {
     DescriptionItemMixin,
     DescriptionItemDataSchema,
@@ -21,6 +25,10 @@ import {
     RelationshipsMixin,
     RelationshipsItemDataSchema,
 } from './mixins/relationships';
+import {
+    LinkedSkillsMixin,
+    LinkedSkillsItemDataSchema,
+} from './mixins/linked-skills';
 
 const SCHEMA = () => ({
     path: new foundry.data.fields.StringField({
@@ -42,22 +50,22 @@ const SCHEMA = () => ({
     }),
 });
 
-export type TalentItemDataSchema =
-    & ReturnType<typeof SCHEMA>
-    & IdItemDataSchema
-    & TypedItemDataSchema<Talent.Type>
-    & DescriptionItemDataSchema
-    & ActivatableItemDataSchema
-    & DamagingItemDataSchema
-    & ModalityItemDataSchema
-    & EventsItemDataSchema
-    & RelationshipsItemDataSchema;
+export type TalentItemDataSchema = ReturnType<typeof SCHEMA> &
+    IdItemDataSchema &
+    TypedItemDataSchema<Talent.Type> &
+    DescriptionItemDataSchema &
+    ActivatableItemDataSchema &
+    DamagingItemDataSchema &
+    ModalityItemDataSchema &
+    EventsItemDataSchema &
+    LinkedSkillsItemDataSchema &
+    RelationshipsItemDataSchema;
 
 export type TalentItemDerivedData = TypedItemDerivedData & {
     hasPath: boolean;
     hasAncestry: boolean;
     hasPower: boolean;
-}
+};
 
 export class TalentItemDataModel extends DataModelMixin<
     TalentItemDataSchema,
@@ -86,6 +94,7 @@ export class TalentItemDataModel extends DataModelMixin<
     DamagingItemMixin(),
     ModalityItemMixin(),
     EventsItemMixin(),
+    LinkedSkillsMixin(),
     RelationshipsMixin(),
 ) {
     static defineSchema() {

--- a/src/templates/item/loot/partials/loot-details-tab.hbs
+++ b/src/templates/item/loot/partials/loot-details-tab.hbs
@@ -2,6 +2,7 @@
 <div class="tab tab-content {{tab.cssClass}}" data-tab="details" data-group="primary">
     <fieldset>
         <legend>{{localize "COSMERE.Item.Type.Loot.label"}}</legend>
+        {{app-item-details-linked-skills}}
         <div class="item-details-form">
             <div class="form-group">
                 <label>{{localize "COSMERE.Item.Sheet.Loot.IsMoney"}}</label>

--- a/src/templates/item/talent/partials/talent-details-tab.hbs
+++ b/src/templates/item/talent/partials/talent-details-tab.hbs
@@ -5,6 +5,7 @@
         <legend>{{localize "COSMERE.Item.Sheet.Basics"}}</legend>
         {{app-item-details-id}}
         {{app-item-details-type}}
+        {{app-item-details-linked-skills}}
         <div class="item-details-form">
             {{!-- Path talent fields --}}
             {{#if @root.isPathTalent}}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds `LinkedSkillsMixin` to the `connection`, `equipment`, `loot`, and `talent` item data models, completing the linked-skills feature begun in commit `1aa35e1`. The existing sheet component (`app-item-details-linked-skills`) is reused — no new component code. The two custom Details templates that didn't previously render it (`loot-details-tab.hbs`, `talent-details-tab.hbs`) are extended to invoke the component, and `ConnectionItemSheet` gains a `Details` tab declaration so the new control has a UI surface (the sheet had no Details tab before).

Files changed:
- `src/system/data/item/connection.ts` — `LinkedSkillsMixin()` added to the composition chain
- `src/system/applications/item/connection-sheet.ts` — adds a `Details` tab (was missing)
- `src/system/data/item/equipment.ts` — `LinkedSkillsMixin()` added to the composition chain
- `src/system/data/item/loot.ts` — `LinkedSkillsMixin()` added to the composition chain
- `src/templates/item/loot/partials/loot-details-tab.hbs` — invokes `{{app-item-details-linked-skills}}`
- `src/system/data/item/talent.ts` — `LinkedSkillsMixin()` added to the composition chain
- `src/templates/item/talent/partials/talent-details-tab.hbs` — invokes `{{app-item-details-linked-skills}}`

No new files, no new i18n keys (the existing `COSMERE.Item.General.LinkedSkills.Label` works for all types), no migration (Foundry V13 hydrates `linkedSkills: []` automatically via `cleanData` — verified experimentally, and consistent with how the previous linked-skills commit `1aa35e1` shipped without a migration).

A note on talents: issue #404 lists talents as "Maybe Talents too?". Including them means a `PathTalent` can declare its own linked skills in addition to those provided by its parent `Path`. This is opt-in by GMs (default `linkedSkills: []`) so it does not auto-pollute existing data, but the same skill can now appear linked to two items in the character sheet if a GM configures it that way. If preferred out of scope, the relevant changes are isolated to `talent.ts` and `talent-details-tab.hbs` — happy to drop them.

**Related Issue**  
Closes #404

**How Has This Been Tested?**  
Manual end-to-end validation on Foundry VTT v13.351, for each of the four new item types (connection, equipment, loot, talent):

1. Create an item of the given type, open its sheet, navigate to the Details tab.
2. Confirm the "Linked Skills" control is rendered and accepts skill selections.
3. Save, reopen the sheet, and confirm persistence.
4. Programmatic check: `Item.create({ ..., system: { linkedSkills: [...] } })` is accepted by the schema, and `item.hasLinkedSkills()` returns `true`.
5. Confirmed the control's `name` attribute resolves to `system.linkedSkills` so Foundry form submission round-trips correctly.

CI/local checks:
- `npm run build` — passes
- `npm run typecheck` — passes (baseline unchanged)
- `npm run lint` — passes (baseline unchanged)

**Screenshots (if applicable)**  
End-to-end validation video showing the UI on all four new types:

https://github.com/user-attachments/assets/e206f4fa-2264-4c3c-9703-8c081fba033b

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
The feature is additive and non-breaking: existing items default to `linkedSkills: []` and existing sheets are unaffected unless a GM populates the new field.
