### PR TITLE
fix(system embedded collections): correct document hierarchy resolution

### DIFF
--- a/src/system/documents/system-embedded-collections/mixin.ts
+++ b/src/system/documents/system-embedded-collections/mixin.ts
@@ -16,6 +16,10 @@ export function SystemEmbeddedCollectionsMixin<
         public readonly hasSystemEmbeddedCollections = true as const;
 
         declare static __schema: foundry.data.fields.SchemaField<foundry.data.fields.DataSchema>;
+        declare static __hierarchy: Record<
+            string,
+            foundry.data.fields.DataField.Any
+        >;
 
         static metadata = Object.freeze(
             foundry.utils.mergeObject(
@@ -69,6 +73,28 @@ export function SystemEmbeddedCollectionsMixin<
             });
 
             return this.__schema;
+        }
+
+        public static get hierarchy(): Record<
+            string,
+            foundry.data.fields.DataField.Any
+        > {
+            if (this.__hierarchy) return this.__hierarchy;
+
+            const hierarchy: Record<string, foundry.data.fields.DataField.Any> =
+                {};
+            for (const [fieldName, field] of this.schema.entries()) {
+                if (
+                    (field.constructor as typeof foundry.data.fields.DataField)
+                        .hierarchical
+                )
+                    hierarchy[fieldName] = field;
+            }
+            Object.defineProperty(this, '__hierarchy', {
+                value: Object.freeze(hierarchy),
+                writable: false,
+            });
+            return hierarchy;
         }
 
         public static isNativeEmbedding(embeddedName: string): boolean {


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue with the system defined embedded collections causing ephemeral document creation to fail.

**Related Issue**  
Closes #732 

**How Has This Been Tested?**  
1. Open console
2. Enter Item.create({ name: 'name', type: 'weapon' })

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351