### PR TITLE
fix(actor): make effects on nested items transfer through to actor

### DIFF
--- a/src/system/applications/actor/components/effects-list.ts
+++ b/src/system/applications/actor/components/effects-list.ts
@@ -138,48 +138,22 @@ export class ActorEffectsListComponent extends HandlebarsApplicationComponent<
 
     /* --- Helpers --- */
 
-    private getEffectFromEvent(event: Event): ActiveEffect | undefined {
-        if (!event.target && !event.currentTarget) return;
+    private getEffectFromEvent(event: Event): ActiveEffect | null {
+        if (!event.target && !event.currentTarget) return null;
 
         return this.getEffectFromElement(
             (event.target ?? event.currentTarget) as HTMLElement,
         );
     }
 
-    private getEffectFromElement(
-        element: HTMLElement,
-    ): ActiveEffect | undefined {
-        const effectElement = $(element).closest('.effect[data-id]');
+    private getEffectFromElement(element: HTMLElement): ActiveEffect | null {
+        const effectElement = $(element).closest('.effect[data-uuid]');
 
-        // Get the id
-        const id = effectElement.data('id') as string;
+        // Get the uuid
+        const uuid = effectElement.data('uuid') as string;
 
-        // Get the parent id (if it exists)
-        const parentId = effectElement.data('parent-id') as string | undefined;
-
-        // Get the effect
-        return this.getEffect(id, parentId);
-    }
-
-    private getEffect(
-        effectId: string,
-        parentId?: string,
-    ): ActiveEffect | undefined {
-        if (!parentId)
-            return this.application.actor.getEmbeddedDocument(
-                'ActiveEffect',
-                effectId,
-                {},
-            );
-        else {
-            // Get item
-            const item = this.application.actor.getEmbeddedDocument(
-                'Item',
-                parentId,
-                {},
-            );
-            return item?.getEmbeddedDocument('ActiveEffect', effectId, {});
-        }
+        const effect = fromUuidSync(uuid) as ActiveEffect.Implementation | null;
+        return effect;
     }
 }
 

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -1346,13 +1346,17 @@ export class CosmereActor<
     }
 
     public *allApplicableEffects() {
-        for (const effect of super.allApplicableEffects()) {
+        for (const effect of this.effects) {
             yield effect;
+        }
+        if (CONFIG.ActiveEffect.legacyTransferral) return;
+        for (const item of this.items) {
+            for (const effect of item.effects) {
+                if (effect.transfer) yield effect;
+            }
 
-            if (effect.parent instanceof CosmereItem) {
-                for (const nestedEffect of effect.parent.nestedEffects) {
-                    if (nestedEffect.transfer) yield nestedEffect;
-                }
+            for (const effect of item.nestedEffects) {
+                if (effect.transfer) yield effect;
             }
         }
     }

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -1345,17 +1345,17 @@ export class CosmereActor<
         } as const satisfies EnricherData<SubType>;
     }
 
-    // public *allApplicableEffects() {
-    //     for (const effect of super.allApplicableEffects()) {
-    //         if (
-    //             !(effect.parent instanceof CosmereItem) ||
-    //             !effect.parent.isEquippable() ||
-    //             effect.parent.system.equipped
-    //         ) {
-    //             yield effect;
-    //         }
-    //     }
-    // }
+    public *allApplicableEffects() {
+        for (const effect of super.allApplicableEffects()) {
+            yield effect;
+
+            if (effect.parent instanceof CosmereItem) {
+                for (const nestedEffect of effect.parent.nestedEffects) {
+                    if (nestedEffect.transfer) yield nestedEffect;
+                }
+            }
+        }
+    }
 
     /**
      * Utility Function to determine a formula value based on a scalar plot of an attribute value

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -478,6 +478,12 @@ export class CosmereItem<
         return this.system.events.filter((event) => !event.disabled) as Rule[];
     }
 
+    public get nestedEffects(): ActiveEffect.Implementation[] {
+        return this.items
+            .map((item) => [...item.effects, ...item.nestedEffects])
+            .flat();
+    }
+
     /* --- Lifecycle --- */
 
     public override async _onClickDocumentLink(event: MouseEvent) {

--- a/src/templates/actors/components/effects-list.hbs
+++ b/src/templates/actors/components/effects-list.hbs
@@ -17,6 +17,7 @@
     {{#each effects as |effect|}}
     <li class="item effect {{#if effect.active}}active{{/if}}" 
         data-id="{{effect.id}}"
+        data-uuid="{{effect.uuid}}"
         {{#if (not (eq effect.parent @root.actor))}}
         data-parent-id="{{effect.parent.id}}"
         {{/if}}


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This PR makes transferable effects from items embedded on other items, transfer through to the actor.

**Related Issue**  
Closes #800 

**How Has This Been Tested?**  
1. Create weapon
2. Add effect to weapon
3. Add action to weapon
4. Add effect to action
5. Create actor
6. Add weapon to actor
7. Ensure both effects are present on actor

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351