### PR TITLE
feat(action data model): restore action system.type

### DIFF
--- a/src/system/data/item/action/index.ts
+++ b/src/system/data/item/action/index.ts
@@ -33,6 +33,13 @@ const SCHEMA = () => ({
     }),
     damage: new DamageField(),
     skillTest: new SkillTestField(),
+    ancestry: new foundry.data.fields.StringField({
+        required: false,
+        nullable: true,
+        initial: null,
+        label: 'COSMERE.Item.Action.Ancestry.Label',
+        hint: 'COSMERE.Item.Action.Ancestry.Hint',
+    }),
 });
 
 export class ActionItemDataModel extends DataModelMixin<ActionItemDataModel.Schema>(

--- a/src/system/data/item/action/index.ts
+++ b/src/system/data/item/action/index.ts
@@ -11,7 +11,7 @@ import { DataModelMixin } from '../../mixins';
 import { IdItemMixin, IdItemDataSchema } from '../mixins/id';
 import {
     TypedItemMixin,
-    //    TypedItemDataSchema,
+    TypedItemDataSchema,
     //    TypedItemDerivedData,
 } from '../mixins/typed';
 import {
@@ -76,7 +76,7 @@ export class ActionItemDataModel extends DataModelMixin<ActionItemDataModel.Sche
 export namespace ActionItemDataModel {
     export type Schema = ReturnType<typeof SCHEMA> &
         IdItemDataSchema &
-        // & TypedItemDataSchema<ActionType>
+        TypedItemDataSchema<ActionType> &
         DescriptionItemDataSchema &
         ResourcesItemMixin.Schema &
         ModalityItemDataSchema &
@@ -86,7 +86,7 @@ export namespace ActionItemDataModel {
     export type InitializedData =
         foundry.data.fields.SchemaField.InitializedData<Schema>;
 
-    // export type DerivedData = TypedItemDerivedData;
+    //    export type DerivedData = TypedItemDerivedData;
 
     export type ConsumeData =
         ActivationField.InitializedData['consumption'][number];

--- a/src/system/data/item/action/index.ts
+++ b/src/system/data/item/action/index.ts
@@ -1,4 +1,4 @@
-// import { ActionType } from '@system/types/cosmere';
+import { ActionType } from '@system/types/cosmere';
 // import { EmptyObject } from '@system/types/utils';
 
 // Fields
@@ -9,11 +9,11 @@ import { SkillTestField } from './fields/skill-test';
 // Mixins
 import { DataModelMixin } from '../../mixins';
 import { IdItemMixin, IdItemDataSchema } from '../mixins/id';
-// import {
-//     TypedItemMixin,
-//     TypedItemDataSchema,
-//     TypedItemDerivedData,
-// } from '../mixins/typed';
+import {
+    TypedItemMixin,
+    //    TypedItemDataSchema,
+    //    TypedItemDerivedData,
+} from '../mixins/typed';
 import {
     DescriptionItemMixin,
     DescriptionItemDataSchema,
@@ -42,17 +42,17 @@ export class ActionItemDataModel extends DataModelMixin<ActionItemDataModel.Sche
     IdItemMixin({
         initialFromName: true,
     }),
-    // TypedItemMixin({
-    //     initial: ActionType.Basic,
-    //     choices: () =>
-    //         Object.entries(CONFIG.COSMERE.action.types).reduce(
-    //             (acc, [key, config]) => ({
-    //                 ...acc,
-    //                 [key]: config.label,
-    //             }),
-    //             {} as Record<ActionType, string>,
-    //         ),
-    // }),
+    TypedItemMixin({
+        initial: ActionType.Basic,
+        choices: () =>
+            Object.entries(CONFIG.COSMERE.action.types).reduce(
+                (acc, [key, config]) => ({
+                    ...acc,
+                    [key]: config.label,
+                }),
+                {} as Record<ActionType, string>,
+            ),
+    }),
     DescriptionItemMixin({
         value: 'COSMERE.Item.Type.Action.desc_placeholder',
     }),

--- a/src/system/data/item/action/index.ts
+++ b/src/system/data/item/action/index.ts
@@ -33,13 +33,6 @@ const SCHEMA = () => ({
     }),
     damage: new DamageField(),
     skillTest: new SkillTestField(),
-    ancestry: new foundry.data.fields.StringField({
-        required: false,
-        nullable: true,
-        initial: null,
-        label: 'COSMERE.Item.Action.Ancestry.Label',
-        hint: 'COSMERE.Item.Action.Ancestry.Hint',
-    }),
 });
 
 export class ActionItemDataModel extends DataModelMixin<ActionItemDataModel.Schema>(

--- a/src/templates/item/action/partials/action-details-tab.hbs
+++ b/src/templates/item/action/partials/action-details-tab.hbs
@@ -5,20 +5,7 @@
         <legend>{{localize "COSMERE.Item.Sheet.Basics"}}</legend>        
         {{app-item-details-id}}
         {{app-item-details-type}}
-        {{#if (eq @root.item.system.type "ancestry")}}
-        <div class="item-details-form">
-            <div class="form-group">
-                <label>{{localize @root.systemFields.ancestry.label}}</label>
-                {{app-id-input
-                    name="system.ancestry"
-                    value=@root.item.system.ancestry
-                }}
-            </div>
-            <p class="hint">
-                {{localize @root.systemFields.ancestry.hint}}
-            </p>
-        </div>        
-        {{/if}}
+
     </fieldset>
     {{app-item-details-activation}}
     {{app-item-details-resources}}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Restores the system.type property for action items by simply uncommenting the mixin and data model in the schema. the ancestry field in the schema was also just copy/pasted from an older version

**Related Issue**  
Closes #786 

**How Has This Been Tested?**  
1. created new action item
2. assigned a different value to the Type property in the Details tab
3. created new weapon item
4. created new embedded action on weapon item
5. assigned the Type property on the embedded action
6. added these items to a character and adversary
7. used the actions
8. ensured there were no new errors in the console from any of these steps
9. refreshed the world and confirmed changes persisted correctly

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version: 13.351

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
