### PR TITLE
fix(character sheet): make talents that belong to a power be assiocated with the correct section

### DIFF
--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -106,44 +106,110 @@ export const DYNAMIC_SECTIONS: Record<string, DynamicItemListSectionGenerator> =
             // Get powers
             const powers = actor.powers;
 
+            const powersWithoutChildren = powers.filter(
+                (p) => !p.hasRelationshipOfType(ItemRelationship.Type.Child),
+            );
+            const powersWithChildren = powers.filter((p) =>
+                p.hasRelationshipOfType(ItemRelationship.Type.Child),
+            );
+
             // Get list of unique power types
-            const powerTypes = [...new Set(powers.map((p) => p.system.type))];
+            const powerTypes = [
+                ...new Set(powersWithoutChildren.map((p) => p.system.type)),
+            ];
 
-            return powerTypes.map((type) => {
-                // Get config
-                const config = CONFIG.COSMERE.power.types[type];
+            return [
+                ...powerTypes.map((type) => {
+                    // Get config
+                    const config = CONFIG.COSMERE.power.types[type];
 
-                return {
-                    id: type,
-                    sortOrder: 100,
-                    label: game.i18n.localize(config.plural),
-                    itemTypeLabel: game.i18n.localize(config.label),
-                    default: false,
+                    return {
+                        id: type,
+                        sortOrder: 100,
+                        label: game.i18n.localize(config.plural),
+                        itemTypeLabel: game.i18n.localize(config.label),
+                        default: false,
+                        filter: (item: CosmereItem) =>
+                            item.isPower() &&
+                            item.system.type === type &&
+                            !item.hasRelationshipOfType(
+                                ItemRelationship.Type.Child,
+                            ),
+                        new: (parent: CosmereActor) =>
+                            CosmereItem.create(
+                                {
+                                    type: ItemType.Power,
+                                    name: game.i18n.format(
+                                        'COSMERE.Item.Type.Power.New',
+                                        {
+                                            type: game.i18n.localize(
+                                                config.label,
+                                            ),
+                                        },
+                                    ),
+                                    system: {
+                                        type,
+                                        activation: {
+                                            type: ActivationType.Utility,
+                                            cost: {
+                                                type: ActionCostType.Action,
+                                                value: 1,
+                                            },
+                                            consume: {
+                                                type: ItemConsumeType.Resource,
+                                                resource: Resource.Investiture,
+                                                value: {
+                                                    actual: 1,
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                                { parent },
+                            ) as Promise<CosmereItem>,
+                    } as ItemListSection;
+                }),
+                ...powersWithChildren.map((power) => ({
+                    id: power.system.id,
+                    sortOrder: 150,
+                    label: game.i18n.format(
+                        'COSMERE.Actor.Sheet.Actions.BaseSectionName',
+                        {
+                            type: power.name,
+                        },
+                    ),
+                    itemTypeLabel: `${power.name} ${game.i18n?.localize('COSMERE.Item.Type.Action.label')}`,
+                    default: true,
                     filter: (item: CosmereItem) =>
-                        item.isPower() && item.system.type === type,
+                        (item.isPower() &&
+                            item.system.id === power.system.id) ||
+                        (item.hasRelationships() &&
+                            item.isRelatedTo(
+                                power,
+                                ItemRelationship.Type.Parent,
+                            )),
                     new: (parent: CosmereActor) =>
                         CosmereItem.create(
                             {
-                                type: ItemType.Power,
-                                name: game.i18n.format(
-                                    'COSMERE.Item.Type.Power.New',
-                                    {
-                                        type: game.i18n.localize(config.label),
-                                    },
+                                type: ItemType.Action,
+                                name: game.i18n.localize(
+                                    'COSMERE.Item.Type.Action.New',
                                 ),
                                 system: {
-                                    type,
                                     activation: {
                                         type: ActivationType.Utility,
                                         cost: {
                                             type: ActionCostType.Action,
                                             value: 1,
                                         },
-                                        consume: {
-                                            type: ItemConsumeType.Resource,
-                                            resource: Resource.Investiture,
-                                            value: {
-                                                actual: 1,
+                                    },
+                                },
+                                flags: {
+                                    [SYSTEM_ID]: {
+                                        meta: {
+                                            origin: {
+                                                type: ItemType.Power,
+                                                id: power.system.id,
                                             },
                                         },
                                     },
@@ -151,8 +217,8 @@ export const DYNAMIC_SECTIONS: Record<string, DynamicItemListSectionGenerator> =
                             },
                             { parent },
                         ) as Promise<CosmereItem>,
-                } as ItemListSection;
-            });
+                })),
+            ];
         },
         paths: (actor: CosmereActor) => {
             // Get paths

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -135,38 +135,6 @@ export const DYNAMIC_SECTIONS: Record<string, DynamicItemListSectionGenerator> =
                             !item.hasRelationshipOfType(
                                 ItemRelationship.Type.Child,
                             ),
-                        new: (parent: CosmereActor) =>
-                            CosmereItem.create(
-                                {
-                                    type: ItemType.Power,
-                                    name: game.i18n.format(
-                                        'COSMERE.Item.Type.Power.New',
-                                        {
-                                            type: game.i18n.localize(
-                                                config.label,
-                                            ),
-                                        },
-                                    ),
-                                    system: {
-                                        type,
-                                        activation: {
-                                            type: ActivationType.Utility,
-                                            cost: {
-                                                type: ActionCostType.Action,
-                                                value: 1,
-                                            },
-                                            consume: {
-                                                type: ItemConsumeType.Resource,
-                                                resource: Resource.Investiture,
-                                                value: {
-                                                    actual: 1,
-                                                },
-                                            },
-                                        },
-                                    },
-                                },
-                                { parent },
-                            ) as Promise<CosmereItem>,
                     } as ItemListSection;
                 }),
                 ...powersWithChildren.map((power) => ({

--- a/src/system/applications/actor/components/character/talents-list.ts
+++ b/src/system/applications/actor/components/character/talents-list.ts
@@ -48,44 +48,96 @@ export const DYNAMIC_SECTIONS: Record<string, DynamicItemListSectionGenerator> =
             // Get powers
             const powers = actor.powers;
 
+            const powersWithoutChildren = powers.filter(
+                (p) => !p.hasRelationshipOfType(ItemRelationship.Type.Child),
+            );
+            const powersWithChildren = powers.filter((p) =>
+                p.hasRelationshipOfType(ItemRelationship.Type.Child),
+            );
+
             // Get list of unique power types
-            const powerTypes = [...new Set(powers.map((p) => p.system.type))];
+            const powerTypes = [
+                ...new Set(powersWithoutChildren.map((p) => p.system.type)),
+            ];
 
-            return powerTypes.map((type) => {
-                // Get config
-                const config = CONFIG.COSMERE.power.types[type];
+            return [
+                ...powerTypes.map((type) => {
+                    // Get config
+                    const config = CONFIG.COSMERE.power.types[type];
 
-                return {
-                    id: type,
-                    sortOrder: 100,
-                    label: game.i18n.localize(config.plural),
-                    itemTypeLabel: game.i18n.localize(config.label),
-                    default: false,
+                    return {
+                        id: type,
+                        sortOrder: 100,
+                        label: game.i18n.localize(config.plural),
+                        itemTypeLabel: game.i18n.localize(config.label),
+                        default: false,
+                        filter: (item: CosmereItem) =>
+                            item.isPower() &&
+                            item.system.type === type &&
+                            !item.hasRelationshipOfType(
+                                ItemRelationship.Type.Child,
+                            ),
+                        new: (parent: CosmereActor) =>
+                            CosmereItem.create(
+                                {
+                                    type: ItemType.Power,
+                                    name: game.i18n.format(
+                                        'COSMERE.Item.Type.Power.New',
+                                        {
+                                            type: game.i18n.localize(
+                                                config.label,
+                                            ),
+                                        },
+                                    ),
+                                    system: {
+                                        type,
+                                        activation: {
+                                            type: ActivationType.Utility,
+                                            cost: {
+                                                type: ActionCostType.Action,
+                                                value: 1,
+                                            },
+                                            consume: {
+                                                type: ItemConsumeType.Resource,
+                                                resource: Resource.Investiture,
+                                                value: {
+                                                    actual: 1,
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                                { parent },
+                            ) as Promise<CosmereItem>,
+                    } as ItemListSection;
+                }),
+                ...powersWithChildren.map((power) => ({
+                    id: power.system.id,
+                    sortOrder: 150,
+                    label: power.name,
+                    itemTypeLabel: `${power.name} ${game.i18n?.localize('COSMERE.Item.Type.Talent.label')}`,
+                    default: true,
                     filter: (item: CosmereItem) =>
-                        item.isPower() && item.system.type === type,
+                        (item.isPower() &&
+                            item.system.id === power.system.id) ||
+                        (item.hasRelationships() &&
+                            item.isRelatedTo(
+                                power,
+                                ItemRelationship.Type.Parent,
+                            )),
                     new: (parent: CosmereActor) =>
                         CosmereItem.create(
                             {
-                                type: ItemType.Power,
-                                name: game.i18n.format(
-                                    'COSMERE.Item.Type.Power.New',
-                                    {
-                                        type: game.i18n.localize(config.label),
-                                    },
+                                type: ItemType.Talent,
+                                name: game.i18n.localize(
+                                    'COSMERE.Item.Type.Talent.New',
                                 ),
-                                system: {
-                                    type,
-                                    activation: {
-                                        type: ActivationType.Utility,
-                                        cost: {
-                                            type: ActionCostType.Action,
-                                            value: 1,
-                                        },
-                                        consume: {
-                                            type: ItemConsumeType.Resource,
-                                            resource: Resource.Investiture,
-                                            value: {
-                                                actual: 1,
+                                flags: {
+                                    [SYSTEM_ID]: {
+                                        meta: {
+                                            origin: {
+                                                type: ItemType.Power,
+                                                id: power.system.id,
                                             },
                                         },
                                     },
@@ -93,8 +145,8 @@ export const DYNAMIC_SECTIONS: Record<string, DynamicItemListSectionGenerator> =
                             },
                             { parent },
                         ) as Promise<CosmereItem>,
-                } as ItemListSection;
-            });
+                })),
+            ];
         },
         paths: (actor: CosmereActor) => {
             // Get paths

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -2248,7 +2248,7 @@ declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
                 'sheet.mode': 'edit' | 'view';
                 meta: {
                     origin: ItemOrigin;
-                    isEphemeral: boolean;
+                    isEphemeral?: boolean;
                 };
                 'meta.origin': ItemOrigin;
                 'meta.isEphemeral': boolean;

--- a/src/system/hooks/item.ts
+++ b/src/system/hooks/item.ts
@@ -136,7 +136,7 @@ Hooks.on('preCreateItem', (item: CosmereItem) => {
         (otherItem) =>
             otherItem.hasRelationships() &&
             otherItem.hasId() &&
-            otherItem.id === origin.id &&
+            (otherItem.system.id === origin.id || otherItem.id === origin.id) &&
             otherItem.type === origin.type,
     );
     if (!parentItem) return;


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Makes talents that get added through a power be associated with the appropriate section. Powers that have children (i.e. talents) now have their own section where they and their talents are shown. Talents that do not have children are rendered as normal.

**Related Issue**  
Closes #861 

**How Has This Been Tested?**  
1. Create power item
2. Create talent tree item
3. Create talent item
4. Add talent item to tree
5. Capture viewbounds on talent tree
6. Set talent tree on power
7. Create character
8. Add power to character
9. View power on character
10. Go to talents tab
11. Click talent to add it to character
12. Check talents tab on character
13. Click `+` button on the power section

**Screenshots (if applicable)**  
<img width="820" height="375" alt="image" src="https://github.com/user-attachments/assets/97b6926c-e9ff-470f-bff4-e12e9eb12cd9" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351