### PR TITLE
fix(actor sheets): add check if resource is valid before running & posts warning

### DIFF
--- a/src/system/applications/actor/components/resource.ts
+++ b/src/system/applications/actor/components/resource.ts
@@ -98,6 +98,17 @@ export class ActorResourceComponent extends HandlebarsApplicationComponent<
     ) {
         // Get resource
         const resource = context.actor.system.resources[params.resource];
+        if (!(params.resource in CONFIG.COSMERE.resources)) {
+            console.warn(
+                "The resource key: '" +
+                    params.resource +
+                    "' does not exist in CONFIG.COSMERE.resources",
+            );
+            return Promise.resolve({
+                ...context,
+                resource: null,
+            });
+        }
 
         // Get resource config
         const config = CONFIG.COSMERE.resources[params.resource];

--- a/src/system/data/actor/common.ts
+++ b/src/system/data/actor/common.ts
@@ -734,6 +734,14 @@ export class CommonActorDataModel<
         (Object.keys(this.resources) as Resource[]).forEach((key) => {
             // Get the resource
             const resource = this.resources[key];
+            if (!(key in CONFIG.COSMERE.resources)) {
+                console.warn(
+                    "The resource key: '" +
+                        key +
+                        "' does not exist in CONFIG.COSMERE.resources",
+                );
+                return;
+            }
 
             // Get max
             const max = resource.max.value;


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Admittedly I think a cleaner fix is to just check upon applying active effects whether or not they exist preemptively. Though I'm not super confident changing the active effect code or overriding the super.apply, so I figured this is a good compromise and also informs the user if their attribute key for resources is incorrect in the console.

**Related Issue**  
Closes #886 

**How Has This Been Tested?**  
1. Create new character
2. Add item to character
3. add effect to item
4. set attribute key to `system.resources.health.value`, mode: add, value: 2
5. press submit changes and see that the character sheet remains open. 
6. Open console and see a new warning in the console informing the user of the issue

**Screenshots (if applicable)**  
<img width="1162" height="322" alt="image" src="https://github.com/user-attachments/assets/eb0e51bb-1294-403c-a474-202f50319a0b" />
<img width="1151" height="307" alt="image" src="https://github.com/user-attachments/assets/a3525be1-0110-4370-b7af-c1e2556108e8" />


**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] No part of this PR was created using generative AI tools.
- [X] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
It does produce 2 more warnings should the invalid behavior happen, but those warnings are intended.
