### PR TITLE
fix(sheet styling): Fix issue where long strings break sheet styling width.

### DIFF
--- a/src/style/sheets/sheet.scss
+++ b/src/style/sheets/sheet.scss
@@ -133,6 +133,7 @@
 
             & > .wrapper {
                 overflow: hidden;
+                overflow-wrap: anywhere;
             }
         }
 
@@ -195,6 +196,7 @@
                 position: unset;
                 min-height: 300px;
                 padding: 0.25rem 0.5rem;
+                overflow-wrap: anywhere;
             }
         }
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where a long string or the headers can break the sheet styling width due to a lack of overflow handling. Fixes the problem by enabling overflow wrapping.

**Related Issue**  
Closes #821 

**How Has This Been Tested?**  
1. Create new actor
2. Go to notes
3. Edit journal
4. Hold W until text overflows the text field and wraps
5. Save and see it still wraps.
6. Edit journal again
7. Open starter set and go to items, armor and drag breastplate onto journal
8. Mark entire UUID link and set as header 1. See that it does not break the sheet
9. Save, and see it does not break anything
10. Do step 8-9 for header 2 as well.

**Screenshots (if applicable)**  
<img width="852" height="850" alt="image" src="https://github.com/user-attachments/assets/83422923-3755-416c-894d-3fac2255096a" />

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] No part of this PR was created using generative AI tools.
- [X] I have tested my changes on Foundry VTT version: 13.351.
