### PR TITLE
fix(event system): make event system recurse through embedded items so modality events fire correctly

### DIFF
--- a/src/system/applications/utils/index.ts
+++ b/src/system/applications/utils/index.ts
@@ -31,7 +31,7 @@ export function getItemFromEvent(
     const itemId = getItemIdFromEvent(event);
 
     // Find the item
-    return actor.items.find((i) => i.id === itemId);
+    return actor.allItems.find((i) => i.id === itemId);
 }
 
 export function getItemFromElement(

--- a/src/system/documents/actor.ts
+++ b/src/system/documents/actor.ts
@@ -242,6 +242,13 @@ export class CosmereActor<
         return this.items.filter((i) => i.isEffectsContainer());
     }
 
+    public get allItems(): CosmereItem[] {
+        return Array.from(this.items).flatMap((item) => [
+            item,
+            ...item.allEmbeddedItems,
+        ]);
+    }
+
     public get skillLinkedItems(): CosmereItem[] {
         return this.items
             .filter(

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -449,13 +449,22 @@ export class CosmereItem<
      * Currently checks equipped state for equippable items.
      */
     public get hasUsableActions(): boolean {
-        return !this.isEquippable() || this.system.equipped 
+        return !this.isEquippable() || this.system.equipped
             ? this.hasActions
-            : false
+            : false;
     }
 
     public get actions(): readonly ActionItem[] {
         return this.items.filter((item) => item.isAction());
+    }
+
+    public get allEmbeddedItems(): readonly CosmereItem[] {
+        if (this.items) {
+            return Array.from(this.items).flatMap((item) => [
+                item,
+                ...item.allEmbeddedItems,
+            ]);
+        } else return [];
     }
 
     /**

--- a/src/system/hooks/actor.ts
+++ b/src/system/hooks/actor.ts
@@ -161,7 +161,7 @@ Hooks.on('updateActor', (actor: CosmereActor, changed: Actor.UpdateData) => {
             );
 
             // Get modality item for the current mode
-            const currentModalityItem = actor.items.find(
+            const currentModalityItem = actor.allItems.find(
                 (item) =>
                     item.hasId() &&
                     item.hasModality() &&
@@ -177,7 +177,7 @@ Hooks.on('updateActor', (actor: CosmereActor, changed: Actor.UpdateData) => {
             }
 
             // Get modality item for the new mode
-            const newModalityItem = actor.items.find(
+            const newModalityItem = actor.allItems.find(
                 (item) =>
                     item.hasId() &&
                     item.hasModality() &&

--- a/src/system/hooks/item-event-system/index.ts
+++ b/src/system/hooks/item-event-system/index.ts
@@ -136,7 +136,7 @@ Hooks.once('ready', () => {
                     const actor = document as CosmereActor;
 
                     // Handle the hook for all items
-                    await actor.items.reduce(async (prev, item) => {
+                    await actor.allItems.reduce(async (prev, item) => {
                         // Wait for the previous item to finish
                         await prev;
 


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Makes several different event system functions iterate through a new actor.allItems getter, so that they collect embedded items as well as non-embedded items.

**Related Issue**  
Closes #885 

**How Has This Been Tested?**  
Activated an embedded action with a modality and an "Activate Modality" event trigger, and observed that the event fired where previously it would not.

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.