### PR TITLE
fix(recover action): set recovery die as Healing damage

### DIFF
--- a/src/packs/actions/basic/recover.json
+++ b/src/packs/actions/basic/recover.json
@@ -29,8 +29,8 @@
             }
         },
         "damage": {
-            "formula": null,
-            "type": null
+            "formula": "@recovery.die.derived",
+            "type": "heal"
         }
     },
     "effects": [],
@@ -39,5 +39,16 @@
         "default": 0
     },
     "flags": {},
+    "_stats": {
+        "coreVersion": "13.351",
+        "systemId": "cosmere-rpg",
+        "systemVersion": "3.0.0",
+        "createdTime": null,
+        "modifiedTime": 1784942489160,
+        "lastModifiedBy": "IU6D3nXFOOMkkx7E",
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null
+    },
     "_key": "!items!Y9lzSbkmwGg7mN61"
 }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Set's the Recover action's damage to `@recovery.die.derived` with type Healing

**Related Issue**  
Closes #877 

**How Has This Been Tested?**  
Used action from actor sheet to confirm it rolls correctly

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
