### PR TITLE
fix(system embedded documents): add special handling for adventures

### DIFF
--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -45,8 +45,8 @@ export function EphemeralEmbeddedDocumentsMixin<
             const metadata = constructor.metadata;
 
             const configForSubType =
-                metadata.ephemeralEmbedded[this.type] ??
-                metadata.ephemeralEmbedded.base;
+                metadata.ephemeralEmbedded?.[this.type] ??
+                metadata.ephemeralEmbedded?.base;
             if (!configForSubType) return;
 
             const embedded = Object.entries(metadata.embedded) as [

--- a/src/system/documents/system-embedded-collections/inject.ts
+++ b/src/system/documents/system-embedded-collections/inject.ts
@@ -1,17 +1,25 @@
 import './socket';
 
-import { SystemEmbeddedCollectionsMixin } from './mixin';
+import { SystemEmbeddedCollectionsMixin, adventureMixin } from './mixin';
 
 globalThis.Item = SystemEmbeddedCollectionsMixin(Item, {
     Item: 'items',
 });
-
 foundry.documents = {
     ...foundry.documents,
     Item: globalThis.Item,
 };
-
 foundry.utils.setProperty(CONFIG, 'Item.documentClass', globalThis.Item);
+
+globalThis.Adventure = adventureMixin(Adventure, {
+    items: Item,
+});
+foundry.utils.setProperty(foundry.documents, 'adventure', globalThis.Adventure);
+foundry.utils.setProperty(
+    CONFIG,
+    'Adventure.documentClass',
+    globalThis.Adventure,
+);
 
 declare global {
     interface ConfiguredSystemEmbeddedCollections {

--- a/src/system/documents/system-embedded-collections/mixin.ts
+++ b/src/system/documents/system-embedded-collections/mixin.ts
@@ -138,6 +138,52 @@ export function SystemEmbeddedCollectionsMixin<
     };
 }
 
+export function adventureMixin(
+    cls: typeof Adventure,
+    fields: Record<string, foundry.abstract.Document.AnyConstructor>,
+) {
+    return class extends cls {
+        declare static __schema: foundry.data.fields.SchemaField<Adventure.Schema>;
+
+        public static defineSchema() {
+            const baseSchema = super.defineSchema();
+
+            return {
+                ...baseSchema,
+                ...Object.entries(fields).reduce(
+                    (acc, [key, cls]) => ({
+                        [key]: new foundry.data.fields.SetField(
+                            new foundry.data.fields.EmbeddedDataField(cls),
+                        ),
+                    }),
+                    {},
+                ),
+            } as unknown as typeof baseSchema;
+        }
+
+        public static get schema(): foundry.data.fields.SchemaField<Adventure.Schema> {
+            if (this.__schema) return this.__schema;
+
+            const base = this.baseDocument;
+            if (!base.hasOwnProperty('__schema')) {
+                const schema = new foundry.data.fields.SchemaField(
+                    this.defineSchema(),
+                );
+                Object.defineProperty(base, '__schema', {
+                    value: schema,
+                    writable: false,
+                });
+            }
+            Object.defineProperty(this, '__schema', {
+                value: (base as unknown as { __schema: unknown }).__schema,
+                writable: false,
+            });
+
+            return this.__schema;
+        }
+    };
+}
+
 class PseudoEmbeddedCollectionField<
     const ElementFieldType extends foundry.abstract.Document.AnyConstructor,
     const ParentDataModel extends foundry.abstract.Document.Any,

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -502,10 +502,15 @@ export function transformResponse(inResponse: SocketResponse): SocketResponse {
 
     if (isGetRequest(inRequest)) {
         if (inRequest.type === 'Adventure')
-            return transformAdventureGetResponse(inResponse);
+            return transformAdventureResponse(inResponse);
 
         return transformGetResponse(inResponse);
-    } else if (isCreateRequest(inRequest) || isUpdateRequest(inRequest)) {
+    } else if (isCreateRequest(inRequest)) {
+        return transformCreateUpdateResponse(inResponse);
+    } else if (isUpdateRequest(inRequest)) {
+        if (inRequest.type === 'Adventure')
+            return transformAdventureResponse(inResponse);
+
         return transformCreateUpdateResponse(inResponse);
     } else if (isDeleteRequest(inRequest)) {
         return transformDeleteResponse(inResponse);
@@ -673,7 +678,7 @@ function transformCRUDResponseCommon(
     };
 }
 
-function transformAdventureGetResponse(
+function transformAdventureResponse(
     inResponse: SocketResponse,
 ): SocketResponse {
     const embeddedDataFields = Object.entries(Adventure.schema.fields).filter(

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -105,6 +105,14 @@ export function transformRequest(
 export async function transformRequest(
     inRequest: DocumentSocketRequest,
 ): Promise<DocumentSocketRequest> {
+    if (inRequest.type === 'Adventure') {
+        if (isGetRequest(inRequest)) {
+            return transformAdventureGetRequest(inRequest);
+        } else if (isUpdateRequest(inRequest)) {
+            return transformAdventureUpdateRequest(inRequest);
+        }
+    }
+
     if (isGetRequest(inRequest)) {
         return transformGetRequest(inRequest);
     } else if (isCRUDRequest(inRequest)) {
@@ -135,20 +143,41 @@ async function transformCRUDRequest(
     const hierarchy = new DocumentHierarchy(targets[0]);
 
     if (!hierarchy.includesSystemEmbedding || !hierarchy.host) {
-        if (!isCreateRequest(inRequest)) return inRequest;
-
-        return foundry.utils.mergeObject(transformRequestCommon(inRequest), {
-            operation: {
-                data: inRequest.operation.data.map((data) =>
-                    data
-                        ? toServerViewObject(
-                              data as AnyDocumentData,
-                              inRequest.type,
-                          )
-                        : data,
-                ),
-            },
-        });
+        if (isCreateRequest(inRequest)) {
+            return foundry.utils.mergeObject(
+                transformRequestCommon(inRequest),
+                {
+                    operation: {
+                        data: inRequest.operation.data.map((data) =>
+                            data
+                                ? toServerViewObject(
+                                      data as AnyDocumentData,
+                                      inRequest.type,
+                                  )
+                                : data,
+                        ),
+                    },
+                },
+            );
+        } else if (isUpdateRequest(inRequest)) {
+            return foundry.utils.mergeObject(
+                transformRequestCommon(inRequest),
+                {
+                    operation: {
+                        updates: inRequest.operation.updates.map((data) =>
+                            data
+                                ? toServerViewObject(
+                                      data as AnyDocumentData,
+                                      inRequest.type,
+                                  )
+                                : data,
+                        ),
+                    },
+                },
+            );
+        } else {
+            return inRequest;
+        }
     } else {
         await queueRequestFor(hierarchy.host.uuid);
 
@@ -395,6 +424,50 @@ function resolveUpdate(
         }, updatedCollectionData)[0];
 }
 
+function transformAdventureGetRequest(
+    inRequest: DocumentSocketRequest<'get'>,
+): DocumentSocketRequest<'get'> {
+    return transformRequestCommon(inRequest);
+}
+
+function transformAdventureUpdateRequest(
+    inRequest: DocumentSocketRequest<'update'>,
+): DocumentSocketRequest {
+    const embeddedDataFields = Object.entries(Adventure.schema.fields).filter(
+        ([key, field]) =>
+            field instanceof foundry.data.fields.SetField &&
+            field.element instanceof foundry.data.fields.EmbeddedDataField,
+    );
+
+    const outRequest = transformRequestCommon(inRequest);
+
+    outRequest.operation.updates = inRequest.operation.updates.map((update) => {
+        if (!update) return update;
+
+        embeddedDataFields.forEach(([key, field]) => {
+            if (!foundry.utils.hasProperty(update, key)) return;
+
+            const documentName = (
+                (field as foundry.data.fields.SetField.Any)
+                    .element as foundry.data.fields.EmbeddedDataField<
+                    typeof foundry.abstract.Document
+                >
+            ).model.documentName;
+            const data = foundry.utils.getProperty(update, key) as AnyObject[];
+
+            foundry.utils.setProperty(
+                update,
+                key,
+                data.map((data) => toServerViewObject(data, documentName)),
+            );
+        });
+
+        return update;
+    });
+
+    return outRequest;
+}
+
 /**
  * Utility function to inject common metadata into transformed requests
  */
@@ -428,6 +501,9 @@ export function transformResponse(inResponse: SocketResponse): SocketResponse {
     const inRequest = inResponse.operation.sourceRequest;
 
     if (isGetRequest(inRequest)) {
+        if (inRequest.type === 'Adventure')
+            return transformAdventureGetResponse(inResponse);
+
         return transformGetResponse(inResponse);
     } else if (isCreateRequest(inRequest) || isUpdateRequest(inRequest)) {
         return transformCreateUpdateResponse(inResponse);
@@ -595,6 +671,44 @@ function transformCRUDResponseCommon(
         type: inRequest.type,
         result: [],
     };
+}
+
+function transformAdventureGetResponse(
+    inResponse: SocketResponse,
+): SocketResponse {
+    const embeddedDataFields = Object.entries(Adventure.schema.fields).filter(
+        ([key, field]) =>
+            field instanceof foundry.data.fields.SetField &&
+            field.element instanceof foundry.data.fields.EmbeddedDataField,
+    );
+
+    const result = inResponse.result?.map((r) => {
+        if (typeof r === 'string') return r;
+
+        embeddedDataFields.forEach(([key, field]) => {
+            if (!foundry.utils.hasProperty(r, key)) return;
+
+            const documentName = (
+                (field as foundry.data.fields.SetField.Any)
+                    .element as foundry.data.fields.EmbeddedDataField<
+                    typeof foundry.abstract.Document
+                >
+            ).model.documentName;
+            const data = foundry.utils.getProperty(r, key) as AnyObject[];
+
+            foundry.utils.setProperty(
+                resolveUpdate,
+                key,
+                data.map((data) => toClientViewObject(data, documentName)),
+            );
+        });
+
+        return r;
+    });
+
+    return foundry.utils.mergeObject(inResponse, {
+        result,
+    }) as SocketResponse;
 }
 
 /* --- Helpers --- */


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes issues with the system embedded documents handling of adventures. 

**Related Issue**  
Closes #839 

**How Has This Been Tested?**  
1. Prepare compendium with an adventure
2. Create an item
3. Add an action to the item
4. Go to adventure, right click and select "rebuild adventure"
5. Go to contents and add the item
6. Click build adventure
7. Delete the item from the world
8. Import the adventure
9. Verify that the action is present

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351