### PR TITLE
Feat: Add Default Skill For Adversary Actions

### DIFF
--- a/src/system/data/item/action/fields/skill-test.ts
+++ b/src/system/data/item/action/fields/skill-test.ts
@@ -1,4 +1,4 @@
-import type { Skill, Attribute } from '@system/types/cosmere';
+import { type Attribute, ActionType, Skill } from '@system/types/cosmere';
 import { NONE } from '@system/types/utils';
 
 // Documents
@@ -65,15 +65,23 @@ export class SkillTestDataModel extends foundry.abstract.DataModel<
         const action = this.item;
 
         if (this.skill === 'default') {
-            if (
-                !action?.parent ||
-                !(action.parent instanceof CosmereItem) ||
-                !action.parent.isWeapon()
-            )
+            if (!action || !action.isAction() || !action.parent) {
                 return null;
+            }
 
-            const weaponType = action.parent.system.type;
-            const skill = CONFIG.COSMERE.items.weapon.types[weaponType]?.skill;
+            let skill;
+
+            if (action.system.type === ActionType.Adversary) {
+                skill = Skill.Athletics;
+            }
+            // not else if because we want weapon to take priority
+            if (
+                action.parent instanceof CosmereItem &&
+                action.parent.isWeapon()
+            ) {
+                const weaponType = action.parent.system.type;
+                skill = CONFIG.COSMERE.items.weapon.types[weaponType]?.skill;
+            }
 
             return skill ?? null;
         } else {


### PR DESCRIPTION
also allows for future expansion of default definition

<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Simple change to add adversary action type default skill for skill tests, set to Athletics.

**Related Issue**  
Closes #898

**How Has This Been Tested?**  
1. Find an adversary with 'Default' set as the skill-test for an action that also deal damage (must have skill of default too)
2. Roll the action
3. See the athletics score be added to skill test and damage

**Screenshots (if applicable)**  
N/A

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
N/A
