### PR TITLE
feat(character sheets): make equippable item actions only appear when equipped

### DIFF
--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -369,7 +369,7 @@ export class ActorActionsListComponent extends ActorItemListComponent {
         // Get all activatable items (actions and items with actions)
         const activatableItems = Array.from(
             this.application.actor.items,
-        ).filter((item) => item.isAction() || item.hasActions);
+        ).filter((item) => item.isAction() || item.hasUsableActions);
 
         const actions = activatableItems.flatMap((item) =>
             item.isAction() ? [item] : item.actions,

--- a/src/system/applications/actor/components/adversary/actions-list.ts
+++ b/src/system/applications/actor/components/adversary/actions-list.ts
@@ -23,7 +23,8 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
     ) {
         // Get all candidate items (actions, items with actions, and traits)
         const candidateItems = Array.from(this.application.actor.items).filter(
-            (item) => item.isAction() || item.hasActions || item.isTrait(),
+            (item) =>
+                item.isAction() || item.hasUsableActions || item.isTrait(),
         );
 
         // Get all actions

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -444,6 +444,21 @@ export class CosmereItem<
         return this.actions.length > 0;
     }
 
+    /**
+     * Whether or not this item has actions that are currently usable for the character.
+     * Currently checks equipped state for equippable items.
+     */
+    public get hasUsableActions(): boolean {
+        if (!this.hasActions) return false;
+        if (this.isEquippable()) {
+            if (this.system.equipped) {
+                return this.hasActions;
+            } else return false;
+        } else {
+            return this.hasActions;
+        }
+    }
+
     public get actions(): readonly ActionItem[] {
         return this.items.filter((item) => item.isAction());
     }

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -449,14 +449,9 @@ export class CosmereItem<
      * Currently checks equipped state for equippable items.
      */
     public get hasUsableActions(): boolean {
-        if (!this.hasActions) return false;
-        if (this.isEquippable()) {
-            if (this.system.equipped) {
-                return this.hasActions;
-            } else return false;
-        } else {
-            return this.hasActions;
-        }
+        return !this.isEquippable() || this.system.equipped 
+            ? this.hasActions
+            : false
     }
 
     public get actions(): readonly ActionItem[] {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Filtered out equippable items which have embedded actions but are not equipped from the actions list

**Related Issue**  
Closes #731 

**How Has This Been Tested?**  
Added a firearm to an actor, verified that actions do not appear, toggled equip state, verified actions do appear, toggled equip state, verified actions disappear.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.