### PR TITLE
feat(data model): increase hard cap on skill ranks from 5 to 40

### DIFF
--- a/src/style/module.scss
+++ b/src/style/module.scss
@@ -697,7 +697,7 @@
             font-size: var(--font-size-12);
             font-weight: 600;
             padding-top: 0.25rem;
-            width: 24px;
+            width: 27px;
             text-align: center;
 
             .operator {
@@ -706,6 +706,10 @@
 
             .val {
                 color: var(--cosmere-color-text-main);
+            }
+
+            .modified {
+                color: var(--cosmere-color-highlight)
             }
         }
 

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -286,7 +286,7 @@ function getSkillsSchema() {
                 nullable: false,
                 integer: true,
                 min: 0,
-                max: 5,
+                max: 40,
                 initial: 0,
             }),
             mod: new DerivedValueField(

--- a/src/templates/actors/components/skill.hbs
+++ b/src/templates/actors/components/skill.hbs
@@ -21,16 +21,24 @@
             <div>
         {{/if}}
         <ul class="pip-list">
-            {{#each (numberRange skill.rank)}}
-                <li class="pip active">
-                    <div {{#if ../editable}}data-action="adjust-skill-rank" data-index='{{@index}}'{{/if}}></div>
-                </li>
-            {{/each}}
-            {{#each (numberRange (sub 5 skill.rank))}}
-                <li class="pip{{#if (gt (add (add @index 1) ../skill.rank) ../maxSkillRank)}} locked{{/if}}">
-                    <div {{#if ../editable}}data-action="adjust-skill-rank" data-index='{{add @index ../skill.rank}}'{{/if}}></div>
-                </li>
-            {{/each}}
+            {{#if (gte skill.rank 5)}}
+                {{#each (numberRange 5)}}
+                    <li class="pip active">
+                        <div {{#if ../editable}}data-action="adjust-skill-rank" data-index='{{@index}}'{{/if}}></div>
+                    </li>
+                {{/each}}
+            {{else}}
+                {{#each (numberRange skill.rank)}}
+                    <li class="pip active">
+                        <div {{#if ../editable}}data-action="adjust-skill-rank" data-index='{{@index}}'{{/if}}></div>
+                    </li>
+                {{/each}}
+                {{#each (numberRange (sub 5 skill.rank))}}
+                    <li class="pip{{#if (gt (add (add @index 1) ../skill.rank) ../maxSkillRank)}} locked{{/if}}">
+                        <div {{#if ../editable}}data-action="adjust-skill-rank" data-index='{{add @index ../skill.rank}}'{{/if}}></div>
+                    </li>
+                {{/each}}
+            {{/if}}
         </ul>
         {{#if editable}}
             </a>

--- a/src/templates/actors/components/skill.hbs
+++ b/src/templates/actors/components/skill.hbs
@@ -1,6 +1,6 @@
 <div class="mod">
     <span class="operator">+</span>
-    <span class="val">{{derived skill.mod }}</span>
+    <span class="{{#if (gte skill.rank 5)}}modified{{else}}val{{/if}} ">{{derived skill.mod }}</span>
 </div>
 <a class="name" data-action="roll-skill">
     <span>{{ localize skill.label }}</span>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Increases the skill rank cap to 40. Does not increase the amount of pips and caps it at 5. Eventually we should overhaul how we do modifiers so we have more control than we currently do since we currently mix modifiers with the actual number which is not good. For now this will work with 3.0.0 MVP.

**Related Issue**  
Closes #536 

**How Has This Been Tested?**  
1. Create new equipment
2. Add event to equipment: Add to actor, Modify skill, Athletics, 6
3. Create new character
4. add equipment to character 6 times
5. see that the skill has increased beyond the usual cap and the modifier number is blue to indicate skill ranks are above 5.

**Screenshots (if applicable)**  
<img width="277" height="184" alt="image" src="https://github.com/user-attachments/assets/acf457fe-891a-4413-b3a7-95477a38dbdc" />
<img width="473" height="259" alt="image" src="https://github.com/user-attachments/assets/237073db-eb8d-4013-be15-88482946fbfc" />


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] No part of this PR was created using generative AI tools.
- [X] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
This is not intended as the complete fix, only a temporary one for now.
