### PR TITLE
fix(character sheets): notes collapse on rerender#627

### DIFF
--- a/src/system/applications/actor/base.ts
+++ b/src/system/applications/actor/base.ts
@@ -489,22 +489,25 @@ export class BaseActorSheet<
         let enrichedAppearanceValue = undefined;
         let enrichedNotesValue = undefined;
         if (this.actor.system.biography) {
-            enrichedBiographyValue = await TextEditor.enrichHTML(
-                this.actor.system.biography,
-                { relativeTo: this.document },
-            );
+            enrichedBiographyValue =
+                await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+                    this.actor.system.biography,
+                    { relativeTo: this.document },
+                );
         }
         if (this.actor.system.appearance) {
-            enrichedAppearanceValue = await TextEditor.enrichHTML(
-                this.actor.system.appearance,
-                { relativeTo: this.document },
-            );
+            enrichedAppearanceValue =
+                await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+                    this.actor.system.appearance,
+                    { relativeTo: this.document },
+                );
         }
         if (this.actor.system.notes) {
-            enrichedNotesValue = await TextEditor.enrichHTML(
-                this.actor.system.notes,
-                { relativeTo: this.document },
-            );
+            enrichedNotesValue =
+                await foundry.applications.ux.TextEditor.implementation.enrichHTML(
+                    this.actor.system.notes,
+                    { relativeTo: this.document },
+                );
         }
 
         // separating this as most times one or both can be shortcutted

--- a/src/system/applications/actor/base.ts
+++ b/src/system/applications/actor/base.ts
@@ -244,10 +244,10 @@ export class BaseActorSheet<
         event.stopPropagation();
 
         // Get html field element
-        const fieldElement = $(event.target!).closest('[field-type]');
+        const fieldElement = $(event.target!).closest('[data-field-type]');
 
         // Get field type
-        const proseFieldType = fieldElement.attr('field-type')!;
+        const proseFieldType = fieldElement.data('field-type')! as string;
 
         // Gets the field to display based on the type found
         if (proseFieldType === 'biography') {

--- a/src/system/applications/actor/components/notes-fields.ts
+++ b/src/system/applications/actor/components/notes-fields.ts
@@ -23,7 +23,7 @@ interface NotesSection {
     editLabel: string;
 
     /**
-     * htmlField
+     * variable name for the htmlField.
      */
     htmlField: string;
 }

--- a/src/system/applications/actor/components/notes-fields.ts
+++ b/src/system/applications/actor/components/notes-fields.ts
@@ -23,7 +23,7 @@ interface NotesSection {
     editLabel: string;
 
     /**
-     * variable name for the htmlField.
+     * label/id for the target html field
      */
     htmlField: string;
 }

--- a/src/system/applications/actor/components/notes-fields.ts
+++ b/src/system/applications/actor/components/notes-fields.ts
@@ -4,6 +4,34 @@ import { BaseActorSheet, BaseActorSheetRenderContext } from '../base';
 import { SYSTEM_ID } from '@src/system/constants';
 import { TEMPLATES } from '@src/system/utils/templates';
 
+type NotesSectionType = 'biography' | 'appearance' | 'notes';
+
+interface NotesSection {
+    /**
+     * The id of the section
+     */
+    id: string;
+
+    /**
+     * Nicely formatted label for the section
+     */
+    label: string;
+
+    /**
+     * Nicely formatted edit label for the section
+     */
+    editLabel: string;
+
+    /**
+     * htmlField
+     */
+    htmlField: string;
+}
+
+interface NotesSectionState {
+    expanded?: boolean;
+}
+
 export class ActorNotesFieldsComponent extends HandlebarsApplicationComponent<// typeof BaseActorSheet
 // TODO: Resolve typing issues
 // NOTE: Use any as workaround for foundry-vtt-types issues
@@ -11,11 +39,46 @@ export class ActorNotesFieldsComponent extends HandlebarsApplicationComponent<//
 any> {
     static TEMPLATE = `${TEMPLATES.DIRECTORY}${TEMPLATES.ACTOR_BASE_NOTES_FIELDS}`;
 
-    public _prepareContext(
+    protected sectionState: Record<string, NotesSectionState> = {};
+    private sectionType: string[] = ['biography', 'appearance', 'notes'];
+    private sections: NotesSection[] = [];
+
+    public async _prepareContext(
         params: unknown,
         context: BaseActorSheetRenderContext,
     ) {
-        return Promise.resolve({ ...context });
+        this.sectionType.forEach((type) => {
+            if (!(type in this.sectionState)) {
+                this.sectionState[type] = {
+                    expanded: false,
+                };
+            }
+        });
+
+        this.sections = [
+            this.prepareSection('appearance'),
+            this.prepareSection('biography'),
+            this.prepareSection('notes'),
+        ];
+
+        return Promise.resolve({
+            ...context,
+            sections: this.sections,
+            sectionState: this.sectionState,
+        });
+    }
+
+    protected prepareSection(type: NotesSectionType): NotesSection {
+        return {
+            id: type,
+            label: game.i18n.localize(
+                `COSMERE.Actor.Sheet.Details.${type.capitalize()}.Label`,
+            ),
+            editLabel: game.i18n.localize(
+                `COSMERE.Actor.Sheet.Details.${type.capitalize()}.Edit`,
+            ),
+            htmlField: `${type}Html`,
+        };
     }
 
     protected _onRender(params: AnyObject): void {
@@ -29,8 +92,18 @@ any> {
     /* --- Event handlers --- */
 
     private onClickCollapsible(event: JQuery.ClickEvent) {
-        const target = event.currentTarget as HTMLElement;
-        target?.parentElement?.classList.toggle('expanded');
+        // Get element from event
+        const target = $(event.target).closest('.html-field');
+
+        // Get the section id
+        const sectionId = target.data('field-type') as string;
+
+        // Update the section state
+        this.sectionState[sectionId].expanded =
+            !this.sectionState[sectionId].expanded;
+
+        // Set classes
+        target.toggleClass('expanded', this.sectionState[sectionId].expanded);
     }
 }
 

--- a/src/templates/actors/components/notes-fields.hbs
+++ b/src/templates/actors/components/notes-fields.hbs
@@ -1,53 +1,23 @@
 <div class="html-field-list">
-    <div class="html-field collapsible {{#if @root.biographyHtml}}expanded{{/if}}" field-type="biography">
-        <h2 class="header">
-            <span class="title">{{localize "COSMERE.Actor.Sheet.Details.Biography.Label"}}</span>
-            {{#if @root.editable}}
-            <a role="button" data-action="edit-html-field" data-tooltip="COSMERE.Actor.Sheet.Details.Biography.Edit">
-                <i class="edit-img fa-solid fa-feather"></i>
-            </a>
-            {{else}}
-            <a><i class="fa-solid fa-lock"></i></a>
-            {{/if}}
-        </h2>
-        <div class="collapsible-content">
-            <div class="wrapper">
-                {{{@root.biographyHtml}}}
+    {{#each @root.sections as |section|}}
+    {{#with (lookup @root.sectionState section.id) as |sectionState|}}
+        <div class="html-field collapsible {{#if sectionState.expanded}}expanded{{/if}}" data-field-type="{{section.id}}">
+            <h2 class="header">
+                <span class="title">{{localize section.label}}</span>
+                {{#if @root.editable}}
+                <a role="button" data-action="edit-html-field" data-tooltip="{{localize section.editLabel}}">
+                    <i class="edit-img fa-solid fa-feather"></i>
+                </a>
+                {{else}}
+                <a><i class="fa-solid fa-lock"></i></a>
+                {{/if}}
+            </h2>
+            <div class="collapsible-content">
+                <div class="wrapper">
+                    {{{lookup @root section.htmlField}}}
+                </div>
             </div>
         </div>
-    </div>
-    <div class="html-field collapsible {{#if @root.appearanceHtml}}expanded{{/if}}" field-type="appearance">
-        <h2 class="header">
-            <span class="title">{{localize "COSMERE.Actor.Sheet.Details.Appearance.Label"}}</span>
-            {{#if @root.editable}}
-            <a role="button" data-action="edit-html-field" data-tooltip="COSMERE.Actor.Sheet.Details.Appearance.Edit">
-                <i class="edit-img fa-solid fa-feather"></i>
-            </a>
-            {{else}}
-            <a><i class="fa-solid fa-lock"></i></a>
-            {{/if}}
-        </h2>
-        <div class="collapsible-content">
-            <div class="wrapper">
-                {{{@root.appearanceHtml}}}
-            </div>
-        </div>
-    </div>
-    <div class="html-field collapsible" field-type="notes">
-        <h2 class="header">
-            <span class="title">{{localize "COSMERE.Actor.Sheet.Details.Notes.Label"}}</span>
-            {{#if @root.editable}}
-            <a role="button" data-action="edit-html-field" data-tooltip="COSMERE.Actor.Sheet.Details.Notes.Edit">
-                <i class="edit-img fa-solid fa-feather"></i>
-            </a>
-            {{else}}
-            <a><i class="fa-solid fa-lock"></i></a>
-            {{/if}}
-        </h2>
-        <div class="collapsible-content">
-            <div class="wrapper">
-                {{{@root.notesHtml}}}
-            </div>
-        </div>
-    </div>
+    {{/with}}
+    {{/each}}
 </div>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where upon rerendering the expanded sections in the notes tab would collapse.

Also cuts out some repetitive code and updates some deprecated calls.

**Related Issue**  
Closes #627 

**How Has This Been Tested?**  
1. Create new character
2. Go to notes
3. Edit appearance
4. Write some stuff idk
5. Save it
6. Expand appearance
7. Expand skills in the left side of the sheet
8. Change focus
9. See that in both instances appearance expanded.

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._
<img width="548" height="600" alt="97c8210b36b504511b1ef0814f748853" src="https://github.com/user-attachments/assets/047a5c4e-6c6d-4bd5-b876-f70dffcd0389" />

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
