### PR TITLE
fix: updates getters for skill test rolls and damage rolls to include skill mod bonuses

### DIFF
--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1868,33 +1868,22 @@ export class CosmereItem<
     }
 
     protected getDamageRollData(
-        skillId: Skill | null | undefined,
-        attributeId: Attribute | null | undefined,
+        skillId: Skill | null,
+        attributeId: Attribute | null,
         actor: CosmereActor,
     ): DamageRollData {
-        const skill = skillId ? actor.system.skills[skillId] : undefined;
+        const skill = skillId
+            ? actor.system.skills[skillId]
+            : {
+                  attribute: attributeId ?? Attribute.Strength,
+                  rank: 0,
+                  mod: { bonus: 0 },
+              };
         const attribute = attributeId
-            ? attributeId
-                ? actor.system.attributes[attributeId]
-                : { value: 0, bonus: 0 }
-            : undefined;
-        let mod;
-        if (skill === undefined || attribute === undefined) {
-            ui.notifications.warn(
-                "Skill: '" +
-                    skillId +
-                    "' or Attribute: '" +
-                    attributeId +
-                    "' is undefined.",
-            );
-            mod = 0;
-        } else {
-            mod =
-                skill.rank +
-                skill.mod.bonus +
-                attribute.value +
-                attribute.bonus;
-        }
+            ? actor.system.attributes[attributeId]
+            : { value: 0, bonus: 0 };
+        const mod =
+            skill.rank + skill.mod.bonus + attribute.value + attribute.bonus;
 
         return {
             ...actor.getRollData(),

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -813,7 +813,9 @@ export class CosmereItem<
                           )
                         : `${game.i18n.localize('GENERIC.Custom')} ${game.i18n.localize('GENERIC.Skill')}`
                 })`,
-                defaultAttribute: skill.attribute ? skill.attribute : undefined,
+                defaultAttribute: data.skill.attribute
+                    ? data.skill.attribute
+                    : undefined,
                 parts: parts,
                 plotDie: options.plotDie ?? this.system.skillTest.plotDie,
                 opportunity:

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1843,11 +1843,12 @@ export class CosmereItem<
     ): D20RollData {
         const skill = skillId
             ? actor.system.skills[skillId]
-            : { attribute: null, rank: 0, mod: 0 };
+            : { attribute: null, rank: 0, mod: { bonus: 0 } };
         const attribute = attributeId
             ? actor.system.attributes[attributeId]
             : { value: 0, bonus: 0 };
-        const mod = skill.rank + attribute.value + attribute.bonus;
+        const mod =
+            skill.rank + skill.mod.bonus + attribute.value + attribute.bonus;
 
         return {
             ...actor.getRollData(),
@@ -1855,8 +1856,7 @@ export class CosmereItem<
             skill: {
                 id: skillId ?? null,
                 rank: skill.rank,
-                mod:
-                    typeof skill.mod === 'number' ? skill.mod : skill.mod.value,
+                mod,
                 attribute: attributeId ? attributeId : skill.attribute,
             },
             attribute: attribute.value,
@@ -1878,12 +1878,23 @@ export class CosmereItem<
                 ? actor.system.attributes[attributeId]
                 : { value: 0, bonus: 0 }
             : undefined;
-        const mod =
-            skill !== undefined || attribute !== undefined
-                ? (skill?.rank ?? 0) +
-                  (attribute?.value ?? 0) +
-                  (attribute?.bonus ?? 0)
-                : undefined;
+        let mod;
+        if (skill === undefined || attribute === undefined) {
+            ui.notifications.warn(
+                "Skill: '" +
+                    skillId +
+                    "' or Attribute: '" +
+                    attributeId +
+                    "' is undefined.",
+            );
+            mod = 0;
+        } else {
+            mod =
+                skill.rank +
+                skill.mod.bonus +
+                attribute.value +
+                attribute.bonus;
+        }
 
         return {
             ...actor.getRollData(),
@@ -1892,7 +1903,7 @@ export class CosmereItem<
                 ? {
                       id: skillId!,
                       rank: skill.rank,
-                      mod: skill.mod.value,
+                      mod,
                       attribute: attributeId! ? attributeId : skill.attribute,
                   }
                 : undefined,


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes issue where skill mod bonuses are not included in the skill test roll and damage roll.

**Related Issue**  
Closes #906 and Closes #912

**How Has This Been Tested?**  
1. Create new adversary
2. Give adversary long spear
3. Give adversary 3 ranks in heavy weaponry
4. Give adversary 3 strength
5. Add passive effect to long spear
6. Go to changes and add new change: Attribute key: `system.skills.hwp.mod.bonus`, change mode: `add`, value: `4`.
7. Use spear strike action
8. See that it rolls 1d20+10 for skill test and 1d8+10 for damage.
9. Use spear strike action and set attribute to speed
10. See that skill test chat says "SPD" not "STR"

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
