### PR TITLE
fix(item events): update use-item handler to roll default action for non-action items and use generic document matching

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -998,15 +998,7 @@
                             },
                             "use-item": {
                                 "Title": "Use item",
-                                "Description": "Uses an item by rolling it.",
-                                "Target": {
-                                    "Label": "Target",
-                                    "Choices": {
-                                        "self": "Self",
-                                        "sibling": "Other on same Actor",
-                                        "global": "Global"
-                                    }
-                                },
+                                "Description": "Uses an item by rolling it. If the selected item is not an action, that item's default action is used instead.",
                                 "UUID": {
                                     "Label": "Item"
                                 },

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -69,7 +69,7 @@ export function EphemeralEmbeddedDocumentsMixin<
 
                     const ephemeralDocuments = generatorFn
                         .call(this as unknown as DocumentOfType<DocumentType>)
-                        .map((doc) => {
+                        .map((doc, i) => {
                             // Get document constructor
                             const cls = doc.constructor as new (
                                 ...args: unknown[]
@@ -78,7 +78,7 @@ export function EphemeralEmbeddedDocumentsMixin<
                             const data = foundry.utils.mergeObject(
                                 doc.toObject(),
                                 {
-                                    _id: doc.id ?? foundry.utils.randomID(), // Ensure id is set
+                                    _id: `ephdoc${i.toFixed().padStart(10, '0')}`, // Assign deterministic id
                                     flags: {
                                         [SYSTEM_ID]: {
                                             meta: {

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -415,9 +415,7 @@ export class CosmereItem<
     }
 
     public get isStrikeAction(): boolean {
-        return (
-            this.isDefaultActivation && !!this.getFlag(SYSTEM_ID, 'isStrike')
-        );
+        return this.isDefaultAction && !!this.getFlag(SYSTEM_ID, 'isStrike');
     }
 
     public get isEphemeral(): boolean {
@@ -449,27 +447,31 @@ export class CosmereItem<
      * Currently checks equipped state for equippable items.
      */
     public get hasUsableActions(): boolean {
-        return !this.isEquippable() || this.system.equipped 
+        return !this.isEquippable() || this.system.equipped
             ? this.hasActions
-            : false
+            : false;
     }
 
     public get actions(): readonly ActionItem[] {
         return this.items.filter((item) => item.isAction());
     }
 
+    public get defaultAction(): ActionItem | null {
+        return this.actions.at(0) ?? null;
+    }
+
     /**
-     * Whether or not this action is the default activation for its parent item.
+     * Whether or not this action is the default for its parent item.
      * Only available for action items that are embedded in other items.
      */
-    public get isDefaultActivation(): boolean {
+    public get isDefaultAction(): boolean {
         if (
             !this.isAction() ||
             !this.parent ||
             !(this.parent instanceof CosmereItem)
         )
             return false;
-        return this.parent.actions.at(0)?.id === this.id;
+        return this.defaultAction?.id === this.id;
     }
 
     /**

--- a/src/system/hooks/item-event-system/handlers/use-item.ts
+++ b/src/system/hooks/item-event-system/handlers/use-item.ts
@@ -3,23 +3,56 @@ import { HandlerType, Event } from '@system/types/item/event-system';
 import { AdvantageMode } from '@system/types/roll';
 
 // Utils
-import { ItemTarget, MatchMode, matchItems } from './utils';
+import { matchDocuments } from '@system/utils/match-document';
+
+// Fields
+import { MatchDocumentField } from '@system/data/fields/match-document-field';
 
 // Constants
 import { SYSTEM_ID } from '@system/constants';
 import { TEMPLATES } from '@system/utils/templates';
 
-interface UseItemHandlerConfigData {
-    target: ItemTarget;
-    uuid?: string | null;
-    matchMode?: MatchMode | null;
-    matchAll?: boolean | null;
-    fastForward: boolean;
-    advantageMode: AdvantageMode;
-    plotDie: boolean;
-    temporaryModifiers?: string;
-    temporaryDamageModifiers?: string;
-}
+const SCHEMA = {
+    matchDocument: new MatchDocumentField({
+        type: 'Item',
+        required: true,
+        label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.AddActions}.Target.Label`,
+    }),
+    fastForward: new foundry.data.fields.BooleanField({
+        initial: true,
+        label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.FastForward.Label`,
+        hint: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.FastForward.Hint`,
+    }),
+    advantageMode: new foundry.data.fields.StringField({
+        initial: AdvantageMode.None,
+        choices: {
+            [AdvantageMode.None]: `DICE.AdvantageMode.None`,
+            [AdvantageMode.Advantage]: `DICE.AdvantageMode.Advantage`,
+            [AdvantageMode.Disadvantage]: `DICE.AdvantageMode.Disadvantage`,
+        },
+        label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.AdvantageMode.Label`,
+    }),
+    plotDie: new foundry.data.fields.BooleanField({
+        initial: false,
+        label: 'DICE.Plot.RaiseTheStakes',
+    }),
+    temporaryModifiers: new foundry.data.fields.StringField({
+        initial: '',
+        label: `DICE.TemporaryBonus.Label`,
+        hint: `DICE.TemporaryBonus.Hint`,
+    }),
+    temporaryDamageModifiers: new foundry.data.fields.StringField({
+        initial: '',
+        label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.TemporaryDamageModifiers.Label`,
+        hint: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.TemporaryDamageModifiers.Hint`,
+    }),
+} as const;
+
+type UseItemHandlerConfigData = foundry.data.fields.SchemaField.InitializedData<
+    typeof SCHEMA
+> & {
+    matchDocument: MatchDocumentField.InitializedType;
+};
 
 export function register() {
     cosmereRPG.api.registerItemEventHandlerType({
@@ -28,101 +61,25 @@ export function register() {
         label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Title`,
         description: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.Description`,
         config: {
-            schema: {
-                target: new foundry.data.fields.StringField({
-                    choices: {
-                        [ItemTarget.Self]: `COSMERE.Item.EventSystem.Event.Handler.General.Target.Choices.${ItemTarget.Self}`,
-                        [ItemTarget.Sibling]: `COSMERE.Item.EventSystem.Event.Handler.General.Target.Choices.${ItemTarget.Sibling}`,
-                        [ItemTarget.EquippedWeapon]: `COSMERE.Item.EventSystem.Event.Handler.General.Target.Choices.${ItemTarget.EquippedWeapon}`,
-                        [ItemTarget.EquippedArmor]: `COSMERE.Item.EventSystem.Event.Handler.General.Target.Choices.${ItemTarget.EquippedArmor}`,
-                        [ItemTarget.Global]: `COSMERE.Item.EventSystem.Event.Handler.General.Target.Choices.${ItemTarget.Global}`,
-                    },
-                    initial: ItemTarget.Sibling,
-                    required: true,
-                    blank: false,
-                    label: `COSMERE.Item.EventSystem.Event.Handler.General.Target.Label`,
-                }),
-                uuid: new foundry.data.fields.DocumentUUIDField({
-                    type: 'Item',
-                    initial: null,
-                    nullable: true,
-                    label: 'Item',
-                }),
-                matchMode: new foundry.data.fields.StringField({
-                    nullable: true,
-                    initial: MatchMode.Identifier,
-                    choices: {
-                        [MatchMode.Identifier]: `COSMERE.Item.EventSystem.Event.Handler.General.MatchMode.Choices.${MatchMode.Identifier}`,
-                        [MatchMode.Name]: `COSMERE.Item.EventSystem.Event.Handler.General.MatchMode.Choices.${MatchMode.Name}`,
-                        [MatchMode.UUID]: `COSMERE.Item.EventSystem.Event.Handler.General.MatchMode.Choices.${MatchMode.UUID}`,
-                    },
-                    label: `COSMERE.Item.EventSystem.Event.Handler.General.MatchMode.Label`,
-                    hint: `COSMERE.Item.EventSystem.Event.Handler.General.MatchMode.Hint`,
-                }),
-                matchAll: new foundry.data.fields.BooleanField({
-                    initial: false,
-                    nullable: true,
-                    label: `COSMERE.Item.EventSystem.Event.Handler.General.MatchAll.Label`,
-                    hint: `COSMERE.Item.EventSystem.Event.Handler.General.MatchAll.Hint`,
-                }),
-                fastForward: new foundry.data.fields.BooleanField({
-                    initial: true,
-                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.FastForward.Label`,
-                    hint: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.FastForward.Hint`,
-                }),
-                advantageMode: new foundry.data.fields.StringField({
-                    initial: AdvantageMode.None,
-                    choices: {
-                        [AdvantageMode.None]: `DICE.AdvantageMode.None`,
-                        [AdvantageMode.Advantage]: `DICE.AdvantageMode.Advantage`,
-                        [AdvantageMode.Disadvantage]: `DICE.AdvantageMode.Disadvantage`,
-                    },
-                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.AdvantageMode.Label`,
-                }),
-                plotDie: new foundry.data.fields.BooleanField({
-                    initial: false,
-                    label: 'DICE.Plot.RaiseTheStakes',
-                }),
-                temporaryModifiers: new foundry.data.fields.StringField({
-                    initial: '',
-                    label: `DICE.TemporaryBonus.Label`,
-                    hint: `DICE.TemporaryBonus.Hint`,
-                }),
-                temporaryDamageModifiers: new foundry.data.fields.StringField({
-                    initial: '',
-                    label: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.TemporaryDamageModifiers.Label`,
-                    hint: `COSMERE.Item.EventSystem.Event.Handler.Types.${HandlerType.UseItem}.TemporaryDamageModifiers.Hint`,
-                }),
-            },
+            schema: SCHEMA,
             template: `${TEMPLATES.DIRECTORY}${TEMPLATES.IES_HANDLER_USE_ITEM}`,
         },
         executor: async function (
             this: UseItemHandlerConfigData,
             event: Event.UseItem,
         ) {
-            if (
-                !event.item.actor &&
-                (this.target === ItemTarget.Sibling ||
-                    this.target === ItemTarget.EquippedWeapon ||
-                    this.target === ItemTarget.EquippedArmor)
-            )
-                return;
-            if (
-                !this.uuid &&
-                (this.target === ItemTarget.Sibling ||
-                    this.target === ItemTarget.Global)
-            )
-                return;
-            if (this.target === ItemTarget.Self && event.type === 'use') return;
+            // Get matched items
+            const items = (
+                await matchDocuments({
+                    ...this.matchDocument,
+                    relativeTo: event.item,
+                })
+            ).filter((doc) => doc instanceof CosmereItem);
+            if (items.length === 0) return;
 
-            // Get the item(s) to use
-            const itemsToUse = await matchItems(
-                event.item,
-                this.target,
-                this.uuid ?? null,
-                this.matchMode ?? MatchMode.Identifier,
-                this.matchAll ?? false,
-            );
+            const actions = items
+                .map((item) => (item.isAction() ? item : item.defaultAction))
+                .filter((action) => !!action);
 
             const configurable =
                 !this.fastForward || (event.options?.configurable ?? true);
@@ -135,18 +92,18 @@ export function register() {
             const plotDie = this.plotDie || !!event.options?.plotDie;
 
             await Promise.all(
-                itemsToUse.map((item) =>
-                    item.use({
+                actions.map((action) =>
+                    action.use({
                         configurable,
                         advantageMode,
                         plotDie,
                         temporaryModifiers: this.temporaryModifiers,
 
-                        ...(item.hasDamage()
+                        ...(action.hasDamage()
                             ? {
                                   damage: {
                                       overrideFormula: [
-                                          item.system.damage.formula ?? '',
+                                          action.system.damage.formula ?? '',
                                           this.temporaryDamageModifiers,
                                       ]
                                           .filter((v) => !!v)

--- a/src/system/utils/migration/migrations/2.1-3.0.ts
+++ b/src/system/utils/migration/migrations/2.1-3.0.ts
@@ -101,7 +101,7 @@ interface UserItemEventHandler {
     type: 'use-item';
     target: string;
     uuid?: string;
-    matchMode?: 'identifier' | 'name' | 'uuid';
+    matchMode?: 'identifier' | 'name' | 'uuid' | 'document-type';
     matchAll?: boolean;
 }
 
@@ -273,9 +273,9 @@ async function migrateEventsItem(
                         steps: [
                             {
                                 target: rule.handler.target,
-                                documentType: 'Item',
                                 reference: rule.handler.uuid,
-                                matchBy: rule.handler.matchMode,
+                                matchBy: 'document-type',
+                                documentType: 'Item',
                                 matchMode: rule.handler.matchAll
                                     ? 'all'
                                     : 'first',

--- a/src/system/utils/migration/migrations/2.1-3.0.ts
+++ b/src/system/utils/migration/migrations/2.1-3.0.ts
@@ -81,6 +81,30 @@ interface ActivationData {
     };
 }
 
+interface EventsItemData {
+    events: Record<string, EventRuleData>;
+}
+
+interface EventRuleData<THandler extends EventHandler = UnknownHandler> {
+    id: string;
+    event: string;
+    handler: THandler;
+}
+
+type EventHandler = UnknownHandler | UserItemEventHandler;
+
+interface UnknownHandler {
+    type: string;
+}
+
+interface UserItemEventHandler {
+    type: 'use-item';
+    target: string;
+    uuid?: string;
+    matchMode?: 'identifier' | 'name' | 'uuid';
+    matchAll?: boolean;
+}
+
 let logger: Logger;
 
 export default {
@@ -110,30 +134,21 @@ async function migrateGlobalItems(
     items: RawDocumentData[],
     compendium?: CompendiumCollection.Any,
 ) {
-    const actionItems = items.filter((i) => i.type === 'action');
-
-    for (const item of actionItems) {
+    for (const item of items) {
         const document = await getPossiblyInvalidDocument<Item.Implementation>(
             'Item',
             item._id,
             compendium,
         );
 
-        await migrateAction(item, document);
-    }
+        if (item.type === 'action') await migrateAction(item, document);
+        else if (isActivatableItemData(item)) {
+            await migrateActivatableItem(item, document);
+        }
 
-    const activatableItems = items.filter((i) =>
-        ACTIVATABLE_ITEM_TYPES.includes(i.type),
-    ) as RawDocumentData<ActivationData>[];
-
-    for (const item of activatableItems) {
-        const document = await getPossiblyInvalidDocument<Item.Implementation>(
-            'Item',
-            item._id,
-            compendium,
-        );
-
-        await migrateActivatableItem(item, document);
+        if (isEventsItemData(item)) {
+            await migrateEventsItem(item, document);
+        }
     }
 }
 
@@ -152,28 +167,21 @@ async function migrateGlobalActors(
                     compendium,
                 );
 
-            const actionItems = data.items.filter((i) => i.type === 'action');
-
-            for (const item of actionItems) {
-                const document = actor.items.get(item._id, {
+            for (const itemData of data.items) {
+                const item = actor.items.get(itemData._id, {
                     invalid: true,
                     strict: true,
                 }) as Item.Implementation;
 
-                await migrateAction(item, document);
-            }
+                if (itemData.type === 'action') {
+                    await migrateAction(itemData, item);
+                } else if (isActivatableItemData(itemData)) {
+                    await migrateActivatableItem(itemData, item);
+                }
 
-            const activatableItems = data.items.filter((i) =>
-                ACTIVATABLE_ITEM_TYPES.includes(i.type),
-            ) as RawDocumentData<ActivationData>[];
-
-            for (const item of activatableItems) {
-                const document = actor.items.get(item._id, {
-                    invalid: true,
-                    strict: true,
-                }) as Item.Implementation;
-
-                await migrateActivatableItem(item, document);
+                if (isEventsItemData(itemData)) {
+                    await migrateEventsItem(itemData, item);
+                }
             }
         } catch (err: unknown) {
             handleDocumentMigrationError(err, 'Actor', data);
@@ -237,6 +245,51 @@ async function migrateActivatableItem(
                 },
             );
         }
+    } catch (err: unknown) {
+        handleDocumentMigrationError(err, 'Item', data);
+    }
+}
+
+async function migrateEventsItem(
+    data: RawDocumentData<EventsItemData>,
+    document: Item.Implementation,
+) {
+    try {
+        logger.debug('Migrating events for item', { raw: data });
+
+        const eventsChanges: Record<string, AnyMutableObject> = {};
+        Object.values(data.system.events).forEach((rule) => {
+            // 'use' event is only available on actions in 3.0
+            if (rule.event === 'use' && data.type !== 'action') {
+                eventsChanges[rule.id] ??= {};
+                eventsChanges[rule.id].event = 'use-action';
+            }
+
+            if (hasUseItemHandler(rule)) {
+                eventsChanges[rule.id] ??= {};
+                eventsChanges[rule.id].handler = {
+                    matchDocument: {
+                        steps: [
+                            {
+                                target: rule.handler.target,
+                                documentType: 'Item',
+                                reference: rule.handler.uuid,
+                                matchBy: rule.handler.matchMode,
+                                matchMode: rule.handler.matchAll
+                                    ? 'all'
+                                    : 'first',
+                            },
+                        ],
+                    },
+                };
+            }
+        });
+
+        await document.update({
+            system: {
+                events: eventsChanges,
+            },
+        });
     } catch (err: unknown) {
         handleDocumentMigrationError(err, 'Item', data);
     }
@@ -378,6 +431,24 @@ function migrateActionData(
 }
 
 /* --- Helpers --- */
+
+function isActivatableItemData(
+    data: RawDocumentData<object>,
+): data is RawDocumentData<ActivationData> {
+    return ACTIVATABLE_ITEM_TYPES.includes(data.type);
+}
+
+function isEventsItemData(
+    data: RawDocumentData<object>,
+): data is RawDocumentData<EventsItemData> {
+    return 'events' in data.system;
+}
+
+function hasUseItemHandler(
+    data: EventRuleData,
+): data is EventRuleData<UserItemEventHandler> {
+    return data.handler.type === 'use-item';
+}
 
 function damageFormulaToDieSizeAndCount(
     formula?: string,

--- a/src/system/utils/migration/migrations/2.1-3.0.ts
+++ b/src/system/utils/migration/migrations/2.1-3.0.ts
@@ -268,21 +268,45 @@ async function migrateEventsItem(
 
             if (hasUseItemHandler(rule)) {
                 eventsChanges[rule.id] ??= {};
-                eventsChanges[rule.id].handler = {
-                    matchDocument: {
-                        steps: [
-                            {
-                                target: rule.handler.target,
-                                reference: rule.handler.uuid,
-                                matchBy: 'document-type',
-                                documentType: 'Item',
-                                matchMode: rule.handler.matchAll
-                                    ? 'all'
-                                    : 'first',
+                switch (rule.handler.target) {
+                    case 'sibling':
+                    case 'global':
+                        eventsChanges[rule.id].handler = {
+                            matchDocument: {
+                                steps: [
+                                    {
+                                        target: rule.handler.target,
+                                        reference: rule.handler.uuid,
+                                        matchBy: rule.handler.matchMode,
+                                        documentType: 'Item',
+                                        matchMode: rule.handler.matchAll
+                                            ? 'all'
+                                            : 'first',
+                                    },
+                                ],
                             },
-                        ],
-                    },
-                };
+                        };
+                        break;
+
+                    case 'equipped-weapon':
+                    case 'equipped-armor':
+                        eventsChanges[rule.id].handler = {
+                            matchDocument: {
+                                steps: [
+                                    {
+                                        target: rule.handler.target,
+                                        reference: rule.handler.uuid,
+                                        matchBy: 'document-type',
+                                        documentType: 'Item',
+                                        matchMode: rule.handler.matchAll
+                                            ? 'all'
+                                            : 'first',
+                                    },
+                                ],
+                            },
+                        };
+                        break;
+                }
             }
         });
 

--- a/src/templates/item/event-system/handlers/use-item.hbs
+++ b/src/templates/item/event-system/handlers/use-item.hbs
@@ -1,73 +1,16 @@
 {{!-- Target --}}
-{{#unless (eq event "use")}}
-    {{formGroup handler.schema.fields.target
-        name="handler.target"
-        value=handler.target
-        localize=true
-    }}
-{{else}}
-    {{formGroup handler.schema.fields.target
-        name="handler.target"
-        value=handler.target
-        localize=true
-        choices=(filterSelectOptions handler.schema.fields.target.choices "self")
-    }}
-{{/unless}}
-
-{{!-- UUID --}}
-{{#if (or (eq handler.target "sibling") (eq handler.target "global"))}}
-    <div class="form-group">
-        <label>
-            {{localize handler.schema.fields.uuid.label}}
-        </label>
-        <div class="form-fields">
-            {{app-document-reference-input 
-                name="handler.uuid"
-                value=handler.uuid
-                type="Item"
-                placeholder="Drag and drop item here"
-            }}
-        </div>
+<div class="form-group">
+    <label >
+        {{localize handler.schema.fields.matchDocument.label}}
+    </label>
+    <div class="form-fields">
+        {{app-match-document-target
+            value=handler.matchDocument
+            name="handler.matchDocument"
+            relativeTo=item
+        }}
     </div>
-{{/if}}
-
-{{!-- Match Mode --}}
-{{#if (eq handler.target "sibling")}}
-    <div class="form-group">
-        <label>
-            {{localize handler.schema.fields.matchMode.label}}
-            <i class="info fa-regular fa-circle-question" 
-                data-tooltip="{{localize handler.schema.fields.matchMode.hint}}"
-            ></i>
-        </label>
-        <div class="form-fields">
-            {{formInput handler.schema.fields.matchMode
-                name="handler.matchMode"
-                value=handler.matchMode
-                localize=true
-            }}
-        </div>
-    </div>
-{{/if}}
-
-{{!-- Match All --}}
-{{#if (or (and (eq handler.target "sibling") (not (eq handler.matchMode "uuid"))) (eq handler.target "equipped-weapon") (eq handler.target "equipped-armor"))}}
-    <div class="form-group">
-        <label>
-            {{localize handler.schema.fields.matchAll.label}}
-            <i class="info fa-regular fa-circle-question" 
-                data-tooltip="{{localize handler.schema.fields.matchAll.hint}}"
-            ></i>
-        </label>
-        <div class="form-fields">
-            {{formInput handler.schema.fields.matchAll
-                name="handler.matchAll"
-                value=handler.matchAll
-                localize=true
-            }}
-        </div>
-    </div>
-{{/if}}
+</div>
 
 {{#unless (eq event "use")}}
     {{!-- Fast forward --}}


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where the use-item handler was unable to be used with anything but actions. The handler will now use the default action for any non-action items. Also updated the handler to use the new generic document matching and implemented the necessary migrations.

Also includes a fix for ephemeral documents getting assigned a fresh uuid every time their data preparation workflow runs, thus not being able to use them as reference item for document matching.

**Related Issue**  
Closes #881 

**How Has This Been Tested?**  
_Behaviour_
1. Create talent
2. Create weapon
3. Add action to talent
4. Add event rule to talent
5. Set rule trigger to "Action used"
6. Set rule handler to "Use item"
7. Edit target
8. Set relation to "Equipped weapon"
9. Set match by to "Document type"
10. Create character
11. Add talent and weapon to character
12. Equip weapon
13. Use talent action -> Ensure weapon strike is used

_Migration_
1. Load version 2.1 of system
2. Create world
3. Create talent
4. Create weapon
5. Set talent activation type to "Utility"
6. Set talent activation cost to 1 action
7. Add event rule to talent
8. Set rule trigger to "Used"
9. Set rule handler to "Use item"
10. Set target to "Equipped weapon"
11. Create character
12. Add talent and weapon to character
13. Return to setup and backup world
14. Close foundry and load system with this branch
15. Open foundry and load world
16. Ensure migration runs successfully
17. Validate talent event on character
18. Use talent action -> ensure weapon strike is used

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351