### PR TITLE
feat(weapons): add loaded trait automation

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -445,6 +445,7 @@
                     "Reach": "Reach"
                 },
                 "Strike": "Strike",
+                "Reload": "Reload",
                 "Improvised": "Improvised Weapon",
                 "Unarmed": "Unarmed Strike"
             },

--- a/src/system/data/item/weapon.ts
+++ b/src/system/data/item/weapon.ts
@@ -6,6 +6,7 @@ import {
     WeaponType,
     EquipType,
     ActivationType,
+    ItemResource,
 } from '@system/types/cosmere';
 import { EmptyObject } from '@system/types/utils';
 
@@ -151,6 +152,23 @@ export class WeaponItemDataModel extends DataModelMixin<
         } else {
             this.equip.hold = HoldType.OneHanded;
             this.equip.hand ??= EquipHand.Main;
+        }
+
+        // Automate "uses" resource when loaded trait is set
+        const loadedTrait = this.traits[WeaponTraitId.Loaded];
+        if (
+            loadedTrait?.active &&
+            loadedTrait?.value &&
+            loadedTrait.value > 0
+        ) {
+            this.resources[ItemResource.Uses] = {
+                key: ItemResource.Uses,
+                max: loadedTrait.value,
+                value:
+                    this.resources[ItemResource.Uses]?.value ??
+                    loadedTrait.value,
+                recharge: null,
+            };
         }
     }
 }

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -31,10 +31,11 @@ export function EphemeralEmbeddedDocumentsMixin<
             ephemeralEmbedded: EphemeralEmbeddedDocumentsConfig<DocumentType>;
         };
 
-        override _initialize(
-            options?: foundry.abstract.Document.InitializeOptions,
-        ) {
-            super._initialize(options);
+        public prepareData() {
+            /* eslint-disable @typescript-eslint/no-unsafe-call */
+            //@ts-expect-error foundry-vtt-types doesn't define the prepareData function on the Document base class (only client document)
+            super.prepareData();
+            /* eslint-enable @typescript-eslint/no-unsafe-call */
 
             if (!this.ephemeralUpdate) this.injectEphemeralDocuments();
         }

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1872,7 +1872,7 @@ export class CosmereItem<
         if (!this.isWeapon()) throw new Error();
 
         const loadedTrait = this.getTrait(WeaponTraitId.Loaded);
-        const hasLoadedTrait = !!loadedTrait;
+        const hasLoadedTrait = !!loadedTrait && loadedTrait.active;
 
         const usesResource = this.getResource(ItemResource.Uses);
         const hasUsesResource = !!usesResource && usesResource.max > 0;

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -39,6 +39,7 @@ import {
     PowerItemDataModel,
     TalentTreeItemDataModel,
     EffectsContainerItemDataModel,
+    TraitItemDataSchema,
 } from '@system/data/item';
 
 import { AttackingItemDataSchema } from '@system/data/item/mixins/attacking';
@@ -109,7 +110,7 @@ import { getEmbedHelpers } from '@system/utils/embed';
 import ItemRelationshipUtils, {
     RemoveRelationshipOptions,
 } from '@system/utils/item/relationship';
-import { matchDocuments } from '@system/utils/match-document';
+import { matchDocuments, DocumentTarget } from '@system/utils/match-document';
 import { EventToggleOptions } from '@system/utils/item/event-system';
 
 // Dialogs
@@ -419,6 +420,10 @@ export class CosmereItem<
         );
     }
 
+    public get isEphemeral(): boolean {
+        return this.getFlag(SYSTEM_ID, 'meta.isEphemeral');
+    }
+
     public get isActivatable(): boolean {
         if (this.type === ItemType.Action) return true;
 
@@ -702,16 +707,7 @@ export class CosmereItem<
         if (!this.isWeapon()) return [];
 
         return [
-            // Weapon strike
-            new CosmereItem({
-                type: ItemType.Action,
-                ...this.weaponStrikeData(),
-                flags: {
-                    [SYSTEM_ID]: {
-                        isStrike: true,
-                    },
-                },
-            }),
+            ...this.getWeaponStrikeData().map((data) => new CosmereItem(data)),
         ];
     }
 
@@ -1552,6 +1548,27 @@ export class CosmereItem<
         });
     }
 
+    public getTrait(
+        traitId: WeaponTraitId | ArmorTraitId,
+    ): TraitsItem['system']['traits'][string] | null {
+        if (!this.hasTraits()) return null;
+        if (!(traitId in this.system.traits)) return null;
+        return this.system.traits[traitId];
+    }
+
+    public isTraitActive(traitId: WeaponTraitId | ArmorTraitId): boolean {
+        const trait = this.getTrait(traitId);
+        if (!trait) return false;
+        return trait.active;
+    }
+
+    public getResource(
+        resourceId: ItemResource,
+    ): ResourcesItem['system']['resources'][ItemResource] | null {
+        if (!this.hasResources()) return null;
+        return this.system.resources[resourceId] ?? null;
+    }
+
     public isRelatedTo(
         item: CosmereItem,
         relType?: ItemRelationship.Type,
@@ -1851,32 +1868,106 @@ export class CosmereItem<
         } as const satisfies EnricherData;
     }
 
-    public weaponStrikeData(this: WeaponItem) {
+    public getWeaponStrikeData(this: WeaponItem) {
         if (!this.isWeapon()) throw new Error();
 
-        return {
-            name: `Strike: ${this.name}`,
-            img: this.img,
-            system: {
-                id: `strike-${this.system.id}`,
-                activation: {
-                    cost: {
-                        value: 1,
-                        type: ActionCostType.Action,
+        const loadedTrait = this.getTrait(WeaponTraitId.Loaded);
+        const hasLoadedTrait = !!loadedTrait;
+
+        const usesResource = this.getResource(ItemResource.Uses);
+        const hasUsesResource = !!usesResource && usesResource.max > 0;
+
+        const actions: Item.CreateData[] = [
+            {
+                type: ItemType.Action,
+                name: `${game.i18n.localize('COSMERE.Item.Weapon.Strike')}: ${this.name}`,
+                img: this.img,
+                system: {
+                    id: `strike-${this.system.id}`,
+                    activation: {
+                        cost: {
+                            value: 1,
+                            type: ActionCostType.Action,
+                        },
+                        type: ActivationType.SkillTest,
+                        consumption:
+                            hasLoadedTrait && hasUsesResource
+                                ? [
+                                      {
+                                          type: ItemConsumeType.ItemResource,
+                                          resource: ItemResource.Uses,
+                                          matchDocument: {
+                                              steps: [
+                                                  {
+                                                      target: DocumentTarget.Parent,
+                                                  },
+                                              ],
+                                          },
+                                          value: {
+                                              min: 1,
+                                              max: 1,
+                                          },
+                                      },
+                                  ]
+                                : undefined,
                     },
-                    type: ActivationType.SkillTest,
+                    skillTest: {
+                        attribute: 'default',
+                        skill: this.system.strike.skill,
+                    },
+                    damage: {
+                        formula: this.strikeDieToFormula(),
+                        type: this.strikeDamageType(),
+                    },
+                    description: this.system.description,
                 },
-                skillTest: {
-                    attribute: 'default',
-                    skill: this.system.strike.skill,
+                flags: {
+                    [SYSTEM_ID]: {
+                        isStrike: true,
+                    },
                 },
-                damage: {
-                    formula: this.strikeDieToFormula(),
-                    type: this.strikeDamageType(),
-                },
-                description: this.system.description,
             },
-        };
+        ];
+
+        if (hasLoadedTrait && hasUsesResource) {
+            const eventId = foundry.utils.randomID();
+
+            actions.push({
+                type: ItemType.Action,
+                name: `${game.i18n.localize('COSMERE.Item.Weapon.Reload')}: ${this.name}`,
+                img: this.img,
+                system: {
+                    id: `reload-${this.system.id}`,
+                    activation: {
+                        cost: {
+                            value: 1,
+                            type: ActionCostType.Action,
+                        },
+                        type: ActivationType.Utility,
+                    },
+                    events: {
+                        [eventId]: {
+                            id: eventId,
+                            description: 'Reload',
+                            event: 'use',
+                            handler: {
+                                type: 'execute-macro',
+                                inline: true,
+                                macro: {
+                                    type: 'script',
+                                    command: `event.item.parent.update({
+                                        "system.resources.uses.value": event.item.parent.system.resources.uses.max
+                                    })`,
+                                },
+                            },
+                        },
+                    },
+                    description: this.system.description,
+                },
+            });
+        }
+
+        return actions;
     }
 
     public weaponTypeToSkill(this: WeaponItem, weaponType?: WeaponType): Skill {
@@ -2157,8 +2248,10 @@ declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
                 'sheet.mode': 'edit' | 'view';
                 meta: {
                     origin: ItemOrigin;
+                    isEphemeral: boolean;
                 };
                 'meta.origin': ItemOrigin;
+                'meta.isEphemeral': boolean;
                 previousLevel?: number;
                 isStartingPath?: boolean;
                 isStrike?: boolean;

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -105,7 +105,7 @@
 
                 {{!-- Controls --}}
                 <div class="controls icon faded">
-                    {{#if (and @root.editable (not action.isStrikeAction))}}
+                    {{#if (and @root.editable (not action.isEphemeral))}}
                         <a data-action="edit-action"
                             data-tooltip="COSMERE.Item.Sheet.ActionsList.Edit"
                         >


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds automation for the loaded trait on weapons. Weapons that have loaded set with any value greater than 0, automatically have their "uses" resource configured to match. The generated strike action has been updated to consume uses and a reload action is also generated.

**Related Issue**  
Closes #830, #741

**How Has This Been Tested?**  
1. Create weapon
2. Enable loaded trait and set value to 3
3. Ensure "uses" resource is applied with matching max / value
4. Go to actions tab -> Ensure both strike and reload actions are generated
5. Create character
6. Drag weapon onto character
7. Use strike action -> Ensure resource consumption dialog appears
8. Continue
9. Repeat strike action 2 more times
10. Use strike action -> Ensure resource warning appears
11. Use reload action
12. Use strike action -> Ensure no resource warning appears

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351