### PR TITLE
fix(ephemeral embedded documents): update ephemerality check to use _stats.createdTime instead of flag

### DIFF
--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -86,7 +86,16 @@ export function EphemeralEmbeddedDocumentsMixin<
                             return new cls(data, { parent: this });
                         });
 
-                    const concreteDocuments = Array.from(collection);
+                    const concreteDocuments = (
+                        Array.from(collection) as object[]
+                    ).filter(
+                        // Documents without _stats.createdTime are considered ephemeral
+                        (doc) =>
+                            !!foundry.utils.getProperty(
+                                doc,
+                                '_stats.createdTime',
+                            ),
+                    ) as DocumentOfType<EmbeddedTypesOf<DocumentType>>[];
 
                     collection.clear();
                     ephemeralDocuments.forEach((doc) => {

--- a/src/system/documents/ephemeral-embeds/mixin.ts
+++ b/src/system/documents/ephemeral-embeds/mixin.ts
@@ -79,28 +79,14 @@ export function EphemeralEmbeddedDocumentsMixin<
                                 doc.toObject(),
                                 {
                                     _id: doc.id ?? foundry.utils.randomID(), // Ensure id is set
-                                    flags: {
-                                        [SYSTEM_ID]: {
-                                            meta: {
-                                                isEphemeral: true,
-                                            },
-                                        },
-                                    },
                                 },
                             );
 
                             // Create new instance of document so we can assign the parent
                             return new cls(data, { parent: this });
                         });
-                    const concreteDocuments = (
-                        Array.from(collection) as object[]
-                    ).filter(
-                        (doc) =>
-                            !foundry.utils.getProperty(
-                                doc,
-                                `flags.${SYSTEM_ID}.meta.isEphemeral`,
-                            ),
-                    ) as DocumentOfType<EmbeddedTypesOf<DocumentType>>[];
+
+                    const concreteDocuments = Array.from(collection);
 
                     collection.clear();
                     ephemeralDocuments.forEach((doc) => {

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -421,7 +421,7 @@ export class CosmereItem<
     }
 
     public get isEphemeral(): boolean {
-        return this.getFlag(SYSTEM_ID, 'meta.isEphemeral');
+        return !foundry.utils.getProperty(this, '_stats.createdTime');
     }
 
     public get isActivatable(): boolean {
@@ -2284,10 +2284,8 @@ declare module '@league-of-foundry-developers/foundry-vtt-types/configuration' {
                 'sheet.mode': 'edit' | 'view';
                 meta: {
                     origin: ItemOrigin;
-                    isEphemeral?: boolean;
                 };
                 'meta.origin': ItemOrigin;
-                'meta.isEphemeral': boolean;
                 previousLevel?: number;
                 isStartingPath?: boolean;
                 isStrike?: boolean;

--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -267,6 +267,10 @@ async function getCRUDRequestTargets(
                     doc.updateSource({ _id: foundry.utils.randomID() });
                 }
 
+                doc.updateSource({
+                    '_stats.createdTime': Date.now(),
+                });
+
                 return doc;
             });
     } else if (isUpdateRequest(request)) {


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Changes the way we determine whether a document is ephemeral to use the `_stats.createdTime` field instead of relying on a flag (`meta.isEphemeral`). This makes ephemerality robust by definition, instead of something the system has to actively manage.

**Related Issue**  
Closes #892 

**How Has This Been Tested?**  
1. Create weapon
2. Go to action
3. View strike action
4. Copy it's uuid
5. Open console
6. Run: `(await Item.create(fromUuidSync('<uuid>').toObject())).getFlag('cosmere-rpg', 'meta.isEphemeral')`
7. Observe `undefined` being reported in console
8. Create character sheet
9. Add the created strike action to character sheet
10. Open context menu, delete strike action
11. Add weapon to actor
12. Equip weapon
13. Ensure embedded strike action is listed on actions list
14. Open context menu -> ensure embedded strike action cannot be deleted (only viewed)
15. Edit weapon
16. Add action
17. Delete added action from weapon sheet 
18. Add action
19. View actions tab on character sheet
20. Delete added action from character sheet

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351

**Additional context**  
Related to #883 
