### PR TITLE
Fix/sheet minimizing and name sizing

### DIFF
--- a/src/style/sheets/actor/adversary.scss
+++ b/src/style/sheets/actor/adversary.scss
@@ -2,9 +2,6 @@
     --border-tier-svg: url('assets/icons/svg/sheet/border_tier.svg');
     --mask-tier-svg: url('assets/icons/svg/sheet/mask_tier.svg');
 
-    min-width: 800px;
-    min-height: 675px;
-
     .sheet-header {
         .title {
             .details {

--- a/src/style/sheets/actor/character.scss
+++ b/src/style/sheets/actor/character.scss
@@ -2,9 +2,6 @@
     --border-level-svg: url('assets/icons/svg/sheet/border_level.svg');
     --mask-level-svg: url('assets/icons/svg/sheet/mask_level.svg');
 
-    min-width: 800px;
-    min-height: 675px;
-
     .sheet-header {
         .title {
             padding-left: 1.25rem;

--- a/src/style/sheets/actor/module.scss
+++ b/src/style/sheets/actor/module.scss
@@ -68,6 +68,7 @@
             flex: 1;
 
             .document-name {
+                width: 100%;
                 font-family: var(--cosmere-font-header-sc);
                 font-weight: 600;
                 font-size: var(--font-size-48);
@@ -82,6 +83,7 @@
             }
 
             .details {
+                width: 100%;
                 font-family: var(--cosmere-font-normal);
                 font-size: var(--font-size-15);
                 font-weight: bold;
@@ -104,6 +106,7 @@
             flex: unset;
             display: flex;
             align-items: center;
+            padding-left: .5rem;
 
             .level {
                 .container {

--- a/src/system/applications/actor/adversary-sheet.ts
+++ b/src/system/applications/actor/adversary-sheet.ts
@@ -104,6 +104,7 @@ export class AdversarySheet extends BaseActorSheet<AdversarySheetRenderContext> 
     protected override _onPosition(options: unknown): void {
         super._onPosition(options);
 
+        if (this.minimized) { return; }
         if (this.isApplyingPositionConstraint) return;
 
         const width = this.position.width as number;

--- a/src/system/applications/actor/character-sheet.ts
+++ b/src/system/applications/actor/character-sheet.ts
@@ -119,6 +119,7 @@ export class CharacterSheet extends BaseActorSheet {
     protected override _onPosition(options: unknown): void {
         super._onPosition(options);
 
+        if (this.minimized) { return }
         if (this.isApplyingPositionConstraint) return;
 
         const width = this.position.width as number;

--- a/src/system/applications/component-system/mixin.ts
+++ b/src/system/applications/component-system/mixin.ts
@@ -308,6 +308,7 @@ export declare class ComponentHandlebarsApplication {
     // public get item(): T extends 'Item' ? Item.Implementation : never;
 
     public readonly components: Record<string, HandlebarsApplicationComponent>;
+    public readonly minimized: boolean;
 
     public id: string;
     public document: foundry.abstract.Document.Any;


### PR DESCRIPTION
**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
- Allow character and adversary sheets to minimize
- Allow names to flex with resizing

**Related Issue**  
Overall resizing issues

**How Has This Been Tested?**  
Create a character sheet and an adversary sheet. 
Double click the header of both and see if they minimize.
Double click the header of both to see if they expand again

Create a long name on both
Resize the sheet to see if the name extends across the header

**Screenshots (if applicable)**  
<img width="869" height="728" alt="image" src="https://github.com/user-attachments/assets/c71d85a3-c5db-4266-abb8-546e0ccffa00" />

<img width="1807" height="1171" alt="image" src="https://github.com/user-attachments/assets/b4578e94-33eb-4526-8fcd-186720aa042c" />

<img width="292" height="113" alt="image" src="https://github.com/user-attachments/assets/da5efebe-503e-4688-998a-ff3aec82b37c" />


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13