### PR TITLE
Revert "fix(system embedded documents): add special handling for adventures "

### DIFF
--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -46,8 +46,8 @@ export function EphemeralEmbeddedDocumentsMixin<
             const metadata = constructor.metadata;
 
             const configForSubType =
-                metadata.ephemeralEmbedded?.[this.type] ??
-                metadata.ephemeralEmbedded?.base;
+                metadata.ephemeralEmbedded[this.type] ??
+                metadata.ephemeralEmbedded.base;
             if (!configForSubType) return;
 
             const embedded = Object.entries(metadata.embedded) as [

--- a/src/system/documents/system-embedded-collections/inject.ts
+++ b/src/system/documents/system-embedded-collections/inject.ts
@@ -1,25 +1,17 @@
 import './socket';
 
-import { SystemEmbeddedCollectionsMixin, adventureMixin } from './mixin';
+import { SystemEmbeddedCollectionsMixin } from './mixin';
 
 globalThis.Item = SystemEmbeddedCollectionsMixin(Item, {
     Item: 'items',
 });
+
 foundry.documents = {
     ...foundry.documents,
     Item: globalThis.Item,
 };
-foundry.utils.setProperty(CONFIG, 'Item.documentClass', globalThis.Item);
 
-globalThis.Adventure = adventureMixin(Adventure, {
-    items: Item,
-});
-foundry.utils.setProperty(foundry.documents, 'adventure', globalThis.Adventure);
-foundry.utils.setProperty(
-    CONFIG,
-    'Adventure.documentClass',
-    globalThis.Adventure,
-);
+foundry.utils.setProperty(CONFIG, 'Item.documentClass', globalThis.Item);
 
 declare global {
     interface ConfiguredSystemEmbeddedCollections {

--- a/src/system/documents/system-embedded-collections/mixin.ts
+++ b/src/system/documents/system-embedded-collections/mixin.ts
@@ -138,52 +138,6 @@ export function SystemEmbeddedCollectionsMixin<
     };
 }
 
-export function adventureMixin(
-    cls: typeof Adventure,
-    fields: Record<string, foundry.abstract.Document.AnyConstructor>,
-) {
-    return class extends cls {
-        declare static __schema: foundry.data.fields.SchemaField<Adventure.Schema>;
-
-        public static defineSchema() {
-            const baseSchema = super.defineSchema();
-
-            return {
-                ...baseSchema,
-                ...Object.entries(fields).reduce(
-                    (acc, [key, cls]) => ({
-                        [key]: new foundry.data.fields.SetField(
-                            new foundry.data.fields.EmbeddedDataField(cls),
-                        ),
-                    }),
-                    {},
-                ),
-            } as unknown as typeof baseSchema;
-        }
-
-        public static get schema(): foundry.data.fields.SchemaField<Adventure.Schema> {
-            if (this.__schema) return this.__schema;
-
-            const base = this.baseDocument;
-            if (!base.hasOwnProperty('__schema')) {
-                const schema = new foundry.data.fields.SchemaField(
-                    this.defineSchema(),
-                );
-                Object.defineProperty(base, '__schema', {
-                    value: schema,
-                    writable: false,
-                });
-            }
-            Object.defineProperty(this, '__schema', {
-                value: (base as unknown as { __schema: unknown }).__schema,
-                writable: false,
-            });
-
-            return this.__schema;
-        }
-    };
-}
-
 class PseudoEmbeddedCollectionField<
     const ElementFieldType extends foundry.abstract.Document.AnyConstructor,
     const ParentDataModel extends foundry.abstract.Document.Any,

--- a/src/system/documents/system-embedded-collections/types/socket.ts
+++ b/src/system/documents/system-embedded-collections/types/socket.ts
@@ -12,8 +12,6 @@ export interface DocumentSocketRequest<
         id: string;
         action: DatabaseAction;
         queue?: boolean;
-        recursive?: boolean;
-        isHierarchical?: boolean;
     };
 }
 
@@ -40,7 +38,6 @@ export interface SocketResponse
             id: string;
         }[];
         queue?: boolean;
-        isHierarchical?: boolean;
     };
     type: foundry.abstract.Document.Type;
 }

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -105,14 +105,6 @@ export function transformRequest(
 export async function transformRequest(
     inRequest: DocumentSocketRequest,
 ): Promise<DocumentSocketRequest> {
-    if (inRequest.type === 'Adventure') {
-        if (isGetRequest(inRequest)) {
-            return transformAdventureGetRequest(inRequest);
-        } else if (isUpdateRequest(inRequest)) {
-            return transformAdventureUpdateRequest(inRequest);
-        }
-    }
-
     if (isGetRequest(inRequest)) {
         return transformGetRequest(inRequest);
     } else if (isCRUDRequest(inRequest)) {
@@ -143,34 +135,20 @@ async function transformCRUDRequest(
     const hierarchy = new DocumentHierarchy(targets[0]);
 
     if (!hierarchy.includesSystemEmbedding || !hierarchy.host) {
-        if (isCreateRequest(inRequest)) {
-            const outRequest = transformRequestCommon(inRequest);
-            outRequest.operation.data = inRequest.operation.data.map((data) =>
-                data
-                    ? toServerViewObject(
-                          data as AnyDocumentData,
-                          inRequest.type,
-                      )
-                    : data,
-            );
+        if (!isCreateRequest(inRequest)) return inRequest;
 
-            return outRequest;
-        } else if (isUpdateRequest(inRequest)) {
-            const outRequest = transformRequestCommon(inRequest);
-            outRequest.operation.updates = inRequest.operation.updates.map(
-                (data) =>
+        return foundry.utils.mergeObject(transformRequestCommon(inRequest), {
+            operation: {
+                data: inRequest.operation.data.map((data) =>
                     data
                         ? toServerViewObject(
                               data as AnyDocumentData,
                               inRequest.type,
                           )
                         : data,
-            );
-
-            return outRequest;
-        } else {
-            return inRequest;
-        }
+                ),
+            },
+        });
     } else {
         await queueRequestFor(hierarchy.host.uuid);
 
@@ -204,7 +182,6 @@ async function transformCRUDRequest(
                         id: doc.id,
                     })),
                 queue: true,
-                isHierarchical: true,
             },
         };
 
@@ -397,7 +374,6 @@ function resolveUpdate(
                               [collection.name]: acc,
                           }),
                 } as AnyObject,
-                { performDeletions: false },
             );
 
             return (
@@ -417,50 +393,6 @@ function resolveUpdate(
                     ) ?? ([update] as AnyDocumentData[])
             );
         }, updatedCollectionData)[0];
-}
-
-function transformAdventureGetRequest(
-    inRequest: DocumentSocketRequest<'get'>,
-): DocumentSocketRequest<'get'> {
-    return transformRequestCommon(inRequest);
-}
-
-function transformAdventureUpdateRequest(
-    inRequest: DocumentSocketRequest<'update'>,
-): DocumentSocketRequest {
-    const embeddedDataFields = Object.entries(Adventure.schema.fields).filter(
-        ([key, field]) =>
-            field instanceof foundry.data.fields.SetField &&
-            field.element instanceof foundry.data.fields.EmbeddedDataField,
-    );
-
-    const outRequest = transformRequestCommon(inRequest);
-
-    outRequest.operation.updates = inRequest.operation.updates.map((update) => {
-        if (!update) return update;
-
-        embeddedDataFields.forEach(([key, field]) => {
-            if (!foundry.utils.hasProperty(update, key)) return;
-
-            const documentName = (
-                (field as foundry.data.fields.SetField.Any)
-                    .element as foundry.data.fields.EmbeddedDataField<
-                    typeof foundry.abstract.Document
-                >
-            ).model.documentName;
-            const data = foundry.utils.getProperty(update, key) as AnyObject[];
-
-            foundry.utils.setProperty(
-                update,
-                key,
-                data.map((data) => toServerViewObject(data, documentName)),
-            );
-        });
-
-        return update;
-    });
-
-    return outRequest;
 }
 
 /**
@@ -496,16 +428,8 @@ export function transformResponse(inResponse: SocketResponse): SocketResponse {
     const inRequest = inResponse.operation.sourceRequest;
 
     if (isGetRequest(inRequest)) {
-        if (inRequest.type === 'Adventure')
-            return transformAdventureResponse(inResponse);
-
         return transformGetResponse(inResponse);
-    } else if (isCreateRequest(inRequest)) {
-        return transformCreateUpdateResponse(inResponse);
-    } else if (isUpdateRequest(inRequest)) {
-        if (inRequest.type === 'Adventure')
-            return transformAdventureResponse(inResponse);
-
+    } else if (isCreateRequest(inRequest) || isUpdateRequest(inRequest)) {
         return transformCreateUpdateResponse(inResponse);
     } else if (isDeleteRequest(inRequest)) {
         return transformDeleteResponse(inResponse);
@@ -629,10 +553,9 @@ function transformCreateUpdateResponse(
             );
     }
 
-    const outResponse = transformCRUDResponseCommon(inResponse);
-    outResponse.result = result;
-
-    return outResponse;
+    return foundry.utils.mergeObject(transformCRUDResponseCommon(inResponse), {
+        result,
+    });
 }
 
 function transformDeleteResponse(inResponse: SocketResponse): SocketResponse {
@@ -663,9 +586,7 @@ function transformCRUDResponseCommon(
             parentUuid: inRequest.operation.parentUuid,
             render: inRequest.operation.render,
             diff: false,
-            recursive: inResponse.operation.isHierarchical
-                ? false
-                : inRequest.operation.recursive,
+            recursive: false,
             renderSheet: foundry.utils.getProperty(
                 inRequest.operation,
                 'renderSheet',
@@ -674,44 +595,6 @@ function transformCRUDResponseCommon(
         type: inRequest.type,
         result: [],
     };
-}
-
-function transformAdventureResponse(
-    inResponse: SocketResponse,
-): SocketResponse {
-    const embeddedDataFields = Object.entries(Adventure.schema.fields).filter(
-        ([key, field]) =>
-            field instanceof foundry.data.fields.SetField &&
-            field.element instanceof foundry.data.fields.EmbeddedDataField,
-    );
-
-    const result = inResponse.result?.map((r) => {
-        if (typeof r === 'string') return r;
-
-        embeddedDataFields.forEach(([key, field]) => {
-            if (!foundry.utils.hasProperty(r, key)) return;
-
-            const documentName = (
-                (field as foundry.data.fields.SetField.Any)
-                    .element as foundry.data.fields.EmbeddedDataField<
-                    typeof foundry.abstract.Document
-                >
-            ).model.documentName;
-            const data = foundry.utils.getProperty(r, key) as AnyObject[];
-
-            foundry.utils.setProperty(
-                resolveUpdate,
-                key,
-                data.map((data) => toClientViewObject(data, documentName)),
-            );
-        });
-
-        return r;
-    });
-
-    return foundry.utils.mergeObject(inResponse, {
-        result,
-    }) as SocketResponse;
 }
 
 /* --- Helpers --- */
@@ -796,7 +679,7 @@ export function toServerViewObject(
                         {} as Record<string, AnyObject[]>,
                     ),
             },
-            { inplace: false, performDeletions: false },
+            { inplace: false },
         );
 
         systemEmbeddedConfig.forEach(([_, collectionName]) => {


### PR DESCRIPTION
This reverts commit 6868ba79d7fa47a085a1815d17b16ef5f6afbffe.
This is due to an error occurring preventing actors from being live updated when being dragged and dropped (moved) on a scene.
<img width="517" height="79" alt="image" src="https://github.com/user-attachments/assets/644526b6-5197-4151-8a9b-5afd5c3475e8" />
