### PR TITLE
fix(character sheets): Remove recharge text from actions list cost

### DIFF
--- a/src/templates/general/components/item-list-resource.hbs
+++ b/src/templates/general/components/item-list-resource.hbs
@@ -13,7 +13,7 @@
         <span>/</span>
         <span class="val">{{ctx.resource.max}}</span>
         <i class="{{ctx.resource.icon}}" data-tooltip={{ctx.resource.label}}></i>
-        {{#if ctx.resource.hasRecharge}}
+        {{#if (and ctx.resource.hasRecharge (not hideRecharge))}}
             <span>{{localize ctx.resource.rechargeLabel}}</span>
         {{/if}}
     </div>

--- a/src/templates/general/components/match-document-resource-target.hbs
+++ b/src/templates/general/components/match-document-resource-target.hbs
@@ -11,7 +11,7 @@
         {{/if}}
         {{#if hasResource}}
             {{#with (itemContext resolvedDocument) as |ctx|}}
-            {{> item-list-resource ctx=ctx showButtons=false}}
+            {{> item-list-resource ctx=ctx showButtons=false hideRecharge=true}}
             {{/with}}
         {{/if}}
     </a>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Removes the recharge text from the "cost" section of actions on lists

**Related Issue**  
Closes #890 

**How Has This Been Tested?**  
Added "Recharge" to a sheet, verified that the "Per Scene" text no longer appears on the "cost" section, but does still appear on the "resources" section

**Screenshots (if applicable)**  
<img width="551" height="124" alt="image" src="https://github.com/user-attachments/assets/66d3edf1-7fad-4722-89d8-f5e5f92c523d" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.