### PR TITLE
fix(item): ensure recharge only applies to resources available on item

### DIFF
--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1416,9 +1416,11 @@ export class CosmereItem<
             resourceOrResources ??
             (Object.keys(this.system.resources) as ItemResource[]);
 
-        const resourcesToRecharge = Array.isArray(resourceOrResources)
-            ? resourceOrResources
-            : [resourceOrResources];
+        const resourcesToRecharge = (
+            Array.isArray(resourceOrResources)
+                ? resourceOrResources
+                : [resourceOrResources]
+        ).filter((resource) => this.system.resources[resource]);
 
         // Recharge resource
         await this.update({


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes bug causing item recharging to fail when item doesn't have all resources configured. Adds a check to ensure only configured resources are considered for recharge.

**Related Issue**  
Closes #794 

**How Has This Been Tested?**  
1. Make a new action on actor
2. Make action have charges
3. Set current charges below max.
4. Go to action tab and use the toggle controls recharge button.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351