### PR TITLE
fix: Adds a check to ensure changes.system contains strike

### DIFF
--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -569,7 +569,8 @@ export class CosmereItem<
                 (changes.system?.strike?.skillLocked ||
                     this.system.strike.skillLocked) &&
                 weaponType !== WeaponType.Special &&
-                !!changes.system
+                !!changes.system &&
+                changes.system?.strike
             ) {
                 const strike = foundry.utils.mergeObject(
                     changes.system.strike,

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -566,11 +566,10 @@ export class CosmereItem<
             const changes = changed as Partial<WeaponItem>;
             const weaponType = changes.system?.type ?? this.system.type;
             if (
-                (changes.system?.strike?.skillLocked ||
-                    this.system.strike.skillLocked) &&
+                !!changes.system?.strike &&
                 weaponType !== WeaponType.Special &&
-                !!changes.system &&
-                changes.system?.strike
+                (changes.system.strike.skillLocked ||
+                    this.system.strike.skillLocked)
             ) {
                 const strike = foundry.utils.mergeObject(
                     changes.system.strike,


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Aims to fix the bug which prevents you from creating events on weapon items

**Related Issue**  
Closes #790 

**How Has This Been Tested?**  
1. Create new weapon item
2. Go to events
3. Press + to create a new event
4. Event is created and no error.

**Screenshots (if applicable)**  
<img width="525" height="181" alt="image" src="https://github.com/user-attachments/assets/8a7228a2-bebc-4f1c-b26e-f550105dc218" />


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: [insert version here].
