### PR TITLE
fix(hooks): add check to ensure goal hooks only fire on progress updates

### DIFF
--- a/src/system/hooks/item.ts
+++ b/src/system/hooks/item.ts
@@ -90,8 +90,9 @@ Hooks.on('updateItem', (item: CosmereItem, update: Item.UpdateData) => {
     if (item.isGoal()) {
         const previousLevel = item.getFlag(SYSTEM_ID, 'previousLevel') ?? 0;
         const newLevel = item.system.level;
+        const isLevelUpdate = foundry.utils.hasProperty(update, 'system.level');
 
-        if (newLevel !== previousLevel) {
+        if (isLevelUpdate && newLevel !== previousLevel) {
             /**
              * Hook: updateProgressGoal
              */


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes a bug with the goal hooks causing them to re-fire on any updates to the goal item after any progress has been made. This was commonly triggered through the grant item event handler, since that registers a relationship.

**Related Issue**  
Closes #820 

**How Has This Been Tested?**  
1. Create a weapon
2. Create a goal
3. Add an event to the goal
4. Set trigger to "Goal Completed"
5. Set handler type to "Grant Items"
6. Add weapon to the list of granted items
7. Add another event to the goal
8. Set trigger to "Goal Completed"
9. Set handler type to "Execute Macro"
10. Enable inline mode
11. Set macro type to script
12. Set macro to: `ui.notifications.notify("Goal completed!")`
13. Create character
14. Add goal to character
15. Progress goal to completion
16. Ensure "Goal completed!" notification only appears once

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351