### PR TITLE
feat(embedded actions): add drag-drop support

### DIFF
--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -15,12 +15,14 @@ import {
 } from '@system/types/utils';
 import { renderSystemTemplate, TEMPLATES } from '@src/system/utils/templates';
 
-
+// Utils
+import AppUtils from '@system/applications/utils';
 
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
 import {
     TabsApplicationMixin,
+    DragDropApplicationMixin,
     TabApplicationRenderOptions,
 } from '@system/applications/mixins';
 import { DescriptionItemData } from '@src/system/data/item/mixins/description';
@@ -38,7 +40,7 @@ export type BaseItemSheetConfiguration =
 export type BaseItemSheetRenderOptions = TabApplicationRenderOptions;
 
 export class BaseItemSheet extends TabsApplicationMixin(
-    ComponentHandlebarsApplicationMixin(ItemSheetV2),
+    DragDropApplicationMixin(ComponentHandlebarsApplicationMixin(ItemSheetV2)),
 ) {
     declare item: CosmereItem;
 
@@ -56,6 +58,12 @@ export class BaseItemSheet extends TabsApplicationMixin(
             'edit-description': this.editDescription,
             save: this.onSave,
         },
+        dragDrop: [
+            {
+                dragSelector: '[data-drag]',
+                dropSelector: '*',
+            },
+        ],
     } as foundry.applications.api.ApplicationV2.DefaultOptions;
     /* eslint-enable @typescript-eslint/unbound-method */
 
@@ -377,6 +385,57 @@ export class BaseItemSheet extends TabsApplicationMixin(
         await this.saveDescription();
     }
 
+    /* --- Drag drop --- */
+
+    protected override _canDragStart(): boolean {
+        return this.isEditable;
+    }
+
+    protected override _canDragDrop(): boolean {
+        return this.isEditable;
+    }
+
+    protected override _onDragStart(event: DragEvent) {
+        // Get dragged item
+        const itemUuid = AppUtils.getItemUuidFromEvent(event);
+        const item = fromUuidSync(itemUuid);
+        if (!item) return;
+
+        const dragData = {
+            type: 'Item',
+            uuid: item.uuid,
+        };
+
+        // Set data transfer
+        event.dataTransfer!.setData('text/plain', JSON.stringify(dragData));
+        event.dataTransfer!.setData('document/item', ''); // Mark the type
+    }
+
+    protected override async _onDrop(event: DragEvent) {
+        const data =
+            foundry.applications.ux.TextEditor.implementation.getDragEventData(
+                event,
+            ) as {
+                type: foundry.abstract.Document.Type;
+                uuid: string;
+            };
+
+        // Ensure document type can be embedded on item
+        if (!(data.type in Item.implementation.metadata.embedded)) return;
+
+        const document = await fromUuid(data.uuid);
+        if (!document) return;
+
+        if (document.parent === this.item) return;
+
+        void this.item.createEmbeddedDocuments(
+            data.type as Item.Embedded.Name,
+            [
+                document.toObject() as foundry.abstract.Document.CreateDataForName<Item.Embedded.Name>,
+            ],
+        );
+    }
+
     /* --- Lifecycle --- */
 
     protected async _onRender(context: AnyObject, options: AnyObject) {
@@ -404,6 +463,4 @@ export class BaseItemSheet extends TabsApplicationMixin(
         this.updatingDescription = false;
         await this.render(true);
     }
-
-
 }

--- a/src/system/applications/item/components/actions-list.ts
+++ b/src/system/applications/item/components/actions-list.ts
@@ -56,21 +56,15 @@ export class ItemActionsListComponent extends HandlebarsApplicationComponent<
     }
 
     private static onEditAction(this: ItemActionsListComponent, event: Event) {
-        console.log('onEditAction', event);
-
         // Get id
         const id = $(event.target!).closest('.action[data-id]').data('id') as
             | string
             | undefined;
         if (!id) return;
 
-        console.log('Action id:', id);
-
         // Get action
         const action = this.item.items.get(id);
         if (!action) return;
-
-        console.log('Action:', action);
 
         void action.sheet?.render(true);
     }

--- a/src/system/documents/embed-config/mixin.ts
+++ b/src/system/documents/embed-config/mixin.ts
@@ -124,6 +124,8 @@ export function EmbedConfigMixin<
                         }
                     }
                 }
+
+                return true;
             });
 
             // Perform create

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -123,6 +123,8 @@ function transformGetRequest(
 async function transformCRUDRequest(
     inRequest: DocumentSocketRequest<DatabaseCRUDAction>,
 ): Promise<DocumentSocketRequest> {
+    if (isCreateRequest(inRequest)) assignIdsCreateRequest(inRequest);
+
     const targets = await getCRUDRequestTargets(inRequest);
     if (targets.length === 0) return inRequest;
 
@@ -184,6 +186,20 @@ async function transformCRUDRequest(
             outRequest,
         ) as DocumentSocketRequest<'update'>;
     }
+}
+
+function assignIdsCreateRequest(request: DocumentSocketRequest<'create'>) {
+    request.operation.data = request.operation.data.map((data) => {
+        if (data) {
+            if (data instanceof foundry.abstract.Document) {
+                data = data.toObject();
+            }
+
+            foundry.utils.setProperty(data, '_id', foundry.utils.randomID());
+        }
+
+        return data;
+    });
 }
 
 async function getCRUDRequestTargets(

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -22,7 +22,11 @@
 
     {{#each actions as |action|}}
     {{#with (itemContext action) as |ctx|}}
-        <li class="item action" data-id="{{action.id}}">
+        <li class="item action" 
+            data-id="{{action.id}}" 
+            data-item-uuid="{{action.uuid}}"
+            {{#if @root.editable}}data-drag="true"{{/if}}
+        >
             <section class="details">
                 {{!-- Image --}}
                 <div class="img">


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds drag-drop support for embedded actions: 
- Allows you to drag actions from anywhere onto an item and have it embedded (like items on actors)
- Allows you to drag actions from the actions list on items
<img width="1364" height="662" alt="foundry-action-drag-drop" src="https://github.com/user-attachments/assets/e0ebe6d1-e7b5-45b7-88ae-05ec1c476cbc" />

**Related Issue**  
Partially addresses #358, Closes #737 

**How Has This Been Tested?**  
1. Create weapon
2. Create action
3. Open weapon item sheet
4. Drag action onto weapon sheet -> Ensure action is embedded
5. Drag strike action from weapon sheet into global items -> Ensure strike is added

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351