### PR TITLE
fix(actor sheet): Fixes issue where certain events are fired twice

### DIFF
--- a/src/system/applications/actor/components/actions-list-entry.ts
+++ b/src/system/applications/actor/components/actions-list-entry.ts
@@ -25,7 +25,6 @@ export class ActionsListEntryComponent extends ActorItemListComponent {
      */
     /* eslint-disable @typescript-eslint/unbound-method */
     static readonly ACTIONS = {
-        ...super.ACTIONS,
         'toggle-action-details': this.onToggleActionDetails,
         'use-item': this.onUseItem,
     };

--- a/src/system/applications/actor/components/actions-list-entry.ts
+++ b/src/system/applications/actor/components/actions-list-entry.ts
@@ -25,7 +25,7 @@ export class ActionsListEntryComponent extends ActorItemListComponent {
      */
     /* eslint-disable @typescript-eslint/unbound-method */
     static readonly ACTIONS = {
-        'toggle-action-details': this.onToggleActionDetails,
+        ...super.ACTIONS,
         'use-item': this.onUseItem,
     };
     /* eslint-enable @typescript-eslint/unbound-method */

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -257,9 +257,11 @@ export class ActorActionsListComponent extends ActorItemListComponent {
      * NOTE: Unbound methods is the standard for defining actions
      * within ApplicationV2
      */
-
+    /* eslint-disable @typescript-eslint/unbound-method */
     static readonly ACTIONS = {
         ...super.ACTIONS,
+        'toggle-section-collapsed': this.onToggleSectionCollapsed,
+        'new-item': this.onNewItem,
     };
 
     /* --- Context --- */

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -253,17 +253,6 @@ const MISC_SECTION: ItemListSection = {
 export class ActorActionsListComponent extends ActorItemListComponent {
     static TEMPLATE = `${TEMPLATES.DIRECTORY}${TEMPLATES.ACTOR_BASE_ACTIONS_LIST}`;
 
-    /**
-     * NOTE: Unbound methods is the standard for defining actions
-     * within ApplicationV2
-     */
-    /* eslint-disable @typescript-eslint/unbound-method */
-    static readonly ACTIONS = {
-        ...super.ACTIONS,
-        'toggle-section-collapsed': this.onToggleSectionCollapsed,
-        'new-item': this.onNewItem,
-    };
-
     /* --- Context --- */
 
     public async _prepareContext(

--- a/src/system/applications/actor/components/character/talents-list.ts
+++ b/src/system/applications/actor/components/character/talents-list.ts
@@ -181,19 +181,6 @@ const MISC_SECTION: ItemListSection = {
 export class ActorTalentsListComponent extends ActorItemListComponent {
     static TEMPLATE = `systems/${SYSTEM_ID}/templates/${TEMPLATES.ACTOR_CHARACTER_TALENTS_LIST}`;
 
-    /**
-     * NOTE: Unbound methods is the standard for defining actions
-     * within ApplicationV2
-     */
-    /* eslint-disable @typescript-eslint/unbound-method */
-    static readonly ACTIONS = {
-        'toggle-section-collapsed': this.onToggleSectionCollapsed,
-        'toggle-action-details': this.onToggleActionDetails,
-        'use-item': this.onUseItem,
-        'new-item': this.onNewItem,
-    };
-    /* eslint-enable @typescript-eslint/unbound-method */
-
     /* --- Context --- */
 
     public async _prepareContext(
@@ -201,8 +188,8 @@ export class ActorTalentsListComponent extends ActorItemListComponent {
         context: ActorTalentsListComponentRenderContext,
     ) {
         // Get all talent items
-        const talentItems = this.application.actor.items.filter((item) =>
-            item.isTalent() || item.isPower(),
+        const talentItems = this.application.actor.items.filter(
+            (item) => item.isTalent() || item.isPower(),
         );
 
         // Ensure all items have an expand state record

--- a/src/system/applications/actor/components/effects-list.ts
+++ b/src/system/applications/actor/components/effects-list.ts
@@ -45,7 +45,6 @@ export class ActorEffectsListComponent extends ActorItemListComponent {
     /* eslint-disable @typescript-eslint/unbound-method */
     static readonly ACTIONS = {
         ...super.ACTIONS,
-        'toggle-action-details': this.onToggleActionDetails,
         'toggle-section-collapsed': this.onToggleSectionCollapsed,
         'toggle-effect-active': this.onToggleEffectActive,
     };

--- a/src/system/applications/actor/components/item-list.ts
+++ b/src/system/applications/actor/components/item-list.ts
@@ -34,6 +34,18 @@ export class ActorItemListComponent extends HandlebarsApplicationComponent<// ty
 // NOTE: Use any as workaround for foundry-vtt-types issues
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 any> {
+    /**
+     * NOTE: Unbound methods is the standard for defining actions
+     * within ApplicationV2
+     */
+    /* eslint-disable @typescript-eslint/unbound-method */
+    static readonly ACTIONS = {
+        'toggle-section-collapsed': this.onToggleSectionCollapsed,
+        'toggle-action-details': this.onToggleActionDetails,
+        'new-item': this.onNewItem,
+    };
+    /* eslint-enable */
+
     protected sections: ItemListSection[] = [];
 
     /**

--- a/src/system/applications/actor/components/item-list.ts
+++ b/src/system/applications/actor/components/item-list.ts
@@ -34,19 +34,6 @@ export class ActorItemListComponent extends HandlebarsApplicationComponent<// ty
 // NOTE: Use any as workaround for foundry-vtt-types issues
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 any> {
-    /**
-     * NOTE: Unbound methods is the standard for defining actions
-     * within ApplicationV2
-     */
-    /* eslint-disable @typescript-eslint/unbound-method */
-    static readonly ACTIONS = {
-        'toggle-section-collapsed': this.onToggleSectionCollapsed,
-        'toggle-action-details': this.onToggleActionDetails,
-        'use-item': this.onUseItem,
-        'new-item': this.onNewItem,
-    };
-    /* eslint-enable */
-
     protected sections: ItemListSection[] = [];
 
     /**


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes issue where the action list events are fired twice.

**Related Issue**  
Closes #844 

**How Has This Been Tested?**  
1. Open new character sheet
2. Go to actions
3. Add new action and see that it adds a new action
4. Try to use new action and it should only be used once
5. Try to use the edit button and see it works
6. Try to expand and contract and see it works with no errors
7. try to contract and expand the action section itself
8. Add a radiant path
9. See that you can do the same for talents as steps 5-7

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.
