### PR TITLE
fix: modifies grabbing of item from uuid to function with compendiums

### DIFF
--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -402,6 +402,9 @@ export class BaseItemSheet extends TabsApplicationMixin(
         const itemUuid = AppUtils.getItemUuidFromEvent(event);
         if (!itemUuid) return;
 
+        const eventItem = this.item.getEmbeddedItemFromUuid(itemUuid);
+        if (!eventItem) return;
+
         const dragData = {
             type: 'Item',
             uuid: itemUuid,

--- a/src/system/applications/item/base.ts
+++ b/src/system/applications/item/base.ts
@@ -400,12 +400,11 @@ export class BaseItemSheet extends TabsApplicationMixin(
     protected override _onDragStart(event: DragEvent) {
         // Get dragged item
         const itemUuid = AppUtils.getItemUuidFromEvent(event);
-        const item = fromUuidSync(itemUuid);
-        if (!item) return;
+        if (!itemUuid) return;
 
         const dragData = {
             type: 'Item',
-            uuid: item.uuid,
+            uuid: itemUuid,
         };
 
         // Set data transfer

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -476,7 +476,12 @@ export class CosmereItem<
      */
     public getEmbeddedItemFromUuid(uuid: string): CosmereItem | null {
         const parsedUuid = foundry.utils.parseUuid(uuid);
-        if (!parsedUuid || parsedUuid.primaryId !== this.id) {
+        if (!parsedUuid) {
+            console.warn(`UUID "${uuid}" could not be parsed`);
+            return null;
+        }
+
+        if (parsedUuid.primaryId !== this.id) {
             console.warn(`UUID "${uuid}" does not belong to "${this.name}"`);
             return null;
         }

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -469,6 +469,37 @@ export class CosmereItem<
         } else return [];
     }
 
+    /** Returns an embedded item found in this item if it exists.
+     *
+     * @param uuid The UUID of the embedded item you want to get.
+     * @returns A {@link CosmereItem} or null if no document could be found.
+     */
+    public getEmbeddedItemFromUuid(uuid: string): CosmereItem | null {
+        const parsedUuid = foundry.utils.parseUuid(uuid);
+        if (!parsedUuid || parsedUuid.primaryId !== this.id) {
+            console.warn(`UUID "${uuid}" does not belong to "${this.name}"`);
+            return null;
+        }
+
+        if (parsedUuid.type !== 'Item') {
+            console.warn(`UUID "${uuid}" is not an Item`);
+            return null;
+        }
+
+        const item = this.allEmbeddedItems.find(
+            (item) => item.id === parsedUuid.id,
+        );
+
+        if (!item) {
+            console.warn(
+                `"${this.name}" does not contain an embedded item with ID "${parsedUuid.id}"`,
+            );
+            return null;
+        }
+
+        return item;
+    }
+
     /**
      * Whether or not this action is the default for its parent item.
      * Only available for action items that are embedded in other items.


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Currently when starting to drag an embedded action in a compendium item, it runs into an error as it's using fromUuidSync and that does not work with compendium items. From what I can tell, there is no reason for _onDragStart to actually get the item itself aside from checking if said item exists. I figure just checking if the uuid exists after trying to grab it from the event is enough of a check.

After the changes, theres a new function to get embedded items which is used instead. This functions for both compendium items and regular items.

**Related Issue**  
Closes #904 

**How Has This Been Tested?**  
1. Create new item compendium
2. add talent
3. add action to talent
4. Drag embedded action in talent to world items
5. drag talent to world items
6. create folder in compendium
7. drag talent into folder
8. drag folder to world items

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] No part of this PR was created using generative AI tools.
- [X] I have tested my changes on Foundry VTT version: 13.351.
