### PR TITLE
Fix/compendium items can be edited using controls menu #788

### DIFF
--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -454,9 +454,13 @@ export class ActorActionsListComponent extends ActorItemListComponent {
                         .closest('.item[data-item-uuid]')
                         .data('item-uuid') as string;
 
-                    // Get item
-                    const item = fromUuidSync(itemUuid) as CosmereItem;
-                    if (!item) return [];
+                    // Get item from loaded actor sheet
+                    const item =
+                        this.application.actor.getNestedEmbeddedItemFromUuid(
+                            itemUuid,
+                        );
+
+                    if (!(item instanceof CosmereItem)) return [];
 
                     const menuItems = [];
 

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -622,8 +622,8 @@ export class CosmereActor<
      * @param itemUuid The UUID of the item you want to get
      * @returns An Item or null if no item could be found.
      */
-    public getNestedEmbeddedItem(itemUuid: string): Item | null {
-        for (const document of this.traverseEmbeddedDocuments()) {
+    public getNestedEmbeddedItemFromUuid(itemUuid: string): Item | null {
+        for (const [, document] of this.traverseEmbeddedDocuments()) {
             if (document instanceof Item && document.uuid === itemUuid) {
                 return document;
             }

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -617,6 +617,21 @@ export class CosmereActor<
 
     /* --- Functions --- */
 
+    /** Returns an embedded item in an actor regardless of how deeply nested it is, if it exists.
+     *
+     * @param itemUuid The UUID of the item you want to get
+     * @returns An Item or null if no item could be found.
+     */
+    public getNestedEmbeddedItem(itemUuid: string): Item | null {
+        for (const document of this.traverseEmbeddedDocuments()) {
+            if (document instanceof Item && document.uuid === itemUuid) {
+                return document;
+            }
+        }
+
+        return null;
+    }
+
     public async setMode(modality: string, mode: string) {
         await this.setFlag(SYSTEM_ID, `mode.${modality}`, mode);
 


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where you could not edit compendium items using the toggle controls context menu
Also adds a new function to CosmereActor sheets that allows you to search for nested items using UUID

**Related Issue**  
Closes #788 

**How Has This Been Tested?**  
Compendium check
1. Create new world
2. Go to compendium
3. Starter rules
4. Unlock Companions and Adversaries and open it
5. Open Archer
6. Select Take Aim and open its toggle controls menu
7. Edit
8. Change name if you want
9. See that it has changed the name in the compendium

Nested check
10. Go to actors
11. Create new actor
12. Go to equipment
13. Create new armor
14. Add action to armor
15. Go to actions actor tab
16. Press toggle controls
17. Press edit
18. See that it goes to the right action that is nested within the armor.

**Screenshots (if applicable)**  
<img width="943" height="1154" alt="image" src="https://github.com/user-attachments/assets/3e825c45-eda3-4616-8f73-efeec2c39c54" />

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] I have tested my changes on Foundry VTT version: v13 build 351.
