### PR TITLE
feat(weapons): add ammo item resource type

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1362,8 +1362,8 @@
                         "Plural": "Charges"
                     },
                     "Ammo": {
-                        "Singular": "Ammunition",
-                        "Plural": "Ammunition"
+                        "Singular": "Ammo",
+                        "Plural": "Ammo"
                     }
                 },
                 "Key": {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1360,6 +1360,10 @@
                     "Charges": {
                         "Singular": "Charge",
                         "Plural": "Charges"
+                    },
+                    "Ammo": {
+                        "Singular": "Ammunition",
+                        "Plural": "Ammunition"
                     }
                 },
                 "Key": {

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -723,6 +723,12 @@ const COSMERE: CosmereRPGConfig = {
                     labelPlural: 'COSMERE.Item.Resource.Types.Charges.Plural',
                     icon: 'fa-solid fa-bolt',
                 },
+                [ItemResource.Ammo]: {
+                    key: ItemResource.Ammo,
+                    label: 'COSMERE.Item.Resource.Types.Ammo.Singular',
+                    labelPlural: 'COSMERE.Item.Resource.Types.Ammo.Plural',
+                    icon: 'fa-solid fa-burst',
+                },
             },
 
             recharge: {

--- a/src/system/data/item/weapon.ts
+++ b/src/system/data/item/weapon.ts
@@ -154,21 +154,31 @@ export class WeaponItemDataModel extends DataModelMixin<
             this.equip.hand ??= EquipHand.Main;
         }
 
-        // Automate "uses" resource when loaded trait is set
+        // Automate "ammo" resource when loaded trait is set
         const loadedTrait = this.traits[WeaponTraitId.Loaded];
         if (
             loadedTrait?.active &&
             loadedTrait?.value &&
             loadedTrait.value > 0
         ) {
-            this.resources[ItemResource.Uses] = {
-                key: ItemResource.Uses,
+            this.resources[ItemResource.Ammo] = {
+                key: ItemResource.Ammo,
                 max: loadedTrait.value,
                 value:
-                    this.resources[ItemResource.Uses]?.value ??
+                    this.resources[ItemResource.Ammo]?.value ??
                     loadedTrait.value,
                 recharge: null,
             };
+            // If this item has no other resources, and no primary resource already set, set ammunition to be the primary resource
+            if (
+                !(
+                    this.resources.charges ||
+                    this.resources.uses ||
+                    this.primaryResource !== 'none'
+                )
+            ) {
+                this.primaryResource = ItemResource.Ammo;
+            }
         }
     }
 }

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1874,8 +1874,8 @@ export class CosmereItem<
         const loadedTrait = this.getTrait(WeaponTraitId.Loaded);
         const hasLoadedTrait = !!loadedTrait && loadedTrait.active;
 
-        const usesResource = this.getResource(ItemResource.Uses);
-        const hasUsesResource = !!usesResource && usesResource.max > 0;
+        const ammoResource = this.getResource(ItemResource.Ammo);
+        const hasAmmoResource = !!ammoResource && ammoResource.max > 0;
 
         const actions: Item.CreateData[] = [
             {
@@ -1891,11 +1891,11 @@ export class CosmereItem<
                         },
                         type: ActivationType.SkillTest,
                         consumption:
-                            hasLoadedTrait && hasUsesResource
+                            hasLoadedTrait && hasAmmoResource
                                 ? [
                                       {
                                           type: ItemConsumeType.ItemResource,
-                                          resource: ItemResource.Uses,
+                                          resource: ItemResource.Ammo,
                                           matchDocument: {
                                               steps: [
                                                   {
@@ -1929,7 +1929,7 @@ export class CosmereItem<
             },
         ];
 
-        if (hasLoadedTrait && hasUsesResource) {
+        if (hasLoadedTrait && hasAmmoResource) {
             const eventId = foundry.utils.randomID();
 
             actions.push({
@@ -1956,7 +1956,7 @@ export class CosmereItem<
                                 macro: {
                                     type: 'script',
                                     command: `event.item.parent.update({
-                                        "system.resources.uses.value": event.item.parent.system.resources.uses.max
+                                        "system.resources.ammo.value": event.item.parent.system.resources.ammo.max
                                     })`,
                                 },
                             },

--- a/src/system/types/cosmere.ts
+++ b/src/system/types/cosmere.ts
@@ -216,6 +216,7 @@ export const enum ItemConsumeType {
 export const enum ItemResource {
     Uses = 'uses',
     Charges = 'charges',
+    Ammo = 'ammo',
 }
 
 export const enum ItemResourceRechargeType {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Adds a new "Ammo" resource type, and configures "ammo" to be the default resource type so it appears visually on lists if it's autogenerated on a weapon with no other resources

**Related Issue**  
Closes #865

**How Has This Been Tested?**  
Added a weapon with "loaded" to a character sheet and verified everything displays correctly


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.