### PR TITLE
feat(actor sheets): add descriptions to effects

### DIFF
--- a/src/system/applications/actor/components/effects-list.ts
+++ b/src/system/applications/actor/components/effects-list.ts
@@ -153,6 +153,21 @@ export class ActorEffectsListComponent extends ActorItemListComponent {
                             .toLocaleLowerCase()
                             .compare(b.name.toLocaleLowerCase()),
                     );
+
+                for (const effect of effects) {
+                    this.itemState[effect.id!] = { expanded: false };
+                    this.itemData[effect.id!] = {
+                        descriptionHTML:
+                            await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+                                effect.description,
+                                {
+                                    relativeTo:
+                                        item as foundry.abstract.Document.Any,
+                                },
+                            ),
+                        isEffectsContainer: false,
+                    };
+                }
                 return effects.length === 1 ? effects[0] : [item, effects];
             }),
         );

--- a/src/templates/actors/components/effects-list.hbs
+++ b/src/templates/actors/components/effects-list.hbs
@@ -22,8 +22,8 @@
             {{#if (isArray effect)}}
 
                 {{#with effect.[0] as |parent|}}
-                {{#with (lookup @root.itemState parent.id) as |state|}}
-                {{#with (lookup @root.itemData parent.id) as |data|}}
+                {{#with (lookup @root.itemState parent.id) as |parentState|}}
+                {{#with (lookup @root.itemData parent.id) as |parentData|}}
 
                 <li class="item effect parent collapsible {{#if state.expanded}}expanded{{/if}}"
                     data-item-id="{{parent.id}}"
@@ -42,13 +42,13 @@
                         <div class="controls icon faded">
                             <a role="button"
                                 data-action="toggle-action-details"
-                                {{#if state.expanded}}
+                                {{#if parentState.expanded}}
                                 data-tooltip="GENERIC.HideDetails"
                                 {{else}}
                                 data-tooltip="GENERIC.ViewDetails"
                                 {{/if}}
                             >
-                                {{#if state.expanded}}
+                                {{#if parentState.expanded}}
                                     <i class="fa-solid fa-compress"></i>
                                 {{else}}
                                     <i class="fa-solid fa-expand"></i>
@@ -67,21 +67,23 @@
 
                     <section class="description collapsible-content">
                         <div class="wrapper">
-                            {{{default data.descriptionHTML '<p>—</p>'}}}
+                            {{{default parentData.descriptionHTML '<p>—</p>'}}}
                         </div>
                     </section>
                 </li>
 
                 {{#with effect.[1] as |children|}}
                 {{#each children as |child|}}
-                    <li class="item effect {{#if child.active}}active{{/if}} indent" data-item-id="{{child.id}}"
+                    {{#with (lookup @root.itemState child.id) as |childState|}}
+                    {{#with (lookup @root.itemData child.id) as |childData|}}
+                    <li class="item effect collapsible {{#if child.active}}active{{/if}} indent" data-item-id="{{child.id}}"
                         {{#if (not (eq child.parent @root.actor))}} data-parent-id="{{child.parent.id}}" {{/if}}
                         data-uuid="{{child.uuid}}">
                         <section class="details">
                             <div class="img">
                                 <img src="{{child.img}}">
                             </div>
-                            <div class="name">
+                            <div class="name" data-action="toggle-action-details">
                                 <span>{{child.name}}</span>
                             </div>
                             <div class="detail wide source">
@@ -100,6 +102,20 @@
                                 {{/if}}
                             </div>
                             <div class="controls icon faded">
+                                <a role="button"
+                                    data-action="toggle-action-details"
+                                    {{#if childState.expanded}}
+                                    data-tooltip="GENERIC.HideDetails"
+                                    {{else}}
+                                    data-tooltip="GENERIC.ViewDetails"
+                                    {{/if}}
+                                >
+                                    {{#if childState.expanded}}
+                                        <i class="fa-solid fa-compress"></i>
+                                    {{else}}
+                                        <i class="fa-solid fa-expand"></i>
+                                    {{/if}}
+                                </a>
                                 {{#if @root.editable}}
                                     <a data-action="toggle-effect-controls"
                                         data-tooltip="APPLICATION.TOOLS.ToggleControls">
@@ -108,7 +124,14 @@
                                 {{/if}}
                             </div>
                         </section>
+                        <section class="description collapsible-content">
+                            <div class="wrapper">
+                                {{{default childData.descriptionHTML (default parentData.descriptionHTML '<p>—</p>')}}}
+                            </div>
+                        </section>
                     </li>
+                    {{/with}}
+                    {{/with}}
                 {{/each}}
                 {{/with}}
 
@@ -117,15 +140,19 @@
                 {{/with}}
 
             {{else}}
+                {{#with (lookup @root.itemState effect.id) as |state|}}
+                {{#with (lookup @root.itemData effect.id) as |data|}}
+                {{#with (lookup @root.itemData effect.parent.id) as |parentData|}}
 
-                <li class="item effect {{#if effect.active}}active{{/if}}" data-item-id="{{effect.id}}"
+
+                <li class="item effect collapsible {{#if effect.active}}active{{/if}}" data-item-id="{{effect.id}}"
                     {{#if (not (eq effect.parent @root.actor))}} data-parent-id="{{effect.parent.id}}" {{/if}}
                     data-uuid="{{effect.uuid}}">
                     <section class="details">
                         <div class="img">
                             <img src="{{effect.img}}">
                         </div>
-                        <div class="name">
+                        <div class="name" data-action="toggle-action-details">
                             <span>{{effect.name}}</span>
                         </div>
                         <div class="detail wide source">
@@ -145,6 +172,20 @@
                             {{/if}}
                         </div>
                         <div class="controls icon faded">
+                            <a role="button"
+                                data-action="toggle-action-details"
+                                {{#if state.expanded}}
+                                data-tooltip="GENERIC.HideDetails"
+                                {{else}}
+                                data-tooltip="GENERIC.ViewDetails"
+                                {{/if}}
+                            >
+                                {{#if state.expanded}}
+                                    <i class="fa-solid fa-compress"></i>
+                                {{else}}
+                                    <i class="fa-solid fa-expand"></i>
+                                {{/if}}
+                            </a>
                             {{#if @root.editable}}
                                 <a data-action="toggle-effect-controls" data-tooltip="APPLICATION.TOOLS.ToggleControls">
                                     <i class="fa-solid fa-ellipsis-vertical"></i>
@@ -152,8 +193,16 @@
                             {{/if}}
                         </div>
                     </section>
+                    <section class="description collapsible-content">
+                        <div class="wrapper">
+                            {{{default data.descriptionHTML (default parentData.descriptionHTML '<p>—</p>')}}}
+                        </div>
+                    </section>
                 </li>
 
+                {{/with}}
+                {{/with}}
+                {{/with}}
             {{/if}}
         {{/each}}
         </div>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Currently the effects have no description unless two effects share one parent item. This aims to give all effects a visible description without having to edit the effect to see it.

**Related Issue**  
Closes #872 

**How Has This Been Tested?**  
1. Create new talent
2. Add effect to talent, rename it to whatever you want
3. Create new character
4. Add talent to character
5. Go to effects tab and see that it has the contract/expand button and that it shares the description of the talent upon expanding
6. Edit talent on character sheet
7. Add new effect
8. Give effect description of your choice
9. Go back to effects tab and see that theres now two effects, one with the talent description and one with your custom description
10. Toggle them on and off and see that the description stays as it should
11. Create adversary 
12. Create new adversary feature
13. Follow same procedure as before but with an adversary feature instead of talent and adversary instead of character
14. see that everything works as it should.

**Screenshots (if applicable)**  
<img width="541" height="201" alt="image" src="https://github.com/user-attachments/assets/e6ca5fe2-ea7f-483c-8d81-ead67110f81c" />
<img width="600" height="266" alt="image" src="https://github.com/user-attachments/assets/b619b633-c4b5-4b22-8eb6-c7a084a9d3ea" />


**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.
