### PR TITLE
feat(character sheets): add item resources to actions list

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -175,6 +175,7 @@
                         "Optional": "{label} (Optional)"
                     },
                     "Uses": "Uses",
+                    "Resources": "Resources",
                     "Use": "Use Action",
                     "Strike": "Strike",
                     "BaseSectionName": "{type} Actions",
@@ -1335,6 +1336,7 @@
                     "Edit": "Edit",
                     "Delete": "Remove",
                     "View": "View",
+                    "Resources": "Resources",
                     "NewAction": {
                         "Name": "New Action"
                     }

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -550,7 +550,7 @@ export class ActorActionsListComponent extends ActorItemListComponent {
                         );
                     }
 
-                    if (!item.isStrikeAction) {
+                    if (!item.isEphemeral) {
                         menuItems.push(
                             {
                                 name: 'GENERIC.Button.Edit',

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -567,6 +567,14 @@ export class ActorActionsListComponent extends ActorItemListComponent {
                                 },
                             },
                         );
+                    } else {
+                        menuItems.push({
+                            name: 'COSMERE.Item.Sheet.ActionsList.View',
+                            icon: 'fa-solid fa-eye',
+                            callback: () => {
+                                void item.sheet?.render(true);
+                            },
+                        });
                     }
 
                     return menuItems.filter((i) => !!i);

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -534,7 +534,7 @@ export class ActorActionsListComponent extends ActorItemListComponent {
 
                     const menuItems = [];
 
-                    if (item.hasResources()) {
+                    if (item.hasResources() && item.hasRecharge) {
                         menuItems.push(
                             /**
                              * NOTE: This is a TEMPORARY context menu option

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -31,6 +31,8 @@ import { SortMode } from './search-bar';
 // Constants
 import { SYSTEM_ID } from '@src/system/constants';
 import { TEMPLATES } from '@src/system/utils/templates';
+import { areKeysPressed } from '@src/system/utils/generic';
+import { KEYBINDINGS } from '@src/system/settings';
 
 interface ActionListSectionData extends ItemListSection {
     items: (CosmereItem | [CosmereItem, ActionItem[]])[]; // Either an action item, or a parent item with its actions
@@ -252,6 +254,77 @@ const MISC_SECTION: ItemListSection = {
 
 export class ActorActionsListComponent extends ActorItemListComponent {
     static TEMPLATE = `${TEMPLATES.DIRECTORY}${TEMPLATES.ACTOR_BASE_ACTIONS_LIST}`;
+
+    /**
+     * NOTE: Unbound methods is the standard for defining actions
+     * within ApplicationV2
+     */
+    /* eslint-disable @typescript-eslint/unbound-method */
+    static readonly ACTIONS = {
+        ...super.ACTIONS,
+        'decrease-resource': this.onDecreaseResource,
+        'increase-resource': this.onIncreaseResource,
+    };
+    /* eslint-enable @typescript-eslint/unbound-method */
+
+    public static async onDecreaseResource(
+        this: ActorActionsListComponent,
+        event: Event,
+    ) {
+        await this.triggerResourceChange(event, false);
+    }
+
+    public static async onIncreaseResource(
+        this: ActorActionsListComponent,
+        event: Event,
+    ) {
+        await this.triggerResourceChange(event, true);
+    }
+
+    private async triggerResourceChange(
+        this: ActorActionsListComponent,
+        event: Event,
+        increase = true,
+    ) {
+        // Get item
+        const item = AppUtils.getItemFromEvent(event, this.application.actor);
+        if (!item) return;
+        if (!item.hasResources()) return;
+        const primaryResource = item.system.primaryResource;
+        if (primaryResource === 'none') return;
+
+        let modifier = increase ? 1 : -1;
+
+        if (areKeysPressed(KEYBINDINGS.CHANGE_QUANTITY_BY_5)) {
+            modifier *= 5;
+        } else if (areKeysPressed(KEYBINDINGS.CHANGE_QUANTITY_BY_10)) {
+            modifier *= 10;
+        } else if (areKeysPressed(KEYBINDINGS.CHANGE_QUANTITY_BY_50)) {
+            modifier *= 50;
+        }
+
+        const resource = item.getResource(primaryResource);
+        if (!resource) return;
+
+        const newResourceValue =
+            resource.value + modifier < resource.max
+                ? resource.value + modifier
+                : resource.max;
+
+        await item.update(
+            {
+                system: {
+                    resources: {
+                        [primaryResource]: {
+                            value: newResourceValue,
+                        },
+                    },
+                },
+            },
+            { render: false },
+        );
+        await this.render();
+    }
 
     /* --- Context --- */
 

--- a/src/system/applications/actor/components/adversary/actions-list.ts
+++ b/src/system/applications/actor/components/adversary/actions-list.ts
@@ -172,7 +172,7 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
 
                     const menuItems = [];
 
-                    if (item.hasResources()) {
+                    if (item.hasResources() && item.hasRecharge) {
                         menuItems.push(
                             /**
                              * NOTE: This is a TEMPORARY context menu option

--- a/src/system/applications/actor/components/adversary/actions-list.ts
+++ b/src/system/applications/actor/components/adversary/actions-list.ts
@@ -205,6 +205,14 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
                                 },
                             },
                         );
+                    } else {
+                        menuItems.push({
+                            name: 'COSMERE.Item.Sheet.ActionsList.View',
+                            icon: 'fa-solid fa-eye',
+                            callback: () => {
+                                void item.sheet?.render(true);
+                            },
+                        });
                     }
 
                     return menuItems.filter((i) => !!i);

--- a/src/system/applications/actor/components/adversary/actions-list.ts
+++ b/src/system/applications/actor/components/adversary/actions-list.ts
@@ -188,7 +188,7 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
                         );
                     }
 
-                    if (!item.isStrikeAction) {
+                    if (!item.isEphemeral) {
                         menuItems.push(
                             {
                                 name: 'GENERIC.Button.Edit',

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -487,6 +487,21 @@ export class CosmereItem<
     }
 
     /**
+     * Returns true if any resource on the item has a recharge configured
+     */
+    public get hasRecharge(): boolean {
+        if (!this.hasResources()) return false;
+        let hasRecharge = false;
+        for (const resource of Object.values(this.system.resources)) {
+            if (!!resource?.recharge && resource.recharge !== 'none') {
+                hasRecharge = true;
+                break;
+            }
+        }
+        return hasRecharge;
+    }
+
+    /**
      * Returns true if effects list is not empty, or if there are nested effects
      */
     public get hasEffects(): boolean {

--- a/src/system/utils/handlebars/index.ts
+++ b/src/system/utils/handlebars/index.ts
@@ -289,6 +289,9 @@ Handlebars.registerHelper(
             if (item.hasResources() && item.system.primaryResource !== 'none') {
                 context.hasResource = true;
                 const resourceType: ItemResource = item.system.primaryResource;
+                //     const recharge = item.system.activation.uses.recharge;
+
+                //     const hasRecharge = recharge != null;
 
                 context.resource = {};
                 context.resource.value =
@@ -300,6 +303,15 @@ Handlebars.registerHelper(
                     CONFIG.COSMERE.item.resource.types[
                         resourceType
                     ].labelPlural;
+                const recharge =
+                    item.system.resources[resourceType].recharge ?? undefined;
+                if (recharge && recharge !== 'none') {
+                    context.resource.hasRecharge = true;
+                    context.resource.rechargeLabel =
+                        CONFIG.COSMERE.item.resource.recharge.types[
+                            recharge
+                        ].label;
+                }
                 context.resource.addTooltip = game.i18n.format(
                     'COSMERE.Actor.Sheet.Equipment.IncreaseResource',
                     {

--- a/src/system/utils/handlebars/types.ts
+++ b/src/system/utils/handlebars/types.ts
@@ -27,6 +27,8 @@ export interface ItemContext {
         addTooltip: string;
         removeTooltip: string;
         icon: string;
+        hasRecharge: boolean;
+        rechargeLabel: string;
     }>;
     price: Partial<{
         value: number;

--- a/src/templates/actors/components/actions-list-entry.hbs
+++ b/src/templates/actors/components/actions-list-entry.hbs
@@ -89,6 +89,9 @@
                     <span>/</span>
                     <span class="val">{{ctx.resource.max}}</span>
                     <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
+                    {{#if ctx.resource.hasRecharge}}
+                        <span>{{localize ctx.resource.rechargeLabel}}</span>
+                    {{/if}}
                 </div>
 
                 {{#if @root.editable}}

--- a/src/templates/actors/components/actions-list-entry.hbs
+++ b/src/templates/actors/components/actions-list-entry.hbs
@@ -73,27 +73,34 @@
             {{/if}}
         </div>
 
-        {{!-- Uses --}}
-        <div class="detail">
-            {{#if ctx.hasUses}}
-
-            {{#if (or (gt ctx.uses.max 1) (not ctx.uses.hasRecharge))}}
-            <span>
-                {{ ctx.uses.value }} / {{ctx.uses.max}}
-                {{#if ctx.uses.hasRecharge}}
-                {{localize ctx.uses.rechargeLabel }}
+        {{!-- Resources --}}
+        <div class="detail wide resource">
+            {{#if ctx.hasResource}}
+                {{#if @root.editable}}
+                <a role="button"
+                    data-action="decrease-resource"
+                    data-tooltip="{{ctx.resource.removeTooltip}}"
+                >
+                    <i class="fa-solid fa-minus"></i>
+                </a>
                 {{/if}}
-            </span>
-            {{else}}
-            <span {{#if (eq ctx.uses.value 0)}}class="inactive"{{/if}}>
-                {{#if ctx.uses.hasRecharge}}
-                {{localize ctx.uses.rechargeLabel }}
-                {{/if}}
-            </span>
-            {{/if}}
+                <div>
+                    <span class="val">{{ctx.resource.value}}</span>
+                    <span>/</span>
+                    <span class="val">{{ctx.resource.max}}</span>
+                    <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
+                </div>
 
+                {{#if @root.editable}}
+                <a role="button"
+                    data-action="increase-resource"
+                    data-tooltip="{{ctx.resource.addTooltip}}"
+                >
+                    <i class="fa-solid fa-plus"></i>
+                </a>
+                {{/if}}
             {{else}}
-            <span>—</span>
+                <span class="val none">—</span>
             {{/if}}
         </div>
 

--- a/src/templates/actors/components/actions-list.hbs
+++ b/src/templates/actors/components/actions-list.hbs
@@ -65,8 +65,41 @@
                             {{!-- Consume --}}
                             <div class="detail extrawide"></div>
 
-                            {{!-- Uses --}}
-                            <div class="detail"></div>
+                            {{!-- Resources --}}
+                            <div class="detail wide resource">
+                            {{#with (itemContext parent) as |ctx|}}
+                                {{#if ctx.hasResource}}
+                                    {{#if @root.editable}}
+                                    <a role="button"
+                                        data-action="decrease-resource"
+                                        data-tooltip="{{ctx.resource.removeTooltip}}"
+                                    >
+                                        <i class="fa-solid fa-minus"></i>
+                                    </a>
+                                    {{/if}}
+                                    <div>
+                                        <span class="val">{{ctx.resource.value}}</span>
+                                        <span>/</span>
+                                        <span class="val">{{ctx.resource.max}}</span>
+                                        <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
+                                        {{#if ctx.resource.hasRecharge}}
+                                            <span>{{localize ctx.resource.rechargeLabel}}</span>
+                                        {{/if}}
+                                    </div>
+
+                                    {{#if @root.editable}}
+                                    <a role="button"
+                                        data-action="increase-resource"
+                                        data-tooltip="{{ctx.resource.addTooltip}}"
+                                    >
+                                        <i class="fa-solid fa-plus"></i>
+                                    </a>
+                                    {{/if}}
+                                {{else}}
+                                    <span class="val none">—</span>
+                                {{/if}}
+                            </div>
+                            {{/with}}
 
                             {{!-- Controls --}}
                             <div class="controls icon faded">

--- a/src/templates/actors/components/actions-list.hbs
+++ b/src/templates/actors/components/actions-list.hbs
@@ -16,8 +16,8 @@
             <span class="subtitle extrawide">
                 {{localize "COSMERE.Actor.Sheet.Actions.Consume.label"}}
             </span>
-            <span class="subtitle">
-                {{localize "COSMERE.Actor.Sheet.Actions.Uses"}}
+            <span class="subtitle wide">
+                {{localize "COSMERE.Actor.Sheet.Actions.Resources"}}
             </span>
             <div class="controls icon active">
                 {{#if @root.editable}}

--- a/src/templates/actors/components/equipment-list.hbs
+++ b/src/templates/actors/components/equipment-list.hbs
@@ -166,6 +166,9 @@
                         <span>/</span>
                         <span class="val">{{ctx.resource.max}}</span>
                         <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
+                        {{#if ctx.resource.hasRecharge}}
+                            <span>{{localize ctx.resource.rechargeLabel}}</span>
+                        {{/if}}
                     </div>
 
                     {{#if @root.editable}}

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -100,6 +100,9 @@
                             <span>/</span>
                             <span class="val">{{ctx.resource.max}}</span>
                             <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
+                            {{#if ctx.resource.hasRecharge}}
+                                <span>{{localize ctx.resource.rechargeLabel}}</span>
+                            {{/if}}
                         </div>
                     {{else}}
                         <span class="val none">—</span>

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -5,7 +5,7 @@
             <span class="title">{{localize "COSMERE.Item.Sheet.ActionsList.Description"}}</span>
             <span class="subtitle wide">{{localize "COSMERE.Item.Sheet.ActionsList.Action"}}</span>
             <span class="subtitle extrawide">{{localize "COSMERE.Item.Sheet.ActionsList.Cost"}}</span>
-            <span class="subtitle wide">{{localize "COSMERE.Item.Sheet.ActionsList.Uses"}}</span>
+            <span class="subtitle wide">{{localize "COSMERE.Item.Sheet.ActionsList.Resources"}}</span>
             <div class="controls icon active">
                 {{#if editable}}
                 <a data-action="create-action"
@@ -90,27 +90,36 @@
                     {{/if}}
                 </div>
 
-                {{!-- Uses --}}
-                <div class="detail wide">
-                    {{#if ctx.hasUses}}
 
-                    {{#if (or (gt ctx.uses.max 1) (not ctx.uses.hasRecharge))}}
-                    <span>
-                        {{ ctx.uses.value }} / {{ctx.uses.max}}
-                        {{#if ctx.uses.hasRecharge}}
-                        {{localize ctx.uses.rechargeLabel }}
-                        {{/if}}
-                    </span>
-                    {{else}}
-                    <span {{#if (eq ctx.uses.value 0)}}class="inactive"{{/if}}>
-                        {{#if ctx.uses.hasRecharge}}
-                        {{localize ctx.uses.rechargeLabel }}
-                        {{/if}}
-                    </span>
-                    {{/if}}
 
+                {{!-- Resources --}}
+                <div class="detail wide resource">
+                    {{#if ctx.hasResource}}
+                        {{#if @root.editable}}
+                        <a role="button"
+                            data-action="decrease-resource"
+                            data-tooltip="{{ctx.resource.removeTooltip}}"
+                        >
+                            <i class="fa-solid fa-minus"></i>
+                        </a>
+                        {{/if}}
+                        <div>
+                            <span class="val">{{ctx.resource.value}}</span>
+                            <span>/</span>
+                            <span class="val">{{ctx.resource.max}}</span>
+                            <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
+                        </div>
+
+                        {{#if @root.editable}}
+                        <a role="button"
+                            data-action="increase-resource"
+                            data-tooltip="{{ctx.resource.addTooltip}}"
+                        >
+                            <i class="fa-solid fa-plus"></i>
+                        </a>
+                        {{/if}}
                     {{else}}
-                    <span>—</span>
+                        <span class="val none">—</span>
                     {{/if}}
                 </div>
 

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -95,29 +95,12 @@
                 {{!-- Resources --}}
                 <div class="detail wide resource">
                     {{#if ctx.hasResource}}
-                        {{#if @root.editable}}
-                        <a role="button"
-                            data-action="decrease-resource"
-                            data-tooltip="{{ctx.resource.removeTooltip}}"
-                        >
-                            <i class="fa-solid fa-minus"></i>
-                        </a>
-                        {{/if}}
                         <div>
                             <span class="val">{{ctx.resource.value}}</span>
                             <span>/</span>
                             <span class="val">{{ctx.resource.max}}</span>
                             <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
                         </div>
-
-                        {{#if @root.editable}}
-                        <a role="button"
-                            data-action="increase-resource"
-                            data-tooltip="{{ctx.resource.addTooltip}}"
-                        >
-                            <i class="fa-solid fa-plus"></i>
-                        </a>
-                        {{/if}}
                     {{else}}
                         <span class="val none">—</span>
                     {{/if}}

--- a/src/templates/item/components/actions-list.hbs
+++ b/src/templates/item/components/actions-list.hbs
@@ -4,7 +4,7 @@
             <div class="img"></div>
             <span class="title">{{localize "COSMERE.Item.Sheet.ActionsList.Description"}}</span>
             <span class="subtitle wide">{{localize "COSMERE.Item.Sheet.ActionsList.Action"}}</span>
-            <span class="subtitle wide">{{localize "COSMERE.Item.Sheet.ActionsList.Cost"}}</span>
+            <span class="subtitle extrawide">{{localize "COSMERE.Item.Sheet.ActionsList.Cost"}}</span>
             <span class="subtitle wide">{{localize "COSMERE.Item.Sheet.ActionsList.Uses"}}</span>
             <div class="controls icon active">
                 {{#if editable}}
@@ -56,7 +56,7 @@
                 </div>
 
                 {{!-- Cost --}}
-                <div class="detail wide nowrap">
+                <div class="detail extrawide nowrap">
                     {{#if ctx.hasConsume}}
                         {{#if (gt ctx.consume.length 1)}}
                             <span>{{localize "COSMERE.Actor.Sheet.Actions.Consume.Multiple"}}</span>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
1. Replaces the now-defunct "uses" section on action lists with a new "Resources" section, matching the equipment resources display.
2. Re-adds the recharge label to items which have a recharge on their primary resource (on both equipment and action item lists)
3. Increases the "cost" section sizing of item embedded action lists to match actor sheet item list display

**Related Issue**  


**How Has This Been Tested?**  
Created actions on an actor with every combination of "uses", "charges", and recharge type and verified that all display correctly. Verified that increase/decrease buttons on actor actions list update resources correctly.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.
