### PR TITLE
fix(actor sheet): add action button on path actions section creates a talent 

### DIFF
--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -175,9 +175,9 @@ export const DYNAMIC_SECTIONS: Record<string, DynamicItemListSectionGenerator> =
                 new: (parent: CosmereActor) =>
                     CosmereItem.create(
                         {
-                            type: ItemType.Talent,
+                            type: ItemType.Action,
                             name: game.i18n.localize(
-                                'COSMERE.Item.Type.Talent.New',
+                                'COSMERE.Item.Type.Action.New',
                             ),
                             system: {
                                 path: path.system.id,

--- a/src/system/applications/actor/components/item-list.ts
+++ b/src/system/applications/actor/components/item-list.ts
@@ -10,7 +10,6 @@ import AppUtils from '@system/applications/utils';
 import { HandlebarsApplicationComponent } from '@system/applications/component-system';
 import { getSystemSetting, SETTINGS } from '@src/system/settings';
 import { ItemRelationship } from '@src/system/data/item/mixins/relationships';
-import { ItemType } from '@src/system/types/cosmere';
 
 export interface ItemState {
     expanded?: boolean;
@@ -162,8 +161,8 @@ any> {
         const item = await section.new?.(this.application.actor);
         if (!item) return;
 
-        if (item.type == ItemType.Talent) {
-            if (!item.actor) return;
+        // Checks if the item belongs to a path and creates a relationship.
+        if (item.actor) {
             for (const otherItem of item.actor.items) {
                 if (otherItem.isPath() && otherItem.system.id == sectionId) {
                     await item.addRelationship(


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes issue where creating a new action in the action tab under a path category creates a talent instead of action

**Related Issue**  
Closes #743 

**How Has This Been Tested?**  
1. Create new character
2. Give character any heroic path
3. Go to actions tab
4. Create new action on the new path category
5. See that it creates a new action for that category

**Screenshots (if applicable)**  
<img width="600" height="282" alt="e62482b1ac91894c538778fbfdee5e13" src="https://github.com/user-attachments/assets/fb71c1c1-9a52-489c-bb00-ef0417a26093" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
This is my final branch on my own fork of the repo. Will switch over to the team repo for any future work.
