### PR TITLE
fix(migrations): Resolve 2.1-3.0 migration issues

### DIFF
--- a/src/system/utils/migration/migrations/2.1-3.0.ts
+++ b/src/system/utils/migration/migrations/2.1-3.0.ts
@@ -142,8 +142,9 @@ async function migrateGlobalActors(
     compendium?: CompendiumCollection.Any,
 ) {
     for (const data of actors) {
+        logger.debug('Migrating actor', { raw: data });
         try {
-            if (data.items.length === 0) return;
+            if (data.items.length === 0) continue;
 
             const actor =
                 await getPossiblyInvalidDocument<Actor.Implementation>(
@@ -261,6 +262,7 @@ function migrateActionData(
 ): ActionItemDataModel | null {
     const activation = data.system.activation;
     if (!activation) return null;
+    if (activation.type == ActivationType.None) return null;
 
     const id =
         data.system.id ??


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Makes sure we attempt migration for all actors, and when we migrate an item which was previously activatable, if it had an activation type of "none", don't create an embedded action for it

**Related Issue**  

**How Has This Been Tested?**  
Ran 2.1-3.0 migration for my personal Stormlight worlds, verified sanity on actors

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.
