### PR TITLE
fix(rolls): make damage roll available when item has skill test and damage configured instead of attack

### DIFF
--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1231,16 +1231,14 @@ export class CosmereItem<
             });
         }
 
-        // Check if the item has an attack
-        const hasAttack = this.hasAttack();
+        const hasSkillTest =
+            this.system.activation!.type === ActivationType.SkillTest;
 
         // Check if the item has damage
         const hasDamage = this.hasDamage() && this.system.damage.formula;
 
         // Check if a roll is required
-        const rollRequired =
-            this.system.activation!.type === ActivationType.SkillTest ||
-            hasDamage;
+        const rollRequired = hasSkillTest || hasDamage;
 
         const messageConfig = {
             user: game.user.id,
@@ -1281,7 +1279,7 @@ export class CosmereItem<
             const rolls: foundry.dice.Roll[] = [];
             let flavor = this.system.activation!.flavor;
 
-            if (hasAttack && hasDamage) {
+            if (hasSkillTest && hasDamage) {
                 const attackResult = await this.rollAttack({
                     ...options,
                     skillTest: {


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Updates the item usage/rolling logic to include the damage roll whenever the item has a skill test and damage configured; Before this required a skill test, damage and an attack to be configured but actions don't contain attack data.

**Related Issue**  
Closes #760 

**How Has This Been Tested?**  
1. Create actor
2. Create weapon
3. Add weapon to actor
4. Use strike action from sheet -> Ensure damage roll is present

**Screenshots (if applicable)**  
<img width="766" height="471" alt="image" src="https://github.com/user-attachments/assets/4c6fed35-a6ea-40d3-8452-d739781056af" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351
