### PR TITLE
feat(character sheet): add item resources on equipment lists

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -192,7 +192,9 @@
                     "Quantity": "Quantity",
                     "Weight": "Weight",
                     "IncreaseQuantity": "Increase quantity",
-                    "DecreaseQuantity": "Decrease quantity"
+                    "DecreaseQuantity": "Decrease quantity",
+                    "Equip": "Equip",
+                    "Resources": "Resources"
                 },
                 "Inventory": {
                     "label": "Inventory",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -194,7 +194,9 @@
                     "IncreaseQuantity": "Increase quantity",
                     "DecreaseQuantity": "Decrease quantity",
                     "Equip": "Equip",
-                    "Resources": "Resources"
+                    "Resources": "Resources",
+                    "DecreaseResource": "Remove {resource}",
+                    "IncreaseResource": "Add {resource}"
                 },
                 "Inventory": {
                     "label": "Inventory",

--- a/src/style/module.scss
+++ b/src/style/module.scss
@@ -509,6 +509,7 @@
             }
 
             .quantity,
+            .resource,
             .duration {
                 display: flex;
                 justify-content: space-evenly;

--- a/src/system/api/item.ts
+++ b/src/system/api/item.ts
@@ -55,6 +55,7 @@ export function registerItemResource(data: ItemResourceConfigData) {
         id: data.id as ItemResource,
         label: data.label,
         labelPlural: data.labelPlural,
+        icon: data.icon,
         source: data.source,
         priority: data.priority,
         strict: data.strict,
@@ -67,6 +68,7 @@ export function registerItemResource(data: ItemResourceConfigData) {
             key: cleaned.id,
             label: cleaned.label,
             labelPlural: cleaned.labelPlural,
+            icon: cleaned.icon,
         };
 
         return true;

--- a/src/system/applications/actor/components/equipment-list.ts
+++ b/src/system/applications/actor/components/equipment-list.ts
@@ -45,6 +45,8 @@ export class ActorEquipmentListComponent extends ActorItemListComponent {
         'cycle-equip': this.onCycleEquip,
         'decrease-quantity': this.onDecreaseQuantity,
         'increase-quantity': this.onIncreaseQuantity,
+        'decrease-resource': this.onDecreaseResource,
+        'increase-resource': this.onIncreaseResource,
     };
     /* eslint-enable @typescript-eslint/unbound-method */
 
@@ -119,6 +121,20 @@ export class ActorEquipmentListComponent extends ActorItemListComponent {
         await this.triggerQuantityChange(event, true);
     }
 
+    public static async onDecreaseResource(
+        this: ActorEquipmentListComponent,
+        event: Event,
+    ) {
+        await this.triggerResourceChange(event, false);
+    }
+
+    public static async onIncreaseResource(
+        this: ActorEquipmentListComponent,
+        event: Event,
+    ) {
+        await this.triggerResourceChange(event, true);
+    }
+
     /* --- Event handlers --- */
     private triggerCurrencyChange() {
         const event = new CustomEvent('currency', {});
@@ -157,6 +173,51 @@ export class ActorEquipmentListComponent extends ActorItemListComponent {
         await this.render();
 
         this.triggerCurrencyChange();
+    }
+
+    private async triggerResourceChange(
+        this: ActorEquipmentListComponent,
+        event: Event,
+        increase = true,
+    ) {
+        // Get item
+        const item = AppUtils.getItemFromEvent(event, this.application.actor);
+        if (!item) return;
+        if (!item.hasResources()) return;
+        const primaryResource = item.system.primaryResource;
+        if (primaryResource === 'none') return;
+
+        let modifier = increase ? 1 : -1;
+
+        if (areKeysPressed(KEYBINDINGS.CHANGE_QUANTITY_BY_5)) {
+            modifier *= 5;
+        } else if (areKeysPressed(KEYBINDINGS.CHANGE_QUANTITY_BY_10)) {
+            modifier *= 10;
+        } else if (areKeysPressed(KEYBINDINGS.CHANGE_QUANTITY_BY_50)) {
+            modifier *= 50;
+        }
+
+        const resource = item.getResource(primaryResource);
+        if (!resource) return;
+
+        const newResourceValue =
+            resource.value + modifier < resource.max
+                ? resource.value + modifier
+                : resource.max;
+
+        await item.update(
+            {
+                system: {
+                    resources: {
+                        [primaryResource]: {
+                            value: newResourceValue,
+                        },
+                    },
+                },
+            },
+            { render: false },
+        );
+        await this.render();
     }
 
     /* --- Context --- */

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -715,11 +715,13 @@ const COSMERE: CosmereRPGConfig = {
                     key: ItemResource.Uses,
                     label: 'COSMERE.Item.Resource.Types.Uses.Singular',
                     labelPlural: 'COSMERE.Item.Resource.Types.Uses.Plural',
+                    icon: 'fa-regular fa-circle-check',
                 },
                 [ItemResource.Charges]: {
                     key: ItemResource.Charges,
                     label: 'COSMERE.Item.Resource.Types.Charges.Singular',
                     labelPlural: 'COSMERE.Item.Resource.Types.Charges.Plural',
+                    icon: 'fa-solid fa-bolt',
                 },
             },
 

--- a/src/system/types/config.ts
+++ b/src/system/types/config.ts
@@ -199,6 +199,7 @@ export interface ItemResourceConfig {
     key: ItemResource;
     label: string;
     labelPlural: string;
+    icon: string;
 }
 
 export interface ItemConsumeTypeConfig {

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -294,10 +294,30 @@ Handlebars.registerHelper(
                 context.resource.value =
                     item.system.resources[resourceType]?.value;
                 context.resource.max = item.system.resources[resourceType]?.max;
+                context.resource.icon =
+                    CONFIG.COSMERE.item.resource.types[resourceType].icon;
                 context.resource.label =
                     CONFIG.COSMERE.item.resource.types[
                         resourceType
                     ].labelPlural;
+                context.resource.addTooltip = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Equipment.IncreaseResource',
+                    {
+                        resource: game.i18n.localize(
+                            CONFIG.COSMERE.item.resource.types[resourceType]
+                                .label,
+                        ),
+                    },
+                );
+                context.resource.removeTooltip = game.i18n.format(
+                    'COSMERE.Actor.Sheet.Equipment.DecreaseResource',
+                    {
+                        resource: game.i18n.localize(
+                            CONFIG.COSMERE.item.resource.types[resourceType]
+                                .label,
+                        ),
+                    },
+                );
             }
 
             if (item.hasTraits()) {

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -12,6 +12,7 @@ import {
     AttackType,
     TurnSpeed,
     ItemResourceRechargeType,
+    ItemResource,
 } from '@system/types/cosmere';
 
 import { CosmereActor } from '@system/documents/actor';
@@ -283,6 +284,20 @@ Handlebars.registerHelper(
                         });
                     }
                 }
+            }
+
+            if (item.hasResources() && item.system.primaryResource !== 'none') {
+                context.hasResource = true;
+                const resourceType: ItemResource = item.system.primaryResource;
+
+                context.resource = {};
+                context.resource.value =
+                    item.system.resources[resourceType]?.value;
+                context.resource.max = item.system.resources[resourceType]?.max;
+                context.resource.label =
+                    CONFIG.COSMERE.item.resource.types[
+                        resourceType
+                    ].labelPlural;
             }
 
             if (item.hasTraits()) {

--- a/src/system/utils/handlebars/types.ts
+++ b/src/system/utils/handlebars/types.ts
@@ -24,6 +24,9 @@ export interface ItemContext {
         value: number;
         max: number;
         label: string;
+        addTooltip: string;
+        removeTooltip: string;
+        icon: string;
     }>;
     price: Partial<{
         value: number;

--- a/src/system/utils/handlebars/types.ts
+++ b/src/system/utils/handlebars/types.ts
@@ -13,11 +13,17 @@ export interface ItemContext {
     isPhysical: boolean;
     hasQuantity: boolean;
     hasWeight: boolean;
+    hasResource: boolean;
     quantity: number;
     weight: Partial<{
         value: number;
         unit: string;
         total: number;
+    }>;
+    resource: Partial<{
+        value: number;
+        max: number;
+        label: string;
     }>;
     price: Partial<{
         value: number;

--- a/src/templates/actors/components/equipment-list.hbs
+++ b/src/templates/actors/components/equipment-list.hbs
@@ -16,7 +16,12 @@
             <span class="subtitle">
                 {{localize "COSMERE.Actor.Sheet.Equipment.Weight"}}
             </span>
-            <div class="subtitle"></div>
+            <span class="subtitle slim">
+                {{localize "COSMERE.Actor.Sheet.Equipment.Equip"}}
+            </span>
+            <span class="subtitle">
+                {{localize "COSMERE.Actor.Sheet.Equipment.Resources"}}
+            </span>
             <div class="controls icon active">
                 {{#if @root.editable}}
                     {{#if section.canAddNewItems}}
@@ -98,7 +103,7 @@
             </div>
 
             {{!-- Equipped --}}
-            <div class="detail equip">
+            <div class="detail slim equip">
             {{#if ctx.isEquippable}}
                 {{#if (eq ctx.equip.type 'hold')}}
                 {{!-- Items equipped by holding them --}}
@@ -143,6 +148,19 @@
                     </a>
                 {{/if}}
             {{/if}}
+            </div>
+
+
+            {{!-- Resources --}}
+            <div class="detail resource">
+                {{#if ctx.hasResource}}
+                    <span class="val">{{ctx.resource.value}}</span>
+                    <span>/</span>
+                    <span class="val">{{ctx.resource.max}}</span>
+                    <span>{{localize ctx.resource.label}}</span>
+                {{else}}
+                    <span class="val none">—</span>
+                {{/if}}
             </div>
 
             {{!-- Controls --}}

--- a/src/templates/actors/components/equipment-list.hbs
+++ b/src/templates/actors/components/equipment-list.hbs
@@ -160,7 +160,6 @@
                     >
                         <i class="fa-solid fa-minus"></i>
                     </a>
-                    {{log ctx.resource.removeTooltip}}
                     {{/if}}
                     <div>
                         <span class="val">{{ctx.resource.value}}</span>

--- a/src/templates/actors/components/equipment-list.hbs
+++ b/src/templates/actors/components/equipment-list.hbs
@@ -19,7 +19,7 @@
             <span class="subtitle slim">
                 {{localize "COSMERE.Actor.Sheet.Equipment.Equip"}}
             </span>
-            <span class="subtitle">
+            <span class="subtitle wide">
                 {{localize "COSMERE.Actor.Sheet.Equipment.Resources"}}
             </span>
             <div class="controls icon active">
@@ -150,14 +150,33 @@
             {{/if}}
             </div>
 
-
             {{!-- Resources --}}
-            <div class="detail resource">
+            <div class="detail wide resource">
                 {{#if ctx.hasResource}}
-                    <span class="val">{{ctx.resource.value}}</span>
-                    <span>/</span>
-                    <span class="val">{{ctx.resource.max}}</span>
-                    <span>{{localize ctx.resource.label}}</span>
+                    {{#if @root.editable}}
+                    <a role="button"
+                        data-action="decrease-resource"
+                        data-tooltip="{{ctx.resource.removeTooltip}}"
+                    >
+                        <i class="fa-solid fa-minus"></i>
+                    </a>
+                    {{log ctx.resource.removeTooltip}}
+                    {{/if}}
+                    <div>
+                        <span class="val">{{ctx.resource.value}}</span>
+                        <span>/</span>
+                        <span class="val">{{ctx.resource.max}}</span>
+                        <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
+                    </div>
+
+                    {{#if @root.editable}}
+                    <a role="button"
+                        data-action="increase-resource"
+                        data-tooltip="{{ctx.resource.addTooltip}}"
+                    >
+                        <i class="fa-solid fa-plus"></i>
+                    </a>
+                    {{/if}}
                 {{else}}
                     <span class="val none">—</span>
                 {{/if}}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds a display for default resource and increase/decrease convenience buttons on the "equipment" tab of character sheets

**Related Issue**  
Closes #779 

**How Has This Been Tested?**  
Added several items with combinations of "uses", "charges", and both to a character sheet. Update values to have a different maximum. Click increase and decrease buttons and validate that charges both on the equipment tab and on the item itself change correctly, and that only the resource configured as the "Primary resource" changes. 

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.
