### PR TITLE
fix(actor sheets): add drag support for embedded actions

### DIFF
--- a/src/system/applications/actor/base.ts
+++ b/src/system/applications/actor/base.ts
@@ -152,9 +152,9 @@ export class BaseActorSheet<
         return this.isEditable;
     }
 
-    protected override _onDragStart(event: DragEvent) {
+    protected override async _onDragStart(event: DragEvent) {
         // Get dragged item
-        const item = AppUtils.getItemFromEvent(event, this.actor);
+        const item = await AppUtils.getItemFromEvent(event, this.actor);
         if (!item) return;
 
         const dragData = {

--- a/src/system/applications/actor/components/actions-list.ts
+++ b/src/system/applications/actor/components/actions-list.ts
@@ -321,7 +321,10 @@ export class ActorActionsListComponent extends ActorItemListComponent {
         increase = true,
     ) {
         // Get item
-        const item = AppUtils.getItemFromEvent(event, this.application.actor);
+        const item = await AppUtils.getItemFromEvent(
+            event,
+            this.application.actor,
+        );
         if (!item) return;
         if (!item.hasResources()) return;
         const primaryResource = item.system.primaryResource;

--- a/src/system/applications/actor/components/equipment-list.ts
+++ b/src/system/applications/actor/components/equipment-list.ts
@@ -50,14 +50,17 @@ export class ActorEquipmentListComponent extends ActorItemListComponent {
     };
     /* eslint-enable @typescript-eslint/unbound-method */
 
-    public static onToggleEquip(
+    public static async onToggleEquip(
         this: ActorEquipmentListComponent,
         event: Event,
     ) {
         if (!this.application.isEditable) return;
 
         // Get item
-        const item = AppUtils.getItemFromEvent(event, this.application.actor);
+        const item = await AppUtils.getItemFromEvent(
+            event,
+            this.application.actor,
+        );
         if (!item) return;
         if (!item.isEquippable()) return;
 
@@ -68,14 +71,17 @@ export class ActorEquipmentListComponent extends ActorItemListComponent {
         });
     }
 
-    public static onCycleEquip(
+    public static async onCycleEquip(
         this: ActorEquipmentListComponent,
         event: Event,
     ) {
         if (!this.application.isEditable) return;
 
         // Get item
-        const item = AppUtils.getItemFromEvent(event, this.application.actor);
+        const item = await AppUtils.getItemFromEvent(
+            event,
+            this.application.actor,
+        );
         if (!item) return;
         if (!item.isEquippable()) return;
 
@@ -148,7 +154,10 @@ export class ActorEquipmentListComponent extends ActorItemListComponent {
         increase = true,
     ) {
         // Get item
-        const item = AppUtils.getItemFromEvent(event, this.application.actor);
+        const item = await AppUtils.getItemFromEvent(
+            event,
+            this.application.actor,
+        );
         if (!item) return;
         if (!item.isPhysical()) return;
 
@@ -181,7 +190,10 @@ export class ActorEquipmentListComponent extends ActorItemListComponent {
         increase = true,
     ) {
         // Get item
-        const item = AppUtils.getItemFromEvent(event, this.application.actor);
+        const item = await AppUtils.getItemFromEvent(
+            event,
+            this.application.actor,
+        );
         if (!item) return;
         if (!item.hasResources()) return;
         const primaryResource = item.system.primaryResource;

--- a/src/system/applications/actor/components/injuries-list.ts
+++ b/src/system/applications/actor/components/injuries-list.ts
@@ -34,12 +34,12 @@ any> {
 
     /* --- Actions --- */
 
-    public static onDecreaseInjuryDuration(
+    public static async onDecreaseInjuryDuration(
         this: ActorInjuriesListComponent,
         event: Event,
     ) {
         // Get injury item
-        const injuryItem = AppUtils.getItemFromEvent(
+        const injuryItem = await AppUtils.getItemFromEvent(
             event,
             this.application.actor,
         );
@@ -55,12 +55,12 @@ any> {
         });
     }
 
-    public static onIncreaseInjuryDuration(
+    public static async onIncreaseInjuryDuration(
         this: ActorInjuriesListComponent,
         event: Event,
     ) {
         // Get injury item
-        const injuryItem = AppUtils.getItemFromEvent(
+        const injuryItem = await AppUtils.getItemFromEvent(
             event,
             this.application.actor,
         );
@@ -147,6 +147,7 @@ any> {
                     return {
                         ...item,
                         id: item.id,
+                        uuid: item.uuid,
                         type,
                         typeLabel: CONFIG.COSMERE.injury.types[type].label,
                         duration: item.system.duration,

--- a/src/system/applications/utils/index.ts
+++ b/src/system/applications/utils/index.ts
@@ -23,28 +23,29 @@ export function getItemUuidFromEvent(event: Event): string | undefined {
     return element.data('item-uuid') as string;
 }
 
-export function getItemFromEvent(
+export async function getItemFromEvent(
     event: Event,
     actor: CosmereActor,
-): CosmereItem | undefined {
-    // Get id
-    const itemId = getItemIdFromEvent(event);
+): Promise<CosmereItem | null> {
+    // Get uuid
+    const uuid = getItemUuidFromEvent(event);
+    if (!uuid) return null;
 
     // Find the item
-    return actor.items.find((i) => i.id === itemId);
+    return foundry.utils.fromUuid<CosmereItem>(uuid);
 }
 
-export function getItemFromElement(
+export async function getItemFromElement(
     element: HTMLElement,
     actor: CosmereActor,
-): CosmereItem | undefined {
-    // Get the id
-    const itemId = $(element)
-        .closest('.item[data-item-id]')
-        .data('item-id') as string;
+): Promise<CosmereItem | null> {
+    // Get the uuid
+    const uuid = $(element)
+        .closest('.item[data-item-uuid]')
+        .data('item-uuid') as string;
 
     // Find the item
-    return actor.items.find((i) => i.id === itemId);
+    return foundry.utils.fromUuid<CosmereItem>(uuid);
 }
 
 export default {

--- a/src/templates/actors/character/components/talents-list.hbs
+++ b/src/templates/actors/character/components/talents-list.hbs
@@ -33,6 +33,7 @@
 
                 <li class="item usable collapsible {{#if state.expanded}}expanded{{/if}}"
                     data-item-id="{{item.id}}"
+                    data-item-uuid="{{item.uuid}}"
                     {{#if @root.editable}}
                     data-drag="true"{{/if}}
                 >

--- a/src/templates/actors/components/equipment-list.hbs
+++ b/src/templates/actors/components/equipment-list.hbs
@@ -47,6 +47,7 @@
 
     <li class="item {{#if ctx.hasActivation}}usable{{/if}} collapsible {{#if state.expanded}}expanded{{/if}}"
         data-item-id="{{item.id}}"
+        data-item-uuid="{{item.uuid}}"
         {{#if @root.editable}}data-drag="true"{{/if}}
     >
         <section class="details">

--- a/src/templates/actors/components/injuries-list.hbs
+++ b/src/templates/actors/components/injuries-list.hbs
@@ -21,7 +21,7 @@
     </li>
 
     {{#each injuries as |injury|}}
-    <li class="item injury {{#if injury.isPermanent}}permanent{{/if}}" data-item-id="{{injury.id}}">
+    <li class="item injury {{#if injury.isPermanent}}permanent{{/if}}" data-item-id="{{injury.id}}" data-item-uuid="{{injury.uuid}}">
         <section class="details">
             <div class="img">
                 <img src="{{injury.img}}">


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Resolves issue causing embedded actions to have empty drop data (`{}`) after being dragged from actor sheet. This was caused by the actor sheet still assuming that all items in the list originate directly from the actor (thus not account for embedded items).

**Related Issue**  
Closes #879

**How Has This Been Tested?**  
1. Create weapon
2. Create character
3. Add weapon to character
4. Go to actions tab
5. On side menu go to items tab
6. Drag strike action from character sheet to global items
7. Open context menu for strike action, click view -> ensure strike action sheet is shown
8. Create equipment
9. Add charges resource set max > 1
10. Add equipment to character
11. Go to equipment tab
12. Increase equipment quantity
13. Decrease equipment quantity
14. Increase current charges
15. Decrease current charges
16. Open context menu, click edit -> ensure equipment sheet is shown
17. Go to effects and conditions tab
18. Add injury
19. Increase duration
20. Decrease duration
21. Open context menu, click edit -> ensure injury sheet is shown

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351