### PR TITLE
fix: Made data model validation for matchDocumentStep check against compendium pack document type if documentName is nullish

### DIFF
--- a/src/system/data/fields/match-document-field/step.ts
+++ b/src/system/data/fields/match-document-field/step.ts
@@ -33,7 +33,7 @@ function defineStepSchema() {
             hint: `COSMERE.Utils.MatchDocument.Target.Hint`,
         }),
         documentType: new foundry.data.fields.StringField({
-            required: true,
+            required: false,
             nullable: true,
             initial: null,
             choices: VALID_DOCUMENT_TYPES.reduce(
@@ -154,7 +154,11 @@ export class MatchDocumentStepField<
                     value.target,
                 )
             ) {
-                if (doc.documentName !== 'Item')
+                // If this doc is inside a compendium which hasn't been loaded, we need to get the document type from the compendium
+                const docNameToCheck =
+                    (doc.documentName as string | undefined) ??
+                    game.packs.get(doc.pack as string)?.documentName;
+                if (docNameToCheck !== 'Item')
                     throw new Error(
                         `Target type "${value.target}" can only be used to match Items`,
                     );


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
This fixes an issue where actions which had consumption references to a compendium item that hadn't been loaded into the world were reverting to "self" as the resource consumption target. We need to use fromUuidSync in the validation to keep things synchronous, and fromUuidSync results in a "Compendium Index" object when the item hasn't been loaded into the world locally. 
That "Compendium Index" object doesn't have a documentName property, but the pack it references does. This change makes the validation check for the documentType being item if it exists, and if it doesn't, checks the pack's documentName property.

**Related Issue**  
Closes #803

**How Has This Been Tested?**  
1. Create new world
2. Create new Item compendium "Item Compendium A"
3. Open Item Compendium A
4. Use the "Create Item" button on the compendium application to create a new Equipment item in "Item Compendium A" labeled "Test Equipment"
5. Enable "Equippable" on the new "Test Equipment" item
6. Add a new "Charges" resource to "Test Equipment"
7. Close "Test Equipment"
8. Create new Item compendium "Item Compendium B"
9. Open Item Compendium B
10. Use the "Create Item" button on the compendium application to create a new Action item named "Test Action"
11. Change "Usage" to "Utility"
12. Add new resource consumption
13. Change to "item resource"
14. Change "Resource" dropdown from "Use" to "Charge"
15. Open "Target" window
16. Change "Relation" to "Equipped Item"
17. Change "Match By" to "Name"
18. Drag and drop "Test Equipment" to the "Reference Document" location
19. Press "Update", observe that resource consumption looks correct
20. Close out of all windows
21. Return to Foundry Setup
22. Reopen Test world
23. Open Item Compendium B
24. Open Test Action
25. Open "Details" tab
26. Observe that it still contains the correct "1 charge from equipped item named Test Equipment" value.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.