### PR TITLE
fix(weapons): re-added skill modifier to strike damage calculations

### DIFF
--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1933,6 +1933,8 @@ export class CosmereItem<
                     damage: {
                         formula: this.strikeDieToFormula(),
                         type: this.strikeDamageType(),
+                        skill: null,
+                        attribute: null,
                     },
                     description: this.system.description,
                 },


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixed strike actions not adding the skill modifier to their damage calculations

**Related Issue**  
Closes #870

**How Has This Been Tested?**  
Used a strike action, verified that it adds the damage modifier correctly

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.
