### PR TITLE
Fix #792: Edit/Remove/Recharge buttons not clickable (Foundry V14)

### DIFF
--- a/src/style/components.scss
+++ b/src/style/components.scss
@@ -1,3 +1,8 @@
+.cosmere-context-menu {
+    position: absolute;
+    z-index: 1000;
+}
+
 app-multi-state-toggle {
     position: relative;
     display: flex;

--- a/src/templates/general/context-menu.hbs
+++ b/src/templates/general/context-menu.hbs
@@ -1,4 +1,4 @@
-<menu class="controls-dropdown">
+<menu class="controls-dropdown cosmere-context-menu">
     {{#each items as |item index|}}
     <li class="header-control">
         <button class="control"


### PR DESCRIPTION
**Type**
- [x] Bug fix

**Description**
On Foundry V14, the context menu shown after clicking "Toggle Controls" (Edit/Remove/Recharge) doesn't work: clicks don't register, or the menu appears in the wrong place (bottom of the sheet instead of next to the button).

The menu is appended directly to the sheet's form element and reuses Foundry's `.controls-dropdown` class. That class only gets `position: absolute` from Foundry core when used in its native header-controls context. Used here, it stays `position: static`, so it renders in normal document flow (landing at the bottom of the sheet) and `z-index` has no effect, letting Foundry's new V14 window chrome (`.window-background`/`.window-corners`) sit on top and block clicks.

Fix: give the menu its own class with explicit `position: absolute` and a `z-index` high enough to stack above that window chrome.

**Related Issue**
Closes #792

**How Has This Been Tested?**
Reproduced the bug on Foundry V14 (character sheet, weapon/action toggle controls), applied the fix, and confirmed the menu now opens anchored next to the button and Edit/Remove/Recharge all work correctly.

**Checklist:**
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: v14 build 364