### PR TITLE
Fix/Context menu embedded actions fix #745

### DIFF
--- a/src/declarations/foundry/client/documents/item.d.ts
+++ b/src/declarations/foundry/client/documents/item.d.ts
@@ -1,6 +1,3 @@
 declare namespace Item {
     type Parent = Actor.Implementation | Item.Implementation | null;
-    namespace Embedded {
-        type Name = 'ActiveEffect' | 'Item';
-    }
 }

--- a/src/declarations/foundry/client/documents/item.d.ts
+++ b/src/declarations/foundry/client/documents/item.d.ts
@@ -1,3 +1,6 @@
 declare namespace Item {
     type Parent = Actor.Implementation | Item.Implementation | null;
+    namespace Embedded {
+        type Name = 'ActiveEffect' | 'Item';
+    }
 }

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -489,11 +489,24 @@ export class ActorActionsListComponent extends ActorItemListComponent {
                                 name: 'GENERIC.Button.Remove',
                                 icon: 'fa-solid fa-trash',
                                 callback: () => {
-                                    // Remove the item
-                                    void this.application.actor.deleteEmbeddedDocuments(
-                                        'Item',
-                                        [item.id!],
-                                    );
+                                    // Check if the Item's parent is not the actor
+                                    const parent = item.parent;
+                                    if (
+                                        parent &&
+                                        parent.documentName === 'Item'
+                                    ) {
+                                        // Remove the item from parent Item
+                                        void parent.deleteEmbeddedDocuments(
+                                            'Item',
+                                            [item.id!],
+                                        );
+                                    } else {
+                                        // If Item's parent is an Actor, remove the item from the Actor
+                                        void this.application.actor.deleteEmbeddedDocuments(
+                                            'Item',
+                                            [item.id!],
+                                        );
+                                    }
                                 },
                             },
                         );

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -489,24 +489,7 @@ export class ActorActionsListComponent extends ActorItemListComponent {
                                 name: 'GENERIC.Button.Remove',
                                 icon: 'fa-solid fa-trash',
                                 callback: () => {
-                                    // Check if the Item's parent is not the actor
-                                    const parent = item.parent;
-                                    if (
-                                        parent &&
-                                        parent.documentName === 'Item'
-                                    ) {
-                                        // Remove the item from parent Item
-                                        void parent.deleteEmbeddedDocuments(
-                                            'Item',
-                                            [item.id!],
-                                        );
-                                    } else {
-                                        // If Item's parent is an Actor, remove the item from the Actor
-                                        void this.application.actor.deleteEmbeddedDocuments(
-                                            'Item',
-                                            [item.id!],
-                                        );
-                                    }
+                                    void item.delete();
                                 },
                             },
                         );


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
adds "Item" as an embedded document name for Items to keep TS from complaining and prevent building
Modifies the action-list script to check if the item has a parent and if the parent is an Item. If it is an Item it will delete from the parent's embeddedCollection instead of the actor's. Otherwise it will use the normal behavior.


**Related Issue**  
Closes #745  

**How Has This Been Tested?**  
1. Create new actor
2. Give actor Singer ancestry
3. Go to Talents section
4. Edit Change Form
5. Go to actions section of dialogue
6. Add new action
7. Exit dialogue.
8. Navigate to Actions section of actor
9. Open context menu on the new action under Change Form
10. Press Remove
11. See that it has been removed from both Change Form's actions and the actor's action list.

**Screenshots (if applicable)**  
Before pressing delete on context menu in action's section
<img width="560" height="340" alt="image" src="https://github.com/user-attachments/assets/5f7eba17-6e4e-4725-99ff-efe99b6cbc28" />

After
<img width="534" height="373" alt="image" src="https://github.com/user-attachments/assets/357c58e5-6af1-4be4-9781-06970cfffa7c" />


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: v13 build 531.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
