### PR TITLE
fix(system embedded documents): update socket utils to handle get response results correctly

### DIFF
--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -385,7 +385,7 @@ export function transformResponse(inResponse: SocketResponse): SocketResponse {
     const inRequest = inResponse.operation.sourceRequest;
 
     if (isGetRequest(inRequest)) {
-        return transformGetReponse(inResponse);
+        return transformGetResponse(inResponse);
     } else if (isCreateRequest(inRequest) || isUpdateRequest(inRequest)) {
         return transformCreateUpdateResponse(inResponse);
     } else if (isDeleteRequest(inRequest)) {
@@ -395,7 +395,7 @@ export function transformResponse(inResponse: SocketResponse): SocketResponse {
     return inResponse;
 }
 
-function transformGetReponse(inResponse: SocketResponse) {
+function transformGetResponse(inResponse: SocketResponse) {
     const inRequest = inResponse.operation.sourceRequest!;
 
     const result = inResponse.result?.map((r) => {

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -398,11 +398,13 @@ export function transformResponse(inResponse: SocketResponse): SocketResponse {
 function transformGetReponse(inResponse: SocketResponse) {
     const inRequest = inResponse.operation.sourceRequest!;
 
-    if (!inResponse.result || inResponse.result.length !== 1) return inResponse;
-    const result = inResponse.result[0] as AnyMutableObject;
+    const result = inResponse.result?.map((r) => {
+        if (typeof r === 'string') return r;
+        return toClientViewObject(r, inRequest.type);
+    });
 
     return foundry.utils.mergeObject(inResponse, {
-        result: [toClientViewObject(result, inRequest.type)],
+        result,
     }) as SocketResponse;
 }
 


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes a bug causing system embedded documents, embedded on a document inside a compendium, to seemingly disappear (client-side) after querying the compendium for it and at least one other document.

**Related Issue**  
Closes #744 

**How Has This Been Tested?**  
1.  Create item compendium
2. Add any item to the compendium
3. Add an item with an action to the compendium
4. Copy the id (not uuid) for both items
5. From the console call: `game.packs.get('<pack id>').getDocuments({ _id__in: [ '<item1_id>', '<item2_id>' ] })`
6. Open the compendium and find the item with the action -> Ensure action is still present

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351