### PR TITLE
fix(system embedded collections): update socket utils to consistently handle non-array collection data

### DIFF
--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -596,11 +596,19 @@ export function toServerViewObject(
                 [`system.${SYSTEM_EMBEDDED_COLLECTIONS_KEY}`]:
                     systemEmbeddedConfig.reduce(
                         (acc, [embeddedName, collectionName]) => {
-                            const collectionData = foundry.utils.getProperty(
+                            let collectionData = foundry.utils.getProperty(
                                 obj,
                                 collectionName,
                             ) as AnyObject[] | undefined;
                             if (!collectionData) return acc;
+
+                            collectionData = ensureArray(collectionData);
+                            if (!collectionData) {
+                                console.warn(
+                                    `Found non-iterable collection data for ${collectionName}. Skipping transformation for this collection.`,
+                                );
+                                return acc;
+                            }
 
                             return {
                                 ...acc,
@@ -624,11 +632,19 @@ export function toServerViewObject(
     // Handle native embedded collections
     Object.entries(cls.metadata.embedded).forEach(
         ([embeddedName, collectionName]) => {
-            const collectionData = foundry.utils.getProperty(
+            let collectionData = foundry.utils.getProperty(
                 obj,
                 collectionName,
             ) as AnyObject[] | undefined;
             if (!collectionData) return;
+
+            collectionData = ensureArray(collectionData);
+            if (!collectionData) {
+                console.warn(
+                    `Found non-iterable collection data for ${collectionName}. Skipping transformation for this collection.`,
+                );
+                return;
+            }
 
             foundry.utils.setProperty(
                 obj,
@@ -669,11 +685,19 @@ export function toClientViewObject(
     if (hasSystemEmbeddedCollections(cls)) {
         Object.entries(cls.metadata.systemEmbedded).forEach(
             ([embeddedName, collectionName]) => {
-                const collectionData = foundry.utils.getProperty(
+                let collectionData = foundry.utils.getProperty(
                     data,
                     `system.${SYSTEM_EMBEDDED_COLLECTIONS_KEY}.${collectionName}`,
                 ) as AnyObject[] | undefined;
                 if (!collectionData) return;
+
+                collectionData = ensureArray(collectionData);
+                if (!collectionData) {
+                    console.warn(
+                        `Found non-iterable collection data for ${collectionName}. Skipping transformation for this collection.`,
+                    );
+                    return;
+                }
 
                 foundry.utils.setProperty(
                     data,
@@ -713,24 +737,12 @@ export function toClientViewObject(
             );
             if (!collectionData) return;
 
-            const collectionDataType = foundry.utils.getType(collectionData);
-            if (collectionDataType !== 'Array') {
-                const isIterable =
-                    typeof collectionData === 'object' &&
-                    Symbol.iterator in collectionData &&
-                    typeof collectionData[Symbol.iterator] === 'function';
-
-                if (!isIterable) {
-                    console.warn(
-                        `Expected collection data for ${collectionName} to be an array or iterable, but got ${collectionDataType}. Skipping transformation for this collection.`,
-                        collectionData,
-                    );
-                    return;
-                }
-
-                collectionData = Array.from(
-                    collectionData as Iterable<AnyObject>,
+            collectionData = ensureArray(collectionData);
+            if (!collectionData) {
+                console.warn(
+                    `Found non-iterable collection data for ${collectionName}. Skipping transformation for this collection.`,
                 );
+                return;
             }
 
             foundry.utils.setProperty(
@@ -745,6 +757,21 @@ export function toClientViewObject(
     return toDocument
         ? new (cls as Document.Constructable.AnyConstructor)(data, { parent })
         : data;
+}
+
+function ensureArray<T extends unknown[]>(collectionData: T): T;
+function ensureArray(collectionData: unknown): unknown[] | null;
+function ensureArray(collectionData: unknown): unknown[] | null {
+    const collectionDataType = foundry.utils.getType(collectionData);
+    if (collectionDataType === 'Array') return collectionData as unknown[];
+
+    const isIterable =
+        typeof collectionData === 'object' &&
+        collectionData !== null &&
+        Symbol.iterator in collectionData &&
+        typeof collectionData[Symbol.iterator] === 'function';
+
+    return isIterable ? Array.from(collectionData as Iterable<unknown>) : null;
 }
 
 class DocumentHierarchy<


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes a bug in the system embedded documents socket utils that caused it to throw an error when encountering non-array collection data. This would then prevent actions being sent to/received from the backend. 

**Related Issue**  
Closes #770 

**How Has This Been Tested?**  
1. Create scene
2. Create adversary
3. Drag adversary into scene

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351