### PR TITLE
fix(documents): add automatic assignment of _stats.createdTime for any retrieved document

### DIFF
--- a/src/system/documents/system-embedded-collections/utils/socket.ts
+++ b/src/system/documents/system-embedded-collections/utils/socket.ts
@@ -935,6 +935,16 @@ export function toClientViewObject(
             );
         });
 
+    // Workaround for when Foundry doesn't assign `_stats.createdTime`
+    if (!foundry.utils.getProperty(data, '_stats.createdTime')) {
+        foundry.utils.setProperty(
+            data,
+            '_stats.createdTime',
+            foundry.utils.getProperty(data, '_stats.modifiedTime') ??
+                Date.now(),
+        );
+    }
+
     return toDocument
         ? new (cls as Document.Constructable.AnyConstructor)(data, { parent })
         : data;


### PR DESCRIPTION
**Type**  
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Resolves the issue of `_stats.createdTime` not getting assigned for embedded documents when importing the parent, by injecting it into the data when retrieving any document (if it's not present).

This resolves the issue of imported actors having all their items treated as ephemeral.

**Related Issue**  
Closes #908 

**How Has This Been Tested?**  
1. Import actor from compendium
2. Open actor sheet
3. Open context menu on any item
4. Ensure edit / remove options are present

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351