### PR TITLE
fix(starter rules): re-add resources to starter rules basic actions

### DIFF
--- a/src/packs/actions/basic/aid.json
+++ b/src/packs/actions/basic/aid.json
@@ -31,7 +31,27 @@
             ],
             "flavor": "",
             "plotDie": false,
-            "uses": null
+            "uses": null,
+            "consumption": [
+                {
+                    "type": "resource",
+                    "value": {
+                        "min": 1,
+                        "max": 1,
+                        "actual": 1
+                    },
+                    "resource": "foc",
+                    "matchDocument": {
+                        "steps": [
+                            {
+                                "target": "ancestor",
+                                "documentType": "Actor",
+                                "matchBy": "document-type"
+                            }
+                        ]
+                    }
+                }
+            ]
         },
         "damage": {
             "formula": null,

--- a/src/packs/actions/basic/dodge.json
+++ b/src/packs/actions/basic/dodge.json
@@ -31,7 +31,27 @@
             ],
             "flavor": "",
             "plotDie": false,
-            "uses": null
+            "uses": null,
+            "consumption": [
+                {
+                    "type": "resource",
+                    "value": {
+                        "min": 1,
+                        "max": 1,
+                        "actual": 1
+                    },
+                    "resource": "foc",
+                    "matchDocument": {
+                        "steps": [
+                            {
+                                "target": "ancestor",
+                                "documentType": "Actor",
+                                "matchBy": "document-type"
+                            }
+                        ]
+                    }
+                }
+            ]
         },
         "damage": {
             "formula": null,

--- a/src/packs/actions/basic/reactive-strike.json
+++ b/src/packs/actions/basic/reactive-strike.json
@@ -31,7 +31,27 @@
             ],
             "flavor": "",
             "plotDie": false,
-            "uses": null
+            "uses": null,
+            "consumption": [
+                {
+                    "type": "resource",
+                    "value": {
+                        "min": 1,
+                        "max": 1,
+                        "actual": 1
+                    },
+                    "resource": "foc",
+                    "matchDocument": {
+                        "steps": [
+                            {
+                                "target": "ancestor",
+                                "documentType": "Actor",
+                                "matchBy": "document-type"
+                            }
+                        ]
+                    }
+                }
+            ]
         },
         "damage": {
             "formula": null,

--- a/src/packs/actions/basic/recover.json
+++ b/src/packs/actions/basic/recover.json
@@ -26,11 +26,41 @@
                 "recharge": "per_scene",
                 "value": 1,
                 "max": 1
-            }
+            },
+            "consumption": [
+                {
+                    "type": "item_resource",
+                    "value": {
+                        "min": 1,
+                        "max": 1,
+                        "actual": 1
+                    },
+                    "resource": "uses",
+                    "matchDocument": {
+                        "steps": [
+                            {
+                                "target": "self",
+                                "documentType": "Actor",
+                                "reference": null,
+                                "matchBy": "document-type",
+                                "matchMode": "first"
+                            }
+                        ]
+                    }
+                }
+            ]
         },
         "damage": {
             "formula": "@recovery.die.derived",
             "type": "heal"
+        },
+        "primaryResource": "uses",
+        "resources": {
+            "uses": {
+                "value": 1,
+                "max": 1,
+                "recharge": "per_scene"
+            }
         }
     },
     "effects": [],


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Restores resource usages to aid, dodge, and reactive strike actions, and restores "uses" property to the Recover action

**Related Issue**  
Partially resolves #875 

**How Has This Been Tested?**  
Added all actions to a character sheet and verified that resources and consume costs appear appropriately

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.