### PR TITLE
fix(system embedded documents): update utils to not reassign id on create if keepId is set

### DIFF
--- a/src/system/documents/embed-config/inject.ts
+++ b/src/system/documents/embed-config/inject.ts
@@ -2,5 +2,9 @@ import { EmbedConfigMixin } from './mixin';
 
 globalThis.Item = EmbedConfigMixin(Item);
 
-foundry.utils.setProperty(foundry, 'documents.Item', globalThis.Item);
+foundry.documents = {
+    ...foundry.documents,
+    Item: globalThis.Item,
+};
+
 foundry.utils.setProperty(CONFIG, 'Item.documentClass', globalThis.Item);

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -195,7 +195,15 @@ function assignIdsCreateRequest(request: DocumentSocketRequest<'create'>) {
                 data = data.toObject();
             }
 
-            foundry.utils.setProperty(data, '_id', foundry.utils.randomID());
+            if (
+                !request.operation.keepId ||
+                !foundry.utils.hasProperty(data, '_id')
+            )
+                foundry.utils.setProperty(
+                    data,
+                    '_id',
+                    foundry.utils.randomID(),
+                );
         }
 
         return data;


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes a bug with the system embedded documents functionality causing the `id` property to get reassigned during document creation when `keepId` is set.

**Related Issue**  
Closes #804 

**How Has This Been Tested?**  
1. Create actor
2. Toggle determined on
3. Toggle determined off
4. Toggle exhausted on
5. Toggle exhausted on again -> Ensure stacks increase

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351
