### PR TITLE
Feat: Consume response in Use Item hook

### DIFF
--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1122,6 +1122,8 @@ export class CosmereItem<
 
         // Handle resource consumption
         if (!!consumeResponse && consumeResponse.length > 0) {
+            // Add consumption data to the options for hook usage
+            options.consumeResponse = consumeResponse;
             // Process each included resource consumption
             for (const consumption of consumeResponse) {
                 const targets =
@@ -1963,6 +1965,12 @@ export namespace CosmereItem {
          * Only used if the item has consumption configured.
          */
         shouldConsume?: boolean;
+
+        /**
+         * Any consumption results will be included here.
+         * Only used if the item use has consumption configured.
+         */
+        consumeResponse?: ActionItemDataModel.ConsumeData[];
 
         /**
          * What advantage modifier to apply to the damage roll.


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds the "Consume Response" result to the options field of the "Use Item" hook so amount of resources consumed is available in the "Use Item" hook and the execute macro handler triggered by an "On Item Used" event trigger

**Related Issue**  
Closes #801 

**How Has This Been Tested?**  
Confirmed in console that the Use Item hook, when using an item which consumes resources, has access to the Consume Response field

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.