### PR TITLE
feat(documents): refactor weapon strikes to be ephemeral documents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import './style.scss';
 import './system/mixins';
 import './system/documents/system-embedded-collections/inject';
 import './system/documents/embed-config/inject';
+import './system/documents/ephemeral-embeds/inject';
 
 import {
     registerItemEventSystem,

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1306,6 +1306,7 @@
                     "Create": "Add Action",
                     "Edit": "Edit",
                     "Delete": "Remove",
+                    "View": "View",
                     "NewAction": {
                         "Name": "New Action"
                     }

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -15,8 +15,6 @@ import {
 } from '@system/types/utils';
 import { renderSystemTemplate, TEMPLATES } from '@src/system/utils/templates';
 
-
-
 // Mixins
 import { ComponentHandlebarsApplicationMixin } from '@system/applications/component-system';
 import {
@@ -288,7 +286,9 @@ export class BaseItemSheet extends TabsApplicationMixin(
     /* --- Context --- */
 
     public async _prepareContext(
-        options: DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions>,
+        options: DeepPartial<foundry.applications.api.ApplicationV2.RenderOptions> & {
+            editable?: boolean;
+        },
     ) {
         let enrichedDescValue = undefined;
         let enrichedShortDescValue = undefined;
@@ -312,7 +312,7 @@ export class BaseItemSheet extends TabsApplicationMixin(
             item: this.item,
             systemFields: this.item.system.schema
                 .fields as foundry.data.fields.DataSchema,
-            editable: this.isEditable,
+            editable: options.editable ?? this.isEditable,
             isUpdatingDescription: this.isUpdatingDescription,
             descHtml: enrichedDescValue,
             shortDescHtml: enrichedShortDescValue,
@@ -404,6 +404,4 @@ export class BaseItemSheet extends TabsApplicationMixin(
         this.updatingDescription = false;
         await this.render(true);
     }
-
-
 }

--- a/src/system/applications/item/components/actions-list.ts
+++ b/src/system/applications/item/components/actions-list.ts
@@ -27,6 +27,7 @@ export class ItemActionsListComponent extends HandlebarsApplicationComponent<
         'create-action': this.onCreateAction,
         'edit-action': this.onEditAction,
         'delete-action': this.onDeleteAction,
+        'view-action': this.onViewAction,
     };
     /* eslint-enable @typescript-eslint/unbound-method */
 
@@ -90,6 +91,20 @@ export class ItemActionsListComponent extends HandlebarsApplicationComponent<
         if (!action) return;
 
         void action.deleteDialog();
+    }
+
+    private static onViewAction(this: ItemActionsListComponent, event: Event) {
+        // Get id
+        const id = $(event.target!).closest('.action[data-id]').data('id') as
+            | string
+            | undefined;
+        if (!id) return;
+
+        // Get action
+        const action = this.item.items.get(id);
+        if (!action) return;
+
+        void action.sheet?.render({ force: true, editable: false });
     }
 
     /* --- Context --- */

--- a/src/system/documents/embed-config/mixin.ts
+++ b/src/system/documents/embed-config/mixin.ts
@@ -1,11 +1,12 @@
 import type { Document } from '@system/types/foundry/document';
 
+import type { EmbeddedDocumentsConfig } from './types';
 import type {
-    EmbeddedDocumentsConfig,
     EmbeddedTypesOf,
     DocumentTypeOf,
     TypedCreateDataForName,
-} from './types';
+} from '@system/types/utils';
+
 import { isAmountLimit, isBooleanLimit, isEmbedLimit } from './utils';
 
 export function EmbedConfigMixin<

--- a/src/system/documents/embed-config/types.ts
+++ b/src/system/documents/embed-config/types.ts
@@ -1,29 +1,4 @@
-import type { Document } from '@system/types/foundry/document';
-import type { KnownKeys } from '@system/types/utils';
-
-type NativeEmbeddedTypesOf<
-    DocumentType extends foundry.abstract.Document.Type,
-> = KnownKeys<foundry.abstract.Document.MetadataFor<DocumentType>['embedded']>;
-
-type SystemEmbeddedTypesOf<
-    DocumentType extends foundry.abstract.Document.Type,
-> = DocumentType extends keyof ConfiguredSystemEmbeddedCollections
-    ? keyof ConfiguredSystemEmbeddedCollections[DocumentType]
-    : never;
-
-export type EmbeddedTypesOf<
-    DocumentType extends foundry.abstract.Document.Type,
-> = NativeEmbeddedTypesOf<DocumentType> | SystemEmbeddedTypesOf<DocumentType>;
-
-export type DocumentTypeOf<
-    DocumentClass extends Document.Constructable.SystemConstructor,
-> = DocumentClass['metadata']['name'];
-
-export type TypedCreateDataForName<
-    DocumentName extends foundry.abstract.Document.Type,
-> = foundry.abstract.Document.CreateDataForName<DocumentName> & {
-    type: foundry.abstract.Document.SubTypesOf<DocumentName>;
-};
+import type { EmbeddedTypesOf } from '@system/types/utils';
 
 /**
  * The behavior to apply when an embed limit is exceeded.

--- a/src/system/documents/embed-config/utils.ts
+++ b/src/system/documents/embed-config/utils.ts
@@ -2,7 +2,6 @@ import type {
     EmbedLimit,
     AmountLimitConfig,
     BooleanLimitConfig,
-    TypedCreateDataForName,
 } from './types';
 
 export function isEmbedLimit(config: unknown): config is EmbedLimit {

--- a/src/system/documents/ephemeral-embeds/inject.ts
+++ b/src/system/documents/ephemeral-embeds/inject.ts
@@ -1,0 +1,6 @@
+import { EphemeralEmbeddedDocumentsMixin } from './mixin';
+
+globalThis.Item = EphemeralEmbeddedDocumentsMixin(Item);
+
+foundry.utils.setProperty(foundry, 'documents.Item', globalThis.Item);
+foundry.utils.setProperty(CONFIG, 'Item.documentClass', globalThis.Item);

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -1,0 +1,130 @@
+// Types
+import type { Document } from '@system/types/foundry/document';
+import type {
+    EmbeddedTypesOf,
+    DocumentTypeOf,
+    AnyObject,
+    AnyMutableObject,
+    DocumentOfType,
+} from '@system/types/utils';
+import type { EphemeralEmbeddedDocumentsConfig } from './types';
+
+// Utils
+import { Logger } from '@system/utils/logger';
+
+// Constants
+import { SYSTEM_ID } from '@system/constants';
+
+export function EphemeralEmbeddedDocumentsMixin<
+    const DocumentClass extends Document.Constructable.SystemConstructor,
+    const DocumentType extends
+        foundry.abstract.Document.WithSubTypes = DocumentTypeOf<DocumentClass>,
+    const InstanceType extends
+        DocumentOfType<DocumentType> = DocumentOfType<DocumentType>,
+>(cls: DocumentClass) {
+    return class EphemeralEmbeddedDocumentsDocument extends cls {
+        private ephemeralUpdate = false;
+
+        declare type: foundry.abstract.Document.SubTypesOf<DocumentType>;
+
+        declare static metadata: foundry.abstract.Document.MetadataFor<DocumentType> & {
+            ephemeralEmbedded: EphemeralEmbeddedDocumentsConfig<DocumentType>;
+        };
+
+        override _initialize(
+            options?: foundry.abstract.Document.InitializeOptions,
+        ) {
+            super._initialize(options);
+
+            if (!this.ephemeralUpdate) this.injectEphemeralDocuments();
+        }
+
+        protected injectEphemeralDocuments(): void {
+            const constructor = this
+                .constructor as unknown as typeof EphemeralEmbeddedDocumentsDocument;
+            const metadata = constructor.metadata;
+
+            const configForSubType =
+                metadata.ephemeralEmbedded[this.type] ??
+                metadata.ephemeralEmbedded.base;
+            if (!configForSubType) return;
+
+            const embedded = Object.entries(metadata.embedded) as [
+                EmbeddedTypesOf<DocumentType>,
+                string,
+            ][];
+            const changes: AnyMutableObject = {};
+
+            embedded.forEach(([embeddedName, field]) => {
+                try {
+                    const generatorFn = configForSubType[embeddedName] as (
+                        this: DocumentOfType<DocumentType>,
+                    ) => DocumentOfType<typeof embeddedName>[];
+                    if (!generatorFn) return;
+
+                    const collection = this.getEmbeddedCollection(
+                        embeddedName as never,
+                    ) as foundry.abstract.EmbeddedCollection<
+                        DocumentOfType<typeof embeddedName>,
+                        InstanceType
+                    >;
+
+                    const ephemeralDocuments = generatorFn.call(
+                        this as unknown as DocumentOfType<DocumentType>,
+                    );
+                    const concreteDocuments = Array.from(collection);
+
+                    changes[field] = [
+                        ...ephemeralDocuments.map((doc) =>
+                            foundry.utils.mergeObject(doc.toObject(), {
+                                flags: {
+                                    [SYSTEM_ID]: {
+                                        meta: {
+                                            isEphemeral: true,
+                                        },
+                                    },
+                                },
+                            }),
+                        ),
+                        ...concreteDocuments
+                            .map((doc) => doc.toObject())
+                            .filter(
+                                (doc) =>
+                                    !foundry.utils.getProperty(
+                                        doc,
+                                        `flags.${SYSTEM_ID}.meta.isEphemeral`,
+                                    ),
+                            ),
+                    ];
+                } catch (err) {
+                    Logger.error(
+                        'ephemeralEmbeddedDocuments',
+                        `Error occured while setting epehemeral embedded documents for ${this.uuid} ${field}`,
+                        err,
+                    );
+                }
+            });
+
+            if (Object.keys(changes).length === 0) return;
+
+            this.ephemeralUpdate = true;
+
+            // Call updateSource and set each collection to an empty array to prevent ephemeral documents from being ordered after concrete documents
+            this.updateSource(
+                Object.keys(changes).reduce(
+                    (acc, field) => ({
+                        ...acc,
+                        [field]: [],
+                    }),
+                    {} as AnyObject,
+                ),
+                { recursive: false },
+            );
+
+            // Call updateSource with actual data to set collections to correct state
+            this.updateSource(changes, { recursive: false });
+
+            this.ephemeralUpdate = false;
+        }
+    };
+}

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -72,7 +72,15 @@ export function EphemeralEmbeddedDocumentsMixin<
                     const ephemeralDocuments = generatorFn.call(
                         this as unknown as DocumentOfType<DocumentType>,
                     );
-                    const concreteDocuments = Array.from(collection);
+                    const concreteDocuments = (
+                        Array.from(collection) as DocumentOfType<DocumentType>[]
+                    ).filter(
+                        (doc) =>
+                            !foundry.utils.getProperty(
+                                doc,
+                                `flags.${SYSTEM_ID}.meta.isEphemeral`,
+                            ),
+                    );
 
                     changes[field] = [
                         ...ephemeralDocuments.map((doc) =>
@@ -86,15 +94,7 @@ export function EphemeralEmbeddedDocumentsMixin<
                                 },
                             }),
                         ),
-                        ...concreteDocuments
-                            .map((doc) => doc.toObject())
-                            .filter(
-                                (doc) =>
-                                    !foundry.utils.getProperty(
-                                        doc,
-                                        `flags.${SYSTEM_ID}.meta.isEphemeral`,
-                                    ),
-                            ),
+                        ...concreteDocuments.map((doc) => doc.toObject()),
                     ];
                 } catch (err) {
                     Logger.error(

--- a/src/system/documents/ephemeral-embeds/types.ts
+++ b/src/system/documents/ephemeral-embeds/types.ts
@@ -1,0 +1,13 @@
+import type { EmbeddedTypesOf, DocumentOfType } from '@system/types/utils';
+
+export type EphemeralEmbeddedDocumentsConfig<
+    DocumentName extends foundry.abstract.Document.WithSubTypes,
+> = {
+    [DocumentType in
+        | foundry.abstract.Document.SubTypesOf<DocumentName>
+        | 'base']?: {
+        [EmbeddedName in EmbeddedTypesOf<DocumentName>]?: (
+            this: DocumentOfType<DocumentName>,
+        ) => DocumentOfType<EmbeddedName>[];
+    };
+};

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -18,6 +18,7 @@ import { AnyObject, EmptyObject, DeepPartial } from '@system/types/utils';
 import { Rule } from '@system/types/item/event-system';
 
 import type { EmbeddedDocumentsConfig } from './embed-config/types';
+import type { EphemeralEmbeddedDocumentsConfig } from './ephemeral-embeds/types';
 
 // Data model
 import {
@@ -139,6 +140,7 @@ class _Item<
 > extends Item<'base'> {
     declare static metadata: foundry.abstract.Document.MetadataFor<'Item'> & {
         embeddedConfig: EmbeddedDocumentsConfig<'Item'>;
+        ephemeralEmbedded: EphemeralEmbeddedDocumentsConfig<'Item'>;
     };
 
     // @ts-expect-error Explicitly declare to get proper typing
@@ -194,6 +196,14 @@ export class CosmereItem<
                         Item: false, // Disable embedding of items in talent tree items
                     },
                 } as EmbeddedDocumentsConfig<'Item'>,
+                // Note: Cannot bind due to static context. Calls are bound safely by mixin.
+                /* eslint-disable @typescript-eslint/unbound-method */
+                ephemeralEmbedded: {
+                    weapon: {
+                        Item: CosmereItem.prepareEphemeralItems,
+                    },
+                },
+                /* eslint-enable @typescript-eslint/unbound-method */
             },
             { inplace: false },
         ),
@@ -201,7 +211,7 @@ export class CosmereItem<
 
     /* --- ItemType type guards --- */
 
-    public isWeapon(): this is CosmereItem<WeaponItemDataModel> {
+    public isWeapon(): this is WeaponItem {
         return this.type === ItemType.Weapon;
     }
 
@@ -397,7 +407,9 @@ export class CosmereItem<
     }
 
     public get isStrikeAction(): boolean {
-        return this.isAction() && !!this.getFlag(SYSTEM_ID, 'isStrike');
+        return (
+            this.isDefaultActivation && !!this.getFlag(SYSTEM_ID, 'isStrike')
+        );
     }
 
     public get isActivatable(): boolean {
@@ -478,6 +490,24 @@ export class CosmereItem<
         return this.system.events.filter((event) => !event.disabled) as Rule[];
     }
 
+    public get strikeAction(): ActionItem | null {
+        if (!this.isWeapon()) return null;
+
+        const strike = this.actions.find(
+            (action) =>
+                action.system.id === `strike-${this.system.id}` &&
+                action.isStrikeAction,
+        );
+
+        // Strike action is ephemeral and should always exist
+        if (!strike)
+            throw new Error(
+                'Invalid Item state. Unable to find strike action.',
+            );
+
+        return strike;
+    }
+
     /* --- Lifecycle --- */
 
     public override async _onClickDocumentLink(event: MouseEvent) {
@@ -527,40 +557,6 @@ export class CosmereItem<
         );
     }
 
-    protected _onCreate(
-        data: Item.CreateData,
-        options: Item.Database.OnCreateOperation,
-        userId: string,
-    ): void {
-        if (this.isWeapon()) {
-            void this.prepareWeaponStrikes();
-        }
-
-        super._onCreate(data, options, userId);
-    }
-
-    protected _onUpdate(
-        changed: Item.UpdateData,
-        options: Item.Database.OnUpdateOperation,
-        userId: string,
-    ): void {
-        super._onUpdate(changed, options, userId);
-
-        if (this.isWeapon()) {
-            const changes = changed as Partial<WeaponItem>;
-            if (
-                changes.name ||
-                changes.img ||
-                changes.system?.id ||
-                changes.system?.description ||
-                changes.system?.type ||
-                changes.system?.strike
-            ) {
-                void this.prepareWeaponStrikes();
-            }
-        }
-    }
-
     protected _preUpdate(
         changed: Item.UpdateData,
         options: Item.Database.PreUpdateOptions,
@@ -583,7 +579,7 @@ export class CosmereItem<
                     changes.system.strike,
                     { skill: this.weaponTypeToSkill(weaponType) },
                 );
-                console.log(strike);
+
                 changes.system.strike = foundry.utils.mergeObject(
                     this.system.strike,
                     strike,
@@ -592,6 +588,23 @@ export class CosmereItem<
         }
 
         return super._preUpdate(changed, options, user);
+    }
+
+    protected static prepareEphemeralItems(this: CosmereItem): CosmereItem[] {
+        if (!this.isWeapon()) return [];
+
+        return [
+            // Weapon strike
+            new CosmereItem({
+                type: ItemType.Action,
+                ...this.weaponStrikeData(),
+                flags: {
+                    [SYSTEM_ID]: {
+                        isStrike: true,
+                    },
+                },
+            }),
+        ];
     }
 
     /* --- Roll & Usage utilities --- */
@@ -1726,47 +1739,9 @@ export class CosmereItem<
         } as const satisfies EnricherData;
     }
 
-    protected async prepareWeaponStrikes(this: WeaponItem) {
-        const strikeAction = await this.getWeaponStrikeAction();
-
-        await strikeAction.update(this.weaponStrikeData());
-    }
-
-    protected async getWeaponStrikeAction(
-        this: WeaponItem,
-    ): Promise<ActionItem> {
-        let action;
-        if (this.hasActions) {
-            action = this.actions.find((action) =>
-                action.system.id.includes('strike-'),
-            );
-        }
-
-        if (!action) {
-            action = await this.createWeaponStrike();
-        }
-        return action;
-    }
-
-    protected async createWeaponStrike(this: WeaponItem): Promise<ActionItem> {
-        const newStrikeAction = (await Item.create(
-            {
-                type: ItemType.Action,
-                ...this.weaponStrikeData(),
-                flags: {
-                    [SYSTEM_ID]: {
-                        isStrike: true,
-                    },
-                },
-            },
-            // @ts-expect-error foundry-vtt-types doesn't correctly resolve the Item.Parent type for the operation's parent property
-            { parent: this },
-        )) as ActionItem;
-
-        return newStrikeAction;
-    }
-
     public weaponStrikeData(this: WeaponItem) {
+        if (!this.isWeapon()) throw new Error();
+
         return {
             name: `Strike: ${this.name}`,
             img: this.img,

--- a/src/system/documents/system-embedded-collections/types/general.ts
+++ b/src/system/documents/system-embedded-collections/types/general.ts
@@ -1,4 +1,7 @@
-import type { AnyMutableObject } from '@system/types/utils';
+import type {
+    AnyMutableObject,
+    AnyEmbeddedCollection,
+} from '@system/types/utils';
 
 export type SystemEmbeddedCollectionsConfig = {
     [K in foundry.abstract.Document.Type]?: string;
@@ -26,17 +29,6 @@ export interface SystemEmbeddedCollectionsDocument
     getEmbeddedCollection(
         embeddedName: foundry.abstract.Document.Type,
     ): AnyEmbeddedCollection | null;
-}
-
-export declare class AnyEmbeddedCollection extends foundry.abstract
-    .EmbeddedCollection<
-    foundry.abstract.Document.Any,
-    foundry.abstract.Document.Any
-> {
-    public _initializeDocument(
-        data: foundry.abstract.Document.Any['_source'],
-        options: foundry.abstract.Document.ConstructionContext<foundry.abstract.Document.Any>,
-    ): foundry.abstract.Document.Any | null;
 }
 
 export type AnyDocumentData = AnyMutableObject & {

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -21,6 +21,7 @@ import type {
 
 // Constants
 import { SYSTEM_EMBEDDED_COLLECTIONS_KEY } from '../constants';
+import { SYSTEM_ID } from '@system/constants';
 
 const DOCUMENT_REQUEST_TIMEOUT_WINDOW = 100;
 const documentsRequestTimeoutMap = new Map<string, number>();
@@ -297,6 +298,13 @@ function resolveUpdatedCollectionData(
 
     return [
         ...collection
+            .filter(
+                (doc) =>
+                    !foundry.utils.getProperty(
+                        doc,
+                        `flags.${SYSTEM_ID}.meta.isEphemeral`,
+                    ),
+            )
             .map((doc) =>
                 foundry.utils.mergeObject(
                     doc.toObject(),
@@ -361,12 +369,20 @@ function resolveUpdate(
             );
 
             return (
-                parentCollection?.map((doc) =>
-                    foundry.utils.mergeObject(
-                        doc.toObject() as AnyDocumentData,
-                        doc.id === curr.id ? update : {},
-                    ),
-                ) ?? ([update] as AnyDocumentData[])
+                parentCollection
+                    ?.filter(
+                        (doc) =>
+                            !foundry.utils.getProperty(
+                                doc,
+                                `flags.${SYSTEM_ID}.meta.isEphemeral`,
+                            ),
+                    )
+                    ?.map((doc) =>
+                        foundry.utils.mergeObject(
+                            doc.toObject() as AnyDocumentData,
+                            doc.id === curr.id ? update : {},
+                        ),
+                    ) ?? ([update] as AnyDocumentData[])
             );
         }, updatedCollectionData)[0];
 }
@@ -634,9 +650,20 @@ export function toServerViewObject(
                             return {
                                 ...acc,
                                 [collectionName]:
-                                    collectionData?.map((doc) =>
-                                        toServerViewObject(doc, embeddedName),
-                                    ) ?? [],
+                                    collectionData
+                                        ?.filter(
+                                            (doc) =>
+                                                !foundry.utils.getProperty(
+                                                    doc,
+                                                    `flags.${SYSTEM_ID}.meta.isEphemeral`,
+                                                ),
+                                        )
+                                        ?.map((doc) =>
+                                            toServerViewObject(
+                                                doc,
+                                                embeddedName,
+                                            ),
+                                        ) ?? [],
                             };
                         },
                         {} as Record<string, AnyObject[]>,
@@ -670,12 +697,20 @@ export function toServerViewObject(
             foundry.utils.setProperty(
                 obj,
                 collectionName,
-                collectionData.map((doc) =>
-                    toServerViewObject(
-                        doc,
-                        embeddedName as foundry.abstract.Document.Type,
+                collectionData
+                    .filter(
+                        (doc) =>
+                            !foundry.utils.getProperty(
+                                doc,
+                                `flags.${SYSTEM_ID}.meta.isEphemeral`,
+                            ),
+                    )
+                    .map((doc) =>
+                        toServerViewObject(
+                            doc,
+                            embeddedName as foundry.abstract.Document.Type,
+                        ),
                     ),
-                ),
             );
         },
     );

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -2,11 +2,14 @@
 import { hasSystemEmbeddedCollections } from './general';
 
 // Types
-import type { AnyObject, AnyMutableObject } from '@system/types/utils';
+import type {
+    AnyObject,
+    AnyMutableObject,
+    AnyEmbeddedCollection,
+} from '@system/types/utils';
 import type { Document } from '@system/types/foundry/document';
 
 import type {
-    AnyEmbeddedCollection,
     AnyDocumentData,
     SystemEmbeddedCollectionsDocument,
 } from '../types/general';

--- a/src/system/types/utils.ts
+++ b/src/system/types/utils.ts
@@ -21,6 +21,55 @@ import type {
     AnyObject,
     AnyConstructor,
 } from '@league-of-foundry-developers/foundry-vtt-types/utils';
+import type { Document } from '@system/types/foundry/document';
+
+type NativeEmbeddedTypesOf<
+    DocumentType extends foundry.abstract.Document.Type,
+> =
+    KnownKeys<
+        foundry.abstract.Document.MetadataFor<DocumentType>['embedded']
+    > extends foundry.abstract.Document.EmbeddedType
+        ? KnownKeys<
+              foundry.abstract.Document.MetadataFor<DocumentType>['embedded']
+          >
+        : never;
+
+type SystemEmbeddedTypesOf<
+    DocumentType extends foundry.abstract.Document.Type,
+> = DocumentType extends keyof ConfiguredSystemEmbeddedCollections
+    ? keyof ConfiguredSystemEmbeddedCollections[DocumentType]
+    : never;
+
+export type EmbeddedTypesOf<
+    DocumentType extends foundry.abstract.Document.Type,
+> = NativeEmbeddedTypesOf<DocumentType> | SystemEmbeddedTypesOf<DocumentType>;
+
+export type DocumentTypeOf<
+    DocumentClass extends Document.Constructable.SystemConstructor,
+> = DocumentClass['metadata']['name'];
+
+export type DocumentOfType<
+    DocumentName extends foundry.abstract.Document.WithSubTypes,
+    SubType extends
+        foundry.abstract.Document.SubTypesOf<DocumentName> = foundry.abstract.Document.SubTypesOf<DocumentName>,
+> = foundry.abstract.Document.OfType<DocumentName, SubType>;
+
+export type TypedCreateDataForName<
+    DocumentName extends foundry.abstract.Document.Type,
+> = foundry.abstract.Document.CreateDataForName<DocumentName> & {
+    type: foundry.abstract.Document.SubTypesOf<DocumentName>;
+};
+
+export declare class AnyEmbeddedCollection extends foundry.abstract
+    .EmbeddedCollection<
+    foundry.abstract.Document.Any,
+    foundry.abstract.Document.Any
+> {
+    public _initializeDocument(
+        data: foundry.abstract.Document.Any['_source'],
+        options: foundry.abstract.Document.ConstructionContext<foundry.abstract.Document.Any>,
+    ): foundry.abstract.Document.Any | null;
+}
 
 // Constant to improve UI consistency
 export const NONE = 'none';

--- a/src/system/utils/match-document.ts
+++ b/src/system/utils/match-document.ts
@@ -1,5 +1,5 @@
 import { CosmereItem } from '@system/documents/item';
-import { AnyEmbeddedCollection } from '../documents/system-embedded-collections/types/general';
+import type { AnyEmbeddedCollection } from '@system/types/utils';
 
 export const DocumentTarget = {
     Self: 'self', // Match the document itself

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -101,19 +101,23 @@
 
                 {{!-- Controls --}}
                 <div class="controls icon faded">
-                    {{#if @root.editable}}
-                    {{#unless action.isStrikeAction}}
-                    <a data-action="edit-action"
-                        data-tooltip="COSMERE.Item.Sheet.ActionsList.Edit"
-                    >
-                        <i class="fa-solid fa-pen-to-square"></i>
-                    </a>
-                    <a data-action="delete-action"
-                        data-tooltip="COSMERE.Item.Sheet.ActionsList.Delete"
-                    >
-                        <i class="fa-solid fa-trash"></i>
-                    </a>
-                    {{/unless}}
+                    {{#if (and @root.editable (not action.isStrikeAction))}}
+                        <a data-action="edit-action"
+                            data-tooltip="COSMERE.Item.Sheet.ActionsList.Edit"
+                        >
+                            <i class="fa-solid fa-pen-to-square"></i>
+                        </a>
+                        <a data-action="delete-action"
+                            data-tooltip="COSMERE.Item.Sheet.ActionsList.Delete"
+                        >
+                            <i class="fa-solid fa-trash"></i>
+                        </a>
+                    {{else}}
+                        <a data-action="view-action"
+                            data-tooltip="COSMERE.Item.Sheet.ActionsList.View"
+                        >
+                            <i class="fa-solid fa-eye"></i>
+                        </a>
                     {{/if}}
                 </div>
             </section>


### PR DESCRIPTION
**Type**  
- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Other (please describe):

**Description**  
Adds generic support for ephemeral embedded documents (non-persisted documents that are derived by/from the parent) and refactors weapon strikes to use this system. 
Weapon strikes are now derived client-side from weapon data when needed and never persisted to the backend.

Also adds the ability to view strike action details (but not edit).

**Related Issue**  
Closes #796 

**How Has This Been Tested?**  
1. Create weapon in a compendium
2. Lock the compendium
3. Copy weapon uuid and compendium id
4. In console run:
```js
const compendium = game.packs.get('<pack id>');
const weapon = await fromUuid('<weapon uuid>')
await compendium.configure({ locked: false });
await weapon.update({ 'system.strike.die.size': 'd6' });
await compendium.configure({ locked: true });
```

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351