### PR TITLE
Fix: Make Item Reference Field Take Up Entire Width

### DIFF
--- a/src/style/sheets/item/module.scss
+++ b/src/style/sheets/item/module.scss
@@ -443,6 +443,11 @@
         display: flex;
         flex-direction: column;
         gap: 0.25rem;
+        
+        p {
+            flex: 1;
+            min-height: 32px;
+        }
 
         .drop-area {
             margin: 0;


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
It seems someone else have already merged a fix in 3.0.0 but it seems to have missed the free talents field.
Just copies the same styling as used in `app-document-reference-input >*` to also apply to the Free Talents.

**Related Issue**  
closes #606 

**How Has This Been Tested?**  

1. Create ancestry item
2. Go to details tab
3. Check "Free Path" and "Free Talents" fields under advancement.
4. Go to events tab
5. Create event
6. Set handler type to "Use Item"
7. Check "Item" field

**Screenshots (if applicable)**  
<img width="512" height="212" alt="image" src="https://github.com/user-attachments/assets/68119558-0d9c-4610-b91d-3d62fbb5e1c2" />

Including this as well since its involved in the bug report even if it is already fixed in 3.0.0
<img width="472" height="113" alt="image" src="https://github.com/user-attachments/assets/ae898ccb-a49f-4125-9b6c-4e664b26a5b5" />


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: v13 build 351