### PR TITLE
Feat: Restore `new` Field for Action and Features On Adversary Actors

### DIFF
--- a/src/system/applications/actor/components/adversary/actions-list.ts
+++ b/src/system/applications/actor/components/adversary/actions-list.ts
@@ -102,6 +102,14 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
         const section = {
             id: type,
             label: CONFIG.COSMERE.items.types[type].labelPlural,
+            createItemTooltip: game.i18n.format(
+                'COSMERE.Actor.Sheet.Actions.NewItem',
+                {
+                    type: game.i18n.localize(
+                        CONFIG.COSMERE.items.types[type].label,
+                    ),
+                },
+            ),
             default: true,
             filter: (item: CosmereItem) =>
                 // the item itself needs to be checked now, not its parent

--- a/src/system/applications/actor/components/adversary/actions-list.ts
+++ b/src/system/applications/actor/components/adversary/actions-list.ts
@@ -1,4 +1,9 @@
-import { ItemType } from '@system/types/cosmere';
+import {
+    ActionCostType,
+    ActionType,
+    ActivationType,
+    ItemType,
+} from '@system/types/cosmere';
 import { ItemListSection } from '@system/types/application/actor/components/item-list';
 
 // Documents
@@ -11,6 +16,7 @@ import {
 } from '../actions-list';
 import { SortMode } from '../search-bar';
 import { AppContextMenu } from '@src/system/applications/utils/context-menu';
+import { CosmereActor } from '@src/system/documents';
 
 // Constants
 
@@ -93,7 +99,7 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
     /* --- Helpers --- */
 
     private prepareSection(type: ItemType): ItemListSection {
-        return {
+        const section = {
             id: type,
             label: CONFIG.COSMERE.items.types[type].labelPlural,
             default: true,
@@ -102,6 +108,52 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
                 // and it seems the type is directly on the item rather than in its system
                 item.type === type,
         };
+
+        let creation = {};
+
+        switch (type) {
+            case ItemType.Action: {
+                creation = {
+                    new: (parent: CosmereActor) =>
+                        CosmereItem.create(
+                            {
+                                type: ItemType.Action,
+                                name: game.i18n.localize(
+                                    'COSMERE.Item.Type.Action.New',
+                                ),
+                                system: {
+                                    type: ActionType.Adversary,
+                                    activation: {
+                                        type: ActivationType.Utility,
+                                        cost: {
+                                            type: ActionCostType.Action,
+                                            value: 1,
+                                        },
+                                    },
+                                },
+                            },
+                            { parent },
+                        ) as Promise<CosmereItem>,
+                };
+                break;
+            }
+            case ItemType.Trait: {
+                creation = {
+                    new: (parent: CosmereActor) =>
+                        CosmereItem.create(
+                            {
+                                type: ItemType.Trait,
+                                name: game.i18n.localize(
+                                    'COSMERE.Item.Type.Trait.New',
+                                ),
+                            },
+                            { parent },
+                        ) as Promise<CosmereItem>,
+                };
+                break;
+            }
+        }
+        return { ...section, ...creation };
     }
 
     private async prepareSectionData(
@@ -150,6 +202,7 @@ export class AdversaryActionsListComponent extends ActorActionsListComponent {
             itemData: await this.prepareItemData(sectionActions.flat().flat()),
         };
     }
+
     public _onInitialize(): void {
         if (this.application.isEditable) {
             // Create context menu


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Simply defines a `new` field on the actions and features sections of the adversary.

**Related Issue**  
Closes #899

**How Has This Been Tested?**  
1. Open an adversary sheet
2. See the + button on the two noted sections
3. Click the plus on Features
4. Ensure it's the correct item type
5. Click the plus on Actions
6. Ensure it is the correct item type, and that Adversary Action is set in the details tab.

**Screenshots (if applicable)**  
<img width="1050" height="575" alt="image" src="https://github.com/user-attachments/assets/43c9bc64-15f4-4742-bd7c-6b83534a4be0" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: [insert version here].

**Additional context**  
N/A
