### PR TITLE
feat(styling): apply op/comp -color classes to regular text

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -206,3 +206,15 @@ em.cosmere-icon,
 i.cosmere-icon {
     font-style: normal;
 }
+
+span.opportunity-color,
+em.opportunity-color,
+i.opportunity-color {
+    color: var(--cosmere-color-opportunity-text);
+}
+
+span.complication-color,
+em.complication-color,
+i.complication-color {
+    color: var(--cosmere-color-complication-text);
+}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds css rules to apply the opportunity-color and complication-color rules to span, em, and i elements

**Related Issue**  
Closes #824 

**How Has This Been Tested?**  
Applied the relevant classes to text in Foundry and observed that the colors were applied correctly

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
I am not opposed to removing the rule that applies the opportunity-color since that would likely not be used anywhere, though it probably doesn't hurt to leave it in Just In Case™
