### PR TITLE
fix(actor sheet): resolve issue preventing passive effect on compendium actor from being toggled

### DIFF
--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -454,7 +454,8 @@ export class ActorActionsListComponent extends ActorItemListComponent {
 
                     // Get item from loaded actor sheet
                     const item =
-                        this.application.actor.getNestedEmbeddedItemFromUuid(
+                        this.application.actor.getEmbeddedDocumentFromUuid(
+                            CosmereItem,
                             itemUuid,
                         );
 

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -455,7 +455,6 @@ export class ActorActionsListComponent extends ActorItemListComponent {
                     // Get item from loaded actor sheet
                     const item =
                         this.application.actor.getEmbeddedDocumentFromUuid(
-                            CosmereItem,
                             itemUuid,
                         );
 

--- a/src/system/applications/actor/components/effects-list.ts
+++ b/src/system/applications/actor/components/effects-list.ts
@@ -227,10 +227,10 @@ export class ActorEffectsListComponent extends ActorItemListComponent {
 
         const actor = this.application.actor;
 
-        const effect = actor.getNestedEmbeddedEffectFromUuid(uuid) as
-            | CosmereActiveEffect
-            | EffectsContainerItem
-            | null;
+        const effect = actor.getEmbeddedDocumentFromUuid(
+            CosmereActiveEffect,
+            uuid,
+        ) as CosmereActiveEffect | EffectsContainerItem | null;
         return effect;
     }
 }

--- a/src/system/applications/actor/components/effects-list.ts
+++ b/src/system/applications/actor/components/effects-list.ts
@@ -227,10 +227,10 @@ export class ActorEffectsListComponent extends ActorItemListComponent {
 
         const actor = this.application.actor;
 
-        const effect = actor.getEmbeddedDocumentFromUuid(
-            CosmereActiveEffect,
-            uuid,
-        ) as CosmereActiveEffect | EffectsContainerItem | null;
+        const effect = actor.getEmbeddedDocumentFromUuid(uuid) as
+            | CosmereActiveEffect
+            | EffectsContainerItem
+            | null;
         return effect;
     }
 }

--- a/src/system/applications/actor/components/effects-list.ts
+++ b/src/system/applications/actor/components/effects-list.ts
@@ -225,7 +225,9 @@ export class ActorEffectsListComponent extends ActorItemListComponent {
         // Get the uuid
         const uuid = effectElement.data('uuid') as string;
 
-        const effect = fromUuidSync(uuid) as
+        const actor = this.application.actor;
+
+        const effect = actor.getNestedEmbeddedEffectFromUuid(uuid) as
             | CosmereActiveEffect
             | EffectsContainerItem
             | null;

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -624,12 +624,18 @@ export class CosmereActor<
 
     /** Returns an embedded item in an actor regardless of how deeply nested it is, if it exists.
      *
-     * @param itemUuid The UUID of the item you want to get
+     * @param itemUuid The UUID of the item you want to get, either the whole UUID or partial. Also works with just the item ID.
      * @returns An Item or null if no item could be found.
      */
     public getNestedEmbeddedItemFromUuid(itemUuid: string): Item | null {
+        const parsedUuid = foundry.utils.parseUuid(itemUuid);
+        let itemId = parsedUuid?.id;
+        if (!itemId) itemId = itemUuid;
         for (const [, document] of this.traverseEmbeddedDocuments()) {
-            if (document instanceof Item && document.uuid === itemUuid) {
+            if (
+                document instanceof Item &&
+                (document.uuid === itemUuid || document.id == itemId)
+            ) {
                 return document;
             }
         }

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -622,41 +622,22 @@ export class CosmereActor<
 
     /* --- Functions --- */
 
-    /** Returns an embedded item in an actor regardless of how deeply nested it is, if it exists.
+    /** Returns an embedded document in an actor regardless of how deeply nested it is, if it exists.
      *
-     * @param itemUuid The UUID of the item you want to get, either the whole UUID or partial. Also works with just the item ID.
-     * @returns An Item or null if no item could be found.
+     * @param documentType the type of document you are getting. In this instance thats either {@link CosmereActiveEffect} or {@link CosmereItem}
+     * @param uuid The UUID of the document you want to get, either the whole UUID or partial. Also works with just the document ID.
+     * @returns A {@link CosmereActiveEffect}, {@link CosmereItem} or null if no effect could be found.
      */
-    public getNestedEmbeddedItemFromUuid(itemUuid: string): Item | null {
-        const parsedUuid = foundry.utils.parseUuid(itemUuid);
-        let itemId = parsedUuid?.id;
-        if (!itemId) itemId = itemUuid;
+    public getEmbeddedDocumentFromUuid(
+        documentType: typeof CosmereActiveEffect | typeof CosmereItem,
+        uuid: string,
+    ): CosmereActiveEffect | CosmereItem | null {
+        const parsedUuid = foundry.utils.parseUuid(uuid);
+        const documentId = parsedUuid?.id ?? uuid;
         for (const [, document] of this.traverseEmbeddedDocuments()) {
             if (
-                document instanceof Item &&
-                (document.uuid === itemUuid || document.id == itemId)
-            ) {
-                return document;
-            }
-        }
-
-        return null;
-    }
-
-    /** Returns an embedded effect in an actor regardless of how deeply nested it is, if it exists.
-     *
-     * @param effectUuid The UUID of the effect you want to get, either the whole UUID or partial. Also works with just the effects ID.
-     * @returns A CosmereActiveEffect or null if no effect could be found.
-     */
-    public getNestedEmbeddedEffectFromUuid(
-        effectUuid: string,
-    ): CosmereActiveEffect | null {
-        const parsedUuid = foundry.utils.parseUuid(effectUuid);
-        const effectId = parsedUuid?.id ?? effectUuid;
-        for (const [, document] of this.traverseEmbeddedDocuments()) {
-            if (
-                document instanceof CosmereActiveEffect &&
-                (document.uuid == effectUuid || document.id == effectId)
+                document instanceof documentType &&
+                (document.uuid == uuid || document.id == documentId)
             ) {
                 return document;
             }

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -637,6 +637,27 @@ export class CosmereActor<
         return null;
     }
 
+    /** Returns an embedded effect in an actor regardless of how deeply nested it is, if it exists.
+     *
+     * @param effectUuid The UUID of the effect you want to get, either the whole UUID or partial. Also works with just the effects ID.
+     * @returns A CosmereActiveEffect or null if no effect could be found.
+     */
+    public getNestedEmbeddedEffectFromUuid(
+        effectUuid: string,
+    ): CosmereActiveEffect | null {
+        const parsedUuid = foundry.utils.parseUuid(effectUuid);
+        const effectId = parsedUuid?.id ?? effectUuid;
+        for (const [, document] of this.traverseEmbeddedDocuments()) {
+            if (
+                document instanceof CosmereActiveEffect &&
+                (document.uuid == effectUuid || document.id == effectId)
+            ) {
+                return document;
+            }
+        }
+        return null;
+    }
+
     public async setMode(modality: string, mode: string) {
         await this.setFlag(SYSTEM_ID, `mode.${modality}`, mode);
 

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -624,20 +624,20 @@ export class CosmereActor<
 
     /** Returns an embedded document in an actor regardless of how deeply nested it is, if it exists.
      *
-     * @param documentType The type of document you are getting. In this instance thats either {@link CosmereActiveEffect} or {@link CosmereItem}
      * @param uuid The UUID of the document you want to get, either the whole UUID or partial. Also works with just the document ID.
      * @returns A {@link CosmereActiveEffect}, {@link CosmereItem} or null if no document could be found.
      */
     public getEmbeddedDocumentFromUuid(
-        documentType: typeof CosmereActiveEffect | typeof CosmereItem,
         uuid: string,
     ): CosmereActiveEffect | CosmereItem | null {
         const parsedUuid = foundry.utils.parseUuid(uuid);
         const documentId = parsedUuid?.id ?? uuid;
         for (const [, document] of this.traverseEmbeddedDocuments()) {
+            if (document.uuid != uuid && document.id != documentId) continue;
+
             if (
-                document instanceof documentType &&
-                (document.uuid == uuid || document.id == documentId)
+                document instanceof CosmereActiveEffect ||
+                document instanceof CosmereItem
             ) {
                 return document;
             }

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -624,9 +624,9 @@ export class CosmereActor<
 
     /** Returns an embedded document in an actor regardless of how deeply nested it is, if it exists.
      *
-     * @param documentType the type of document you are getting. In this instance thats either {@link CosmereActiveEffect} or {@link CosmereItem}
+     * @param documentType The type of document you are getting. In this instance thats either {@link CosmereActiveEffect} or {@link CosmereItem}
      * @param uuid The UUID of the document you want to get, either the whole UUID or partial. Also works with just the document ID.
-     * @returns A {@link CosmereActiveEffect}, {@link CosmereItem} or null if no effect could be found.
+     * @returns A {@link CosmereActiveEffect}, {@link CosmereItem} or null if no document could be found.
      */
     public getEmbeddedDocumentFromUuid(
         documentType: typeof CosmereActiveEffect | typeof CosmereItem,


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes issue where FromUuidSync is used to get effects on compendium items which does not work as intended. Replaced code with a new method to get an effect from a UUID directly from the actor itself which works for compendium actors.

**Related Issue**  
Closes #822 

**How Has This Been Tested?**  
1. Unlock companions and adversaries in starter rules
2. Open it and go to companion, special, greater larkin
3. go to effects and toggle effect and see it gets toggled.

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] No part of this PR was created using generative AI tools.
- [X] I have tested my changes on Foundry VTT version: 13.351.
