### PR TITLE
Fix #691: avoid recursive mergeObject on live Item instance in rollDa…

### DIFF
--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -549,18 +549,17 @@ export class CosmereItem<
 
         const formula = options.overrideFormula ?? this.system.damage.formula;
         // Perform the roll
-        const roll = await damageRoll(
-            foundry.utils.mergeObject(options, {
-                formula:
-                    rollData.mod !== undefined
-                        ? `${formula} + ${rollData.mod}`
-                        : formula,
-                damageType: this.system.damage.type,
-                mod: rollData.mod,
-                data: rollData,
-                source: this.name,
-            }) as DamageRollConfiguration,
-        );
+        const roll = await damageRoll({
+            ...options,
+            formula:
+                rollData.mod !== undefined
+                    ? `${formula} + ${rollData.mod}`
+                    : formula,
+            damageType: this.system.damage.type,
+            mod: rollData.mod,
+            data: rollData,
+            source: this.name,
+        } as DamageRollConfiguration);
 
         // Gather the formula options for graze rolls
         const unmoddedRoll = roll.clone();
@@ -606,13 +605,12 @@ export class CosmereItem<
 
         const usesBaseDamage = grazeFormula.includes('@damage');
 
-        const grazeRoll = await damageRoll(
-            foundry.utils.mergeObject(options, {
-                formula: grazeFormula,
-                damageType: this.system.damage.type,
-                data: rollData,
-            }) as DamageRollConfiguration,
-        );
+        const grazeRoll = await damageRoll({
+            ...options,
+            formula: grazeFormula,
+            damageType: this.system.damage.type,
+            data: rollData,
+        } as DamageRollConfiguration);
 
         // update with results from the basic roll if needed and store for display
         if (usesBaseDamage) grazeRoll.replaceDieResults(roll.dice);


### PR DESCRIPTION
**Type**
- [x] Bug fix

**Description**
`rollDamage()` embeds the live `CosmereItem` instance (`this`) inside `rollData.source` via `getDamageRollData()`. The two subsequent `foundry.utils.mergeObject(options, {...})` calls both reuse the same `options` reference, and since `mergeObject` mutates its target and merges nested objects recursively, the second call ends up recursing into the Item instance itself and trying to reassign its properties — including `effects`, which is a read-only getter on `Document` as of Foundry V14. This throws `Cannot assign to read only property 'effects' of object '#<CosmereItem>'` and aborts the roll before any chat message is created

Both calls are replaced with plain object spreads (`{...options, ...}`), which is all that's needed here — a shallow merge of simple keys, never a recursive merge into `source`

**Related Issue**
Closes #691

**How Has This Been Tested?**
- Verified balanced braces/parens in the modified file.
- Reproduce the original error on Foundry V14 with an attack roll, apply the fix, and confirm the attack + damage roll (including graze) now completes and posts to chat normally

**Checklist:**
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: v14 build 364