### PR TITLE
fix(actions): resolve issue preventing embedded action usage

### DIFF
--- a/src/system/applications/actor/components/item-list.ts
+++ b/src/system/applications/actor/components/item-list.ts
@@ -125,11 +125,15 @@ any> {
             );
     }
 
-    public static onUseItem(this: ActorItemListComponent, event: Event) {
+    public static async onUseItem(this: ActorItemListComponent, event: Event) {
         event.preventDefault();
         event.stopPropagation();
+
         // Get item
-        const item = AppUtils.getItemFromEvent(event, this.application.actor);
+        const uuid = AppUtils.getItemUuidFromEvent(event);
+        if (!uuid) return;
+
+        const item = await fromUuid<CosmereItem>(uuid);
         if (!item) return;
 
         // Use the item

--- a/src/system/applications/utils/index.ts
+++ b/src/system/applications/utils/index.ts
@@ -12,6 +12,17 @@ export function getItemIdFromEvent(event: Event): string | undefined {
     return element.data('item-id') as string;
 }
 
+export function getItemUuidFromEvent(event: Event): string | undefined {
+    if (!event.target && !event.currentTarget) return;
+
+    const element = $(event.target ?? event.currentTarget!).closest(
+        '.item[data-item-uuid]',
+    );
+    if (element.length === 0) return;
+
+    return element.data('item-uuid') as string;
+}
+
 export function getItemFromEvent(
     event: Event,
     actor: CosmereActor,
@@ -38,6 +49,7 @@ export function getItemFromElement(
 
 export default {
     getItemIdFromEvent,
+    getItemUuidFromEvent,
     getItemFromEvent,
     getItemFromElement,
 };

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1052,8 +1052,6 @@ export class CosmereItem<
     public async use(
         options: CosmereItem.UseOptions = {},
     ): Promise<D20Roll | [D20Roll, ...DamageRoll[]] | null> {
-        console.log('USE', options);
-
         if (!this.isAction()) return null;
 
         // Set up post roll actions

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1052,6 +1052,8 @@ export class CosmereItem<
     public async use(
         options: CosmereItem.UseOptions = {},
     ): Promise<D20Roll | [D20Roll, ...DamageRoll[]] | null> {
+        console.log('USE', options);
+
         if (!this.isAction()) return null;
 
         // Set up post roll actions


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Resolves an issue introduced in recent merge that prevented embedded actions from being used from actor sheet.

**Related Issue**  
Closes #751 

**How Has This Been Tested?**  
1. Create actor
2. Create weapon
3. Open actor sheet
4. Add weapon to actor
5. Navigate to "actions" tab
6. Click strike action -> ensure rolls

**Checklist:**  
- ~[ ] I have commented on my code, particularly in hard-to-understand areas.~ N/A
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351