### PR TITLE
feat(character sheet): add item resource consumption 

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1840,6 +1840,7 @@
         "Description": "Description",
         "Talent": "Talent",
         "Goal": "Goal",
+        "From": "from",
         "Button": {
             "Source": "Edit Source",
             "Roll": "Roll",

--- a/src/style/module.scss
+++ b/src/style/module.scss
@@ -508,6 +508,7 @@
                 .target {
                     display: inline-block;
                     vertical-align: middle;
+                    font-size: var(--font-size-14);
                 }
             }
 

--- a/src/style/module.scss
+++ b/src/style/module.scss
@@ -476,6 +476,10 @@
                 color: var(--cosmere-color-text-sub);
                 text-transform: uppercase;
 
+                &.nowrap{
+                    white-space:nowrap;
+                }
+
                 &.wide {
                     width: 76px;
                 }
@@ -500,6 +504,11 @@
                 font-size: var(--font-size-10);
                 font-weight: 600;
                 font-variant: lining-nums;
+
+                .target {
+                    display: inline-block;
+                    vertical-align: middle;
+                }
             }
 
             .action,

--- a/src/style/module.scss
+++ b/src/style/module.scss
@@ -484,6 +484,10 @@
                     width: 76px;
                 }
 
+                &.extrawide {
+                    width: 114px;
+                }
+
                 &.thin {
                     width: 16px;
                 }
@@ -504,6 +508,7 @@
                 font-size: var(--font-size-10);
                 font-weight: 600;
                 font-variant: lining-nums;
+                vertical-align: middle;
 
                 .target {
                     display: inline-block;

--- a/src/system/applications/components/match-document-target.ts
+++ b/src/system/applications/components/match-document-target.ts
@@ -144,6 +144,7 @@ export class MatchDocumentTargetComponent extends HandlebarsApplicationComponent
             resolvedDocument,
             resolvedReference,
             editable: params.editable !== false && params.name,
+            short: params.short,
         });
     }
 }
@@ -155,6 +156,7 @@ export namespace MatchDocumentTargetComponent {
         type?: foundry.abstract.Document.Type;
         name?: string;
         editable?: boolean;
+        short?: boolean;
     }
 }
 

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -545,63 +545,14 @@ Handlebars.registerHelper(
     'resourceCostLabel',
     (consume: ActionItemDataModel.ConsumeData) => {
         const { value } = consume;
+        let resource = '';
         if (consume.type === ItemConsumeType.Resource) {
-            const resource = game.i18n.localize(
+            resource = game.i18n.localize(
                 CONFIG.COSMERE.resources[consume.resource].label ??
                     'GENERIC.Unknown',
             );
-
-            let label = '';
-
-            // Get adjusted minimum value, to account for optional formatting
-            const adjustedMin = Math.max(value.min, 1);
-
-            // Static range
-            if (adjustedMin === value.max) {
-                label = game.i18n.format(
-                    'COSMERE.Actor.Sheet.Actions.Consume.Static',
-                    {
-                        amount: adjustedMin.toFixed(),
-                        resource,
-                    },
-                );
-            }
-            // Uncapped range
-            else if (value.max === -1) {
-                label = game.i18n.format(
-                    'COSMERE.Actor.Sheet.Actions.Consume.RangeUncapped',
-                    {
-                        amount: adjustedMin.toFixed(),
-                        resource,
-                    },
-                );
-            }
-            // Capped range
-            else {
-                label = game.i18n.format(
-                    'COSMERE.Actor.Sheet.Actions.Consume.RangeCapped',
-                    {
-                        min: adjustedMin.toFixed(),
-                        max: value.max.toFixed(),
-                        resource,
-                    },
-                );
-            }
-
-            // Treat actual minimum value of 0 as an "optional" cost
-            if (value.min === 0) {
-                label = game.i18n.format(
-                    'COSMERE.Actor.Sheet.Actions.Consume.Optional',
-                    {
-                        label,
-                    },
-                );
-            }
-
-            return label;
         } else if (consume.type === ItemConsumeType.ItemResource) {
             const singular = value.min == 1 && value.max == 1;
-            let resource = '';
             if (singular) {
                 resource = game.i18n.localize(
                     CONFIG.COSMERE.item.resource.types[consume.resource]
@@ -613,59 +564,59 @@ Handlebars.registerHelper(
                         .labelPlural ?? 'GENERIC.Unknown',
                 );
             }
-
-            let label = '';
-
-            // Get adjusted minimum value, to account for optional formatting
-            const adjustedMin = Math.max(value.min, 1);
-
-            // Static range
-            if (adjustedMin === value.max) {
-                label = game.i18n.format(
-                    'COSMERE.Actor.Sheet.Actions.Consume.Static',
-                    {
-                        amount: adjustedMin.toFixed(),
-                        resource,
-                    },
-                );
-            }
-            // Uncapped range
-            else if (value.max === -1) {
-                label = game.i18n.format(
-                    'COSMERE.Actor.Sheet.Actions.Consume.RangeUncapped',
-                    {
-                        amount: adjustedMin.toFixed(),
-                        resource,
-                    },
-                );
-            }
-            // Capped range
-            else {
-                label = game.i18n.format(
-                    'COSMERE.Actor.Sheet.Actions.Consume.RangeCapped',
-                    {
-                        min: adjustedMin.toFixed(),
-                        max: value.max.toFixed(),
-                        resource,
-                    },
-                );
-            }
-
-            // Treat actual minimum value of 0 as an "optional" cost
-            if (value.min === 0) {
-                label = game.i18n.format(
-                    'COSMERE.Actor.Sheet.Actions.Consume.Optional',
-                    {
-                        label,
-                    },
-                );
-            }
-
-            return label;
         }
         // else if (consume.type === ItemConsumeType.Item){
 
         // }
+
+        let label = '';
+
+        // Get adjusted minimum value, to account for optional formatting
+        const adjustedMin = Math.max(value.min, 1);
+
+        // Static range
+        if (adjustedMin === value.max) {
+            label = game.i18n.format(
+                'COSMERE.Actor.Sheet.Actions.Consume.Static',
+                {
+                    amount: adjustedMin.toFixed(),
+                    resource,
+                },
+            );
+        }
+        // Uncapped range
+        else if (value.max === -1) {
+            label = game.i18n.format(
+                'COSMERE.Actor.Sheet.Actions.Consume.RangeUncapped',
+                {
+                    amount: adjustedMin.toFixed(),
+                    resource,
+                },
+            );
+        }
+        // Capped range
+        else {
+            label = game.i18n.format(
+                'COSMERE.Actor.Sheet.Actions.Consume.RangeCapped',
+                {
+                    min: adjustedMin.toFixed(),
+                    max: value.max.toFixed(),
+                    resource,
+                },
+            );
+        }
+
+        // Treat actual minimum value of 0 as an "optional" cost
+        if (value.min === 0) {
+            label = game.i18n.format(
+                'COSMERE.Actor.Sheet.Actions.Consume.Optional',
+                {
+                    label,
+                },
+            );
+        }
+
+        return label;
     },
 );
 

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -369,6 +369,8 @@ Handlebars.registerHelper(
                         .consumption) {
                         const consumesResource =
                             consumable.type === ItemConsumeType.Resource;
+                        const consumesItemResource =
+                            consumable.type === ItemConsumeType.ItemResource;
                         // const consumesItem =
                         //     consumable.type === ItemConsumeType.Item;
                         const consumesItem = false;
@@ -378,6 +380,7 @@ Handlebars.registerHelper(
                             type: consumable.type,
                             value: consumable.value,
                             consumesResource,
+                            consumesItemResource,
                             consumesItem,
 
                             ...(consumable.type === ItemConsumeType.Resource
@@ -387,6 +390,18 @@ Handlebars.registerHelper(
                                           CONFIG.COSMERE.resources[
                                               consumable.resource
                                           ].label,
+                                  }
+                                : {}),
+
+                            ...(consumable.type === ItemConsumeType.ItemResource
+                                ? {
+                                      resource: consumable.resource,
+                                      resourceLabel:
+                                          CONFIG.COSMERE.item.resource.types[
+                                              consumable.resource
+                                          ].label,
+                                      relativeTo: item,
+                                      matchDocument: consumable.matchDocument,
                                   }
                                 : {}),
                         });
@@ -530,62 +545,127 @@ Handlebars.registerHelper(
     'resourceCostLabel',
     (consume: ActionItemDataModel.ConsumeData) => {
         const { value } = consume;
-        const resource = game.i18n.localize(
-            consume.type === ItemConsumeType.Resource
-                ? CONFIG.COSMERE.resources[consume.resource].label
-                : consume.type === ItemConsumeType.ItemResource
-                  ? CONFIG.COSMERE.item.resource.types[consume.resource].label
-                  : 'GENERIC.Unknown',
-        );
-
-        let label = '';
-
-        // Get adjusted minimum value, to account for optional formatting
-        const adjustedMin = Math.max(value.min, 1);
-
-        // Static range
-        if (adjustedMin === value.max) {
-            label = game.i18n.format(
-                'COSMERE.Actor.Sheet.Actions.Consume.Static',
-                {
-                    amount: adjustedMin.toFixed(),
-                    resource,
-                },
+        if (consume.type === ItemConsumeType.Resource) {
+            const resource = game.i18n.localize(
+                CONFIG.COSMERE.resources[consume.resource].label ??
+                    'GENERIC.Unknown',
             );
-        }
-        // Uncapped range
-        else if (value.max === -1) {
-            label = game.i18n.format(
-                'COSMERE.Actor.Sheet.Actions.Consume.RangeUncapped',
-                {
-                    amount: adjustedMin.toFixed(),
-                    resource,
-                },
-            );
-        }
-        // Capped range
-        else {
-            label = game.i18n.format(
-                'COSMERE.Actor.Sheet.Actions.Consume.RangeCapped',
-                {
-                    min: adjustedMin.toFixed(),
-                    max: value.max.toFixed(),
-                    resource,
-                },
-            );
-        }
 
-        // Treat actual minimum value of 0 as an "optional" cost
-        if (value.min === 0) {
-            label = game.i18n.format(
-                'COSMERE.Actor.Sheet.Actions.Consume.Optional',
-                {
-                    label,
-                },
-            );
-        }
+            let label = '';
 
-        return label;
+            // Get adjusted minimum value, to account for optional formatting
+            const adjustedMin = Math.max(value.min, 1);
+
+            // Static range
+            if (adjustedMin === value.max) {
+                label = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Actions.Consume.Static',
+                    {
+                        amount: adjustedMin.toFixed(),
+                        resource,
+                    },
+                );
+            }
+            // Uncapped range
+            else if (value.max === -1) {
+                label = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Actions.Consume.RangeUncapped',
+                    {
+                        amount: adjustedMin.toFixed(),
+                        resource,
+                    },
+                );
+            }
+            // Capped range
+            else {
+                label = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Actions.Consume.RangeCapped',
+                    {
+                        min: adjustedMin.toFixed(),
+                        max: value.max.toFixed(),
+                        resource,
+                    },
+                );
+            }
+
+            // Treat actual minimum value of 0 as an "optional" cost
+            if (value.min === 0) {
+                label = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Actions.Consume.Optional',
+                    {
+                        label,
+                    },
+                );
+            }
+
+            return label;
+        } else if (consume.type === ItemConsumeType.ItemResource) {
+            const singular = value.min == 1 && value.max == 1;
+            let resource = '';
+            if (singular) {
+                resource = game.i18n.localize(
+                    CONFIG.COSMERE.item.resource.types[consume.resource]
+                        .label ?? 'GENERIC.Unknown',
+                );
+            } else {
+                resource = game.i18n.localize(
+                    CONFIG.COSMERE.item.resource.types[consume.resource]
+                        .labelPlural ?? 'GENERIC.Unknown',
+                );
+            }
+
+            let label = '';
+
+            // Get adjusted minimum value, to account for optional formatting
+            const adjustedMin = Math.max(value.min, 1);
+
+            // Static range
+            if (adjustedMin === value.max) {
+                label = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Actions.Consume.Static',
+                    {
+                        amount: adjustedMin.toFixed(),
+                        resource,
+                    },
+                );
+            }
+            // Uncapped range
+            else if (value.max === -1) {
+                label = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Actions.Consume.RangeUncapped',
+                    {
+                        amount: adjustedMin.toFixed(),
+                        resource,
+                    },
+                );
+            }
+            // Capped range
+            else {
+                label = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Actions.Consume.RangeCapped',
+                    {
+                        min: adjustedMin.toFixed(),
+                        max: value.max.toFixed(),
+                        resource,
+                    },
+                );
+            }
+
+            // Treat actual minimum value of 0 as an "optional" cost
+            if (value.min === 0) {
+                label = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Actions.Consume.Optional',
+                    {
+                        label,
+                    },
+                );
+            }
+
+            return label;
+        }
+        // else if (consume.type === ItemConsumeType.Item){
+
+        // }
     },
 );
 

--- a/src/system/utils/handlebars/types.ts
+++ b/src/system/utils/handlebars/types.ts
@@ -67,6 +67,7 @@ export interface ItemContext {
         type: string;
         value: NumberRange;
         consumesResource: boolean;
+        consumesItemResource: boolean;
         consumesItem: boolean;
         resource: string;
     }>[];

--- a/src/templates/actors/components/actions-list-entry.hbs
+++ b/src/templates/actors/components/actions-list-entry.hbs
@@ -37,7 +37,7 @@
         </div>
 
         {{!-- Consume --}}
-        <div class="detail wide nowrap">
+        <div class="detail extrawide nowrap">
             {{!-- Consume --}}
             {{#if ctx.hasConsume}}
                 {{#if (gt ctx.consume.length 1)}}

--- a/src/templates/actors/components/actions-list-entry.hbs
+++ b/src/templates/actors/components/actions-list-entry.hbs
@@ -48,7 +48,19 @@
                     {{#if consume.consumesResource}}
                     <span>{{resourceCostLabel consume}}</span>
                     {{/if}}
+                    {{#if consume.consumesItemResource}}
 
+                    <span>{{resourceCostLabel consume}}</span>
+
+                    <span>from</span>
+                    <div class="target">
+                        {{app-match-document-target
+                            value=consume.matchDocument
+                            relativeTo=consume.relativeTo
+                            short=true
+                        }}
+                    </div>
+                    {{/if}}
                     {{!-- TODO: Item consume --}}
                     {{#if consume.consumesItem}}
                     <span>—</span>

--- a/src/templates/actors/components/actions-list-entry.hbs
+++ b/src/templates/actors/components/actions-list-entry.hbs
@@ -52,7 +52,7 @@
 
                     <span>{{resourceCostLabel consume}}</span>
 
-                    <span>from</span>
+                    <span>{{localize "COSMERE.Generic.From"}}</span>
                     <div class="target">
                         {{app-match-document-target
                             value=consume.matchDocument

--- a/src/templates/actors/components/actions-list-entry.hbs
+++ b/src/templates/actors/components/actions-list-entry.hbs
@@ -52,7 +52,7 @@
 
                     <span>{{resourceCostLabel consume}}</span>
 
-                    <span>{{localize "COSMERE.Generic.From"}}</span>
+                    <span>{{localize "GENERIC.From"}}</span>
                     <div class="target">
                         {{app-match-document-target
                             value=consume.matchDocument

--- a/src/templates/actors/components/actions-list-entry.hbs
+++ b/src/templates/actors/components/actions-list-entry.hbs
@@ -37,7 +37,7 @@
         </div>
 
         {{!-- Consume --}}
-        <div class="detail wide">
+        <div class="detail wide nowrap">
             {{!-- Consume --}}
             {{#if ctx.hasConsume}}
                 {{#if (gt ctx.consume.length 1)}}

--- a/src/templates/actors/components/actions-list.hbs
+++ b/src/templates/actors/components/actions-list.hbs
@@ -13,7 +13,7 @@
             <span class="subtitle">
                 {{localize "COSMERE.Actor.Sheet.Actions.Activation"}}
             </span>
-            <span class="subtitle wide">
+            <span class="subtitle extrawide">
                 {{localize "COSMERE.Actor.Sheet.Actions.Consume.label"}}
             </span>
             <span class="subtitle">
@@ -64,7 +64,7 @@
                             <div class="detail action"></div>
 
                             {{!-- Consume --}}
-                            <div class="detail wide"></div>
+                            <div class="detail extrawide"></div>
 
                             {{!-- Uses --}}
                             <div class="detail"></div>

--- a/src/templates/general/components/match-document-target.hbs
+++ b/src/templates/general/components/match-document-target.hbs
@@ -17,6 +17,7 @@
     {{#with (last value.steps) as |step|}}
         {{#if (not (or (eq step.target "self") (eq step.target "parent")))}}
             {{#if (and (eq step.matchBy "document-type") step.documentType)}}
+                <span class="type">{{localize (concat "DOCUMENT." step.documentType)}}</span>
             {{else if @root.resolvedReference}}
                 <a class="content-link document-link" data-link
                     data-uuid="{{@root.resolvedReference.uuid}}"

--- a/src/templates/general/components/match-document-target.hbs
+++ b/src/templates/general/components/match-document-target.hbs
@@ -24,7 +24,7 @@
                     data-type="{{@root.resolvedReference.documentName}}"
                     data-tooltip="{{localize (concat "COSMERE.Utils.MatchDocument.Target.Type." step.target ".Label")}} {{localize (concat "COSMERE.Utils.MatchDocument.MatchBy.Explain." step.matchBy)}} {{@root.resolvedReference.name}} (NOT FOUND)"
                 >
-                    <span class="complication-color">!</span>
+                    <i class="complication-color fa-solid fa-exclamation-circle"></i>
                     {{#if @root.resolvedReference.img}}
                         <img src="{{@root.resolvedReference.img}}" alt="{{@root.resolvedReference.name}}">
                     {{/if}}

--- a/src/templates/general/components/match-document-target.hbs
+++ b/src/templates/general/components/match-document-target.hbs
@@ -22,7 +22,7 @@
                     data-uuid="{{@root.resolvedReference.uuid}}"
                     data-id="{{@root.resolvedReference.id}}"
                     data-type="{{@root.resolvedReference.documentName}}"
-                    data-tooltip="{{@root.resolvedReference.name}} (NOT FOUND)"
+                    data-tooltip="{{localize (concat "COSMERE.Utils.MatchDocument.Target.Type." step.target ".Label")}} {{localize (concat "COSMERE.Utils.MatchDocument.MatchBy.Explain." step.matchBy)}} {{@root.resolvedReference.name}} (NOT FOUND)"
                 >
                     {{#if @root.resolvedReference.img}}
                         <img src="{{@root.resolvedReference.img}}" alt="{{@root.resolvedReference.name}}">

--- a/src/templates/general/components/match-document-target.hbs
+++ b/src/templates/general/components/match-document-target.hbs
@@ -24,6 +24,7 @@
                     data-type="{{@root.resolvedReference.documentName}}"
                     data-tooltip="{{localize (concat "COSMERE.Utils.MatchDocument.Target.Type." step.target ".Label")}} {{localize (concat "COSMERE.Utils.MatchDocument.MatchBy.Explain." step.matchBy)}} {{@root.resolvedReference.name}} (NOT FOUND)"
                 >
+                    <span class="complication-color">!</span>
                     {{#if @root.resolvedReference.img}}
                         <img src="{{@root.resolvedReference.img}}" alt="{{@root.resolvedReference.name}}">
                     {{/if}}

--- a/src/templates/general/components/match-document-target.hbs
+++ b/src/templates/general/components/match-document-target.hbs
@@ -1,9 +1,48 @@
+{{!-- Short-form --}}
+{{#if short}}
 {{#if resolvedDocument}}
 
-    <a class="content-link document-link" data-link 
-        data-uuid="{{resolvedDocument.uuid}}" 
-        data-id="{{resolvedDocument.id}}" 
-        data-type="{{resolvedDocument.documentName}}" 
+    <a class="content-link document-link" data-link
+        data-uuid="{{resolvedDocument.uuid}}"
+        data-id="{{resolvedDocument.id}}"
+        data-type="{{resolvedDocument.documentName}}"
+        data-tooltip="{{resolvedDocument.name}}"
+    >
+        {{#if resolvedDocument.img}}
+            <img src="{{resolvedDocument.img}}" alt="{{resolvedDocument.name}}">
+        {{/if}}
+    </a>
+
+{{else if (gt value.steps.length 0)}}
+    {{#with (last value.steps) as |step|}}
+        {{#if (not (or (eq step.target "self") (eq step.target "parent")))}}
+            {{#if (and (eq step.matchBy "document-type") step.documentType)}}
+            {{else if @root.resolvedReference}}
+                <a class="content-link document-link" data-link
+                    data-uuid="{{@root.resolvedReference.uuid}}"
+                    data-id="{{@root.resolvedReference.id}}"
+                    data-type="{{@root.resolvedReference.documentName}}"
+                    data-tooltip="{{@root.resolvedReference.name}} (NOT FOUND)"
+                >
+                    {{#if @root.resolvedReference.img}}
+                        <img src="{{@root.resolvedReference.img}}" alt="{{@root.resolvedReference.name}}">
+                    {{/if}}
+                </a>
+            {{else}}
+                <span>UNKNOWN</span>
+            {{/if}}
+        {{/if}}
+    {{/with}}
+{{/if}}
+
+{{!-- Long-form --}}
+{{else}}
+{{#if resolvedDocument}}
+
+    <a class="content-link document-link" data-link
+        data-uuid="{{resolvedDocument.uuid}}"
+        data-id="{{resolvedDocument.id}}"
+        data-type="{{resolvedDocument.documentName}}"
         data-tooltip="{{localize (concat "DOCUMENT." resolvedDocument.documentName)}}"
     >
         {{#if resolvedDocument.img}}
@@ -25,10 +64,10 @@
             {{#if (and (eq step.matchBy "document-type") step.documentType)}}
                 <span class="type">{{localize (concat "DOCUMENT." step.documentType)}}</span>
             {{else if @root.resolvedReference}}
-                <a class="content-link document-link" data-link 
-                    data-uuid="{{@root.resolvedReference.uuid}}" 
-                    data-id="{{@root.resolvedReference.id}}" 
-                    data-type="{{@root.resolvedReference.documentName}}" 
+                <a class="content-link document-link" data-link
+                    data-uuid="{{@root.resolvedReference.uuid}}"
+                    data-id="{{@root.resolvedReference.id}}"
+                    data-type="{{@root.resolvedReference.documentName}}"
                     data-tooltip="{{localize (concat "DOCUMENT." @root.resolvedReference.documentName)}}"
                 >
                     {{#if @root.resolvedReference.img}}
@@ -46,10 +85,11 @@
 
 {{#if editable}}
     <div class="controls">
-        <a data-action="configure" 
+        <a data-action="configure"
             data-tooltip="COSMERE.Utils.MatchDocument.Target.Configure"
         >
             <i class="fa-solid fa-gear"></i>
         </a>
     </div>
+{{/if}}
 {{/if}}

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -56,7 +56,7 @@
                 </div>
 
                 {{!-- Cost --}}
-                <div class="detail wide">
+                <div class="detail wide nowrap">
                     {{#if ctx.hasConsume}}
                         {{#if (gt ctx.consume.length 1)}}
                             <span>{{localize "COSMERE.Actor.Sheet.Actions.Consume.Multiple"}}</span>

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -69,7 +69,7 @@
                             {{#if consume.consumesItemResource}}
                                 <span>{{resourceCostLabel consume}}</span>
 
-                                <span>from</span>
+                                <span>{{localize "COSMERE.Generic.From"}}</span>
                                 <div class="target">
                                     {{app-match-document-target
                                         value=consume.matchDocument

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -69,7 +69,7 @@
                             {{#if consume.consumesItemResource}}
                                 <span>{{resourceCostLabel consume}}</span>
 
-                                <span>{{localize "COSMERE.Generic.From"}}</span>
+                                <span>{{localize "GENERIC.From"}}</span>
                                 <div class="target">
                                     {{app-match-document-target
                                         value=consume.matchDocument

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -22,8 +22,8 @@
 
     {{#each actions as |action|}}
     {{#with (itemContext action) as |ctx|}}
-        <li class="item action" 
-            data-id="{{action.id}}" 
+        <li class="item action"
+            data-id="{{action.id}}"
             data-item-uuid="{{action.uuid}}"
             {{#if @root.editable}}data-drag="true"{{/if}}
         >
@@ -66,7 +66,18 @@
                             {{#if consume.consumesResource}}
                                 <span>{{resourceCostLabel consume}}</span>
                             {{/if}}
+                            {{#if consume.consumesItemResource}}
+                                <span>{{resourceCostLabel consume}}</span>
 
+                                <span>from</span>
+                                <div class="target">
+                                    {{app-match-document-target
+                                        value=consume.matchDocument
+                                        relativeTo=consume.relativeTo
+                                        short=true
+                                    }}
+                                </div>
+                            {{/if}}
                             {{!-- TODO: Item consume --}}
                             {{#if consume.consumesItem}}
                                 <span>—</span>

--- a/src/templates/item/components/resource-consumption-list.hbs
+++ b/src/templates/item/components/resource-consumption-list.hbs
@@ -16,8 +16,8 @@
                         {{/if}}
                     </span>
 
-                    <span>from</span>
-                    
+                    <span>{{localize "COSMERE.Generic.From"}}</span>
+
                     <div class="target">
                         {{app-match-document-target
                             value=consume.matchDocument
@@ -28,12 +28,12 @@
 
                 <div class="controls">
                     {{#if (not disabled)}}
-                        <a data-action="edit-consumption" 
+                        <a data-action="edit-consumption"
                             data-tooltip="COSMERE.Item.Sheet.Activation.ResourceConsumption.Edit"
                         >
                             <i class="fa-solid fa-pen-to-square"></i>
                         </a>
-                        <a data-action="delete-consumption" 
+                        <a data-action="delete-consumption"
                             data-tooltip="COSMERE.Item.Sheet.Activation.ResourceConsumption.Delete"
                         >
                             <i class="fa-solid fa-trash"></i>
@@ -48,7 +48,7 @@
     </ul>
 </div>
 <div class="controls">
-    <a data-action="add-consumption" 
+    <a data-action="add-consumption"
         data-tooltip="COSMERE.Item.Sheet.Activation.ResourceConsumption.Add"
     >
         <i class="fa-solid fa-plus"></i>

--- a/src/templates/item/components/resource-consumption-list.hbs
+++ b/src/templates/item/components/resource-consumption-list.hbs
@@ -16,7 +16,7 @@
                         {{/if}}
                     </span>
 
-                    <span>{{localize "COSMERE.Generic.From"}}</span>
+                    <span>{{localize "GENERIC.From"}}</span>
 
                     <div class="target">
                         {{app-match-document-target


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds the ability to display item resource costs on the character sheet "Actions" tab, with a shortened version of the target link. The link also is able to display an error icon when the item with resources can't be found on the sheet.

**Related Issue**  
Closes #778 

**How Has This Been Tested?**  
1. Created a new action on an actor sheet. 
2. Set up a new equippable item named "Test" in a new compendium, with a "charges" resource
3. Configured the action on the actor sheet to consume 1 charge from "test".
4. Verified that the actions display now includes "1 charge from [ERROR SYMBOL] [test icon]", with a link directing to the "Test" item reference in the compendium
5. Added "Test" to the character
6. Verified that the actions display did not change
7. Equipped "Test" on the actor
8. Verified that the actions display error symbol disappeared, and the link directed to the copy of "test" on the actor sheet.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.
