### PR TITLE
fix(ephemeral embedded documents): make concrete documents no longer get re-instantiated

### DIFF
--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -70,11 +70,15 @@ export function EphemeralEmbeddedDocumentsMixin<
                     const ephemeralDocuments = generatorFn
                         .call(this as unknown as DocumentOfType<DocumentType>)
                         .map((doc) => {
-                            const newDoc = new (doc.constructor as new (
+                            // Get document constructor
+                            const cls = doc.constructor as new (
                                 ...args: unknown[]
-                            ) => DocumentOfType<EmbeddedTypesOf<DocumentType>>)(
-                                foundry.utils.mergeObject(doc.toObject(), {
-                                    _id: doc.id ?? foundry.utils.randomID(),
+                            ) => DocumentOfType<EmbeddedTypesOf<DocumentType>>;
+
+                            const data = foundry.utils.mergeObject(
+                                doc.toObject(),
+                                {
+                                    _id: doc.id ?? foundry.utils.randomID(), // Ensure id is set
                                     flags: {
                                         [SYSTEM_ID]: {
                                             meta: {
@@ -82,17 +86,11 @@ export function EphemeralEmbeddedDocumentsMixin<
                                             },
                                         },
                                     },
-                                }),
-                                {
-                                    parent: this,
                                 },
                             );
 
-                            Object.entries(doc.apps).forEach(
-                                ([id, app]) => (newDoc.apps[id] = app),
-                            );
-
-                            return newDoc;
+                            // Create new instance of document so we can assign the parent
+                            return new cls(data, { parent: this });
                         });
                     const concreteDocuments = (
                         Array.from(collection) as object[]

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -67,9 +67,33 @@ export function EphemeralEmbeddedDocumentsMixin<
                         InstanceType
                     >;
 
-                    const ephemeralDocuments = generatorFn.call(
-                        this as unknown as DocumentOfType<DocumentType>,
-                    );
+                    const ephemeralDocuments = generatorFn
+                        .call(this as unknown as DocumentOfType<DocumentType>)
+                        .map((doc) => {
+                            const newDoc = new (doc.constructor as new (
+                                ...args: unknown[]
+                            ) => DocumentOfType<EmbeddedTypesOf<DocumentType>>)(
+                                foundry.utils.mergeObject(doc.toObject(), {
+                                    _id: doc.id ?? foundry.utils.randomID(),
+                                    flags: {
+                                        [SYSTEM_ID]: {
+                                            meta: {
+                                                isEphemeral: true,
+                                            },
+                                        },
+                                    },
+                                }),
+                                {
+                                    parent: this,
+                                },
+                            );
+
+                            Object.entries(doc.apps).forEach(
+                                ([id, app]) => (newDoc.apps[id] = app),
+                            );
+
+                            return newDoc;
+                        });
                     const concreteDocuments = (
                         Array.from(collection) as object[]
                     ).filter(
@@ -82,22 +106,10 @@ export function EphemeralEmbeddedDocumentsMixin<
 
                     collection.clear();
                     ephemeralDocuments.forEach((doc) => {
-                        //@ts-expect-error foundry-vtt-types resolves the parameter type to `undefined`
-                        doc.updateSource({
-                            flags: {
-                                [SYSTEM_ID]: {
-                                    meta: {
-                                        isEphemeral: true,
-                                    },
-                                },
-                            },
-                        });
-
-                        collection.set(doc.id!, doc);
+                        collection.set(doc.id!, doc, { modifySource: false });
                     });
-
                     concreteDocuments.forEach((doc) =>
-                        collection.set(doc.id!, doc),
+                        collection.set(doc.id!, doc, { modifySource: false }),
                     );
                 } catch (err) {
                     Logger.error(

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -23,8 +23,6 @@ export function EphemeralEmbeddedDocumentsMixin<
         DocumentOfType<DocumentType> = DocumentOfType<DocumentType>,
 >(cls: DocumentClass) {
     return class EphemeralEmbeddedDocumentsDocument extends cls {
-        private ephemeralUpdate = false;
-
         declare type: foundry.abstract.Document.SubTypesOf<DocumentType>;
 
         declare static metadata: foundry.abstract.Document.MetadataFor<DocumentType> & {
@@ -37,7 +35,7 @@ export function EphemeralEmbeddedDocumentsMixin<
             super.prepareData();
             /* eslint-enable @typescript-eslint/no-unsafe-call */
 
-            if (!this.ephemeralUpdate) this.injectEphemeralDocuments();
+            this.injectEphemeralDocuments();
         }
 
         protected injectEphemeralDocuments(): void {
@@ -54,7 +52,6 @@ export function EphemeralEmbeddedDocumentsMixin<
                 EmbeddedTypesOf<DocumentType>,
                 string,
             ][];
-            const changes: AnyMutableObject = {};
 
             embedded.forEach(([embeddedName, field]) => {
                 try {
@@ -74,29 +71,34 @@ export function EphemeralEmbeddedDocumentsMixin<
                         this as unknown as DocumentOfType<DocumentType>,
                     );
                     const concreteDocuments = (
-                        Array.from(collection) as DocumentOfType<DocumentType>[]
+                        Array.from(collection) as object[]
                     ).filter(
                         (doc) =>
                             !foundry.utils.getProperty(
                                 doc,
                                 `flags.${SYSTEM_ID}.meta.isEphemeral`,
                             ),
-                    );
+                    ) as DocumentOfType<EmbeddedTypesOf<DocumentType>>[];
 
-                    changes[field] = [
-                        ...ephemeralDocuments.map((doc) =>
-                            foundry.utils.mergeObject(doc.toObject(), {
-                                flags: {
-                                    [SYSTEM_ID]: {
-                                        meta: {
-                                            isEphemeral: true,
-                                        },
+                    collection.clear();
+                    ephemeralDocuments.forEach((doc) => {
+                        //@ts-expect-error foundry-vtt-types resolves the parameter type to `undefined`
+                        doc.updateSource({
+                            flags: {
+                                [SYSTEM_ID]: {
+                                    meta: {
+                                        isEphemeral: true,
                                     },
                                 },
-                            }),
-                        ),
-                        ...concreteDocuments.map((doc) => doc.toObject()),
-                    ];
+                            },
+                        });
+
+                        collection.set(doc.id!, doc);
+                    });
+
+                    concreteDocuments.forEach((doc) =>
+                        collection.set(doc.id!, doc),
+                    );
                 } catch (err) {
                     Logger.error(
                         'ephemeralEmbeddedDocuments',
@@ -105,27 +107,6 @@ export function EphemeralEmbeddedDocumentsMixin<
                     );
                 }
             });
-
-            if (Object.keys(changes).length === 0) return;
-
-            this.ephemeralUpdate = true;
-
-            // Call updateSource and set each collection to an empty array to prevent ephemeral documents from being ordered after concrete documents
-            this.updateSource(
-                Object.keys(changes).reduce(
-                    (acc, field) => ({
-                        ...acc,
-                        [field]: [],
-                    }),
-                    {} as AnyObject,
-                ),
-                { recursive: false },
-            );
-
-            // Call updateSource with actual data to set collections to correct state
-            this.updateSource(changes, { recursive: false });
-
-            this.ephemeralUpdate = false;
         }
     };
 }


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes a bug with the ephemeral embedded documents forcing concrete documents to get re-instantiated on update, causing them to lose track of their associated applications (sheets). Subsequent updates to the document then wouldn't propagate out to the open sheet.

**Related Issue**  
Closes #850 

**How Has This Been Tested?**  
1. Create weapon
2. Add action to weapon
3. Add event to action
4. Delete the event (or perform any other update against the action)

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351