### PR TITLE
fix(rolls): constants are not properly calculated #915

### DIFF
--- a/src/system/dice/damage-roll.ts
+++ b/src/system/dice/damage-roll.ts
@@ -134,15 +134,8 @@ export class DamageRoll extends foundry.dice.Roll<DamageRollData> {
             const diceRolls = $(tooltip).find('.roll.die');
             const firstPart = $(tooltip).find('.tooltip-part').first();
 
-            let total = 0;
-            $(tooltip)
-                .find('.value')
-                .each((_index, value) => {
-                    total += Number($(value).text());
-                });
-
             firstPart.find('.dice-rolls').empty().append(diceRolls);
-            firstPart.find('.value').text(total);
+            firstPart.find('.value').text(String(this.total));
 
             const tooltipFinal = $(tooltip)
                 .find('.dice-tooltip')

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -696,7 +696,7 @@ export class CosmereChatMessage<
         if (constant === 0) return;
 
         const sign = constant < 0 ? '-' : '+';
-        const newTotal = Number(html.find('.value').text()) + constant;
+        const newTotal = Number(html.find('.value').text());
 
         if (roll.hasDice) html.find('.value').text(newTotal);
 

--- a/src/system/documents/chat-message.ts
+++ b/src/system/documents/chat-message.ts
@@ -20,7 +20,7 @@ import { getSystemSetting, KEYBINDINGS, SETTINGS } from '@system/settings';
 import {
     areKeysPressed,
     getApplyTargets,
-    getConstantFromRoll,
+    getValuesFromRoll,
     TargetDescriptor,
 } from '@system/utils/generic';
 import { renderSystemTemplate, TEMPLATES } from '@system/utils/templates';
@@ -237,7 +237,23 @@ export class CosmereChatMessage<
 
         const section = $(sectionHTML as unknown as HTMLElement);
         const tooltip = section.find('.dice-tooltip');
-        this.enrichD20Tooltip(d20Roll as unknown as Roll, tooltip[0]); // TEMP: Workaround
+
+        // Overwrite die roll results to include multiplied/divided bonuses
+        const dieRolls = tooltip.find('.dice').toArray();
+        const bonuses = getValuesFromRoll(d20Roll as unknown as Roll);
+        for (const [index, dieRoll] of dieRolls.entries()) {
+            const dieRollValue = dieRoll.querySelector('.value');
+            if (dieRollValue)
+                dieRollValue.textContent = bonuses[index].result.toString();
+            const dieRolls = dieRoll.querySelector('.dice-rolls');
+            if (dieRolls) {
+                const constant = document.createElement('li');
+                constant.classList.add('constant');
+                constant.textContent = bonuses[index].math;
+                dieRolls.append(constant);
+            }
+        }
+        this.enrichD20Tooltip(bonuses[bonuses.length - 1].result, tooltip[0]); // TEMP: Workaround
         tooltip.prepend(section.find('.dice-formula'));
 
         html.find('.chat-card').append(section);
@@ -458,7 +474,16 @@ export class CosmereChatMessage<
 
         const section = $(sectionHTML as unknown as HTMLElement);
         const tooltip = section.find('.dice-tooltip');
-        this.enrichD20Tooltip(injuryRoll as unknown as Roll, tooltip[0]); // TEMP: Workaround
+
+        // Overwrite die roll results to include multiplied/divided bonuses
+        const dieRolls = tooltip.find('.dice').toArray();
+        const bonuses = getValuesFromRoll(injuryRoll as unknown as Roll);
+        for (const [index, dieRoll] of dieRolls.entries()) {
+            const dieRollValue = dieRoll.querySelector('.value');
+            if (dieRollValue)
+                dieRollValue.textContent = bonuses[index].result.toString();
+        }
+        this.enrichD20Tooltip(bonuses[bonuses.length - 1].result, tooltip[0]); // TEMP: Workaround
         tooltip.prepend(section.find('.dice-formula'));
 
         if (game.user.isGM || this.isAuthor) {
@@ -692,7 +717,8 @@ export class CosmereChatMessage<
         html.find('.label').text(type);
         html.find('.label').parent().prepend(icon);
 
-        const constant = getConstantFromRoll(roll as unknown as Roll); // TEMP: Workaround
+        const values = getValuesFromRoll(roll as unknown as Roll); // TEMP: Workaround
+        const constant = values[values.length - 1].result;
         if (constant === 0) return;
 
         const sign = constant < 0 ? '-' : '+';
@@ -717,8 +743,7 @@ export class CosmereChatMessage<
      * @param roll The roll instance.
      * @param html The roll tooltip markup.
      */
-    protected enrichD20Tooltip(roll: Roll, html: HTMLElement) {
-        const constant = getConstantFromRoll(roll as unknown as Roll); // TEMP: Workaround
+    protected enrichD20Tooltip(constant: number, html: HTMLElement) {
         if (constant === 0) return;
 
         const sign = constant < 0 ? '-' : '+';

--- a/src/system/utils/generic.ts
+++ b/src/system/utils/generic.ts
@@ -172,21 +172,114 @@ export function isFastForward() {
 }
 
 /**
- * Computes the constant value of a roll (i.e. total of numeric terms).
- * @param roll The roll to calculate the constant total from.
- * @returns The total constant value.
+ * Separates bonuses and returns an array containing the final number and the math sorted by first die roll + additional die rolls + ... + loose bonus numbers.
+ * @param roll The roll to calculate the values from.
+ * @returns An array of objects containing the value of a roll or constant and their respective math equations
  */
-export function getConstantFromRoll(roll: Roll) {
-    const dieResult = roll.dice.reduce((sum, die) => {
-        if (die.total) {
-            return sum + die.total;
+export function getValuesFromRoll(roll: Roll) {
+    // Separate die rolls and their multiplications / divisions from other terms
+    const groups: foundry.dice.terms.RollTerm[][] = [];
+    let currentGroup: foundry.dice.terms.RollTerm[] = [];
+    for (const term of roll.terms) {
+        // If it encounters + or -, push to groups and clear, UNLESS group.length is 0.
+        if (
+            term instanceof foundry.dice.terms.OperatorTerm &&
+            (term.operator === '+' || term.operator === '-')
+        ) {
+            // If currentGroup is empty, then operator decides whether this initially starts negative or positive.
+            if (currentGroup.length === 0) {
+                currentGroup.push(term);
+            } else {
+                // Otherwise, push the group and empty it then add the new term operator to cleared currentGroup.
+                groups.push(currentGroup);
+                currentGroup = [];
+                currentGroup.push(term);
+            }
         } else {
-            return sum;
+            currentGroup.push(term);
         }
-    }, 0);
-    const total = roll.total ? roll.total : 0;
+    }
+    groups.push(currentGroup);
 
-    return total - dieResult;
+    console.log(groups);
+
+    // multiply and divide roll results and add to final bonus. Its important to keep the die rolls in order of how they will appear
+    const finalNumbers: { result: number; math: string }[] = [];
+    let finalBonus = 0;
+
+    for (const group of groups) {
+        let groupResult = 0;
+        let sign = 1;
+        let operator = '*';
+        let hasDie = false;
+
+        let math = '';
+        // All terms in one group should only consist of die rolls except the first, numbers and * or /. Thus, we can perform all operations on the bonus variable
+        for (const [index, term] of group.entries()) {
+            // Handle Operators
+            if (term instanceof foundry.dice.terms.OperatorTerm) {
+                // A + or - at the start determines the sign of the whole group
+                if (index === 0) {
+                    if (term.operator === '-') sign = -1;
+                    continue;
+                }
+
+                if (term.operator === '*' || term.operator === '/') {
+                    operator = term.operator;
+                }
+
+                continue;
+            }
+
+            // Get the value of a die or number
+            let value: number | undefined;
+            if (term instanceof foundry.dice.terms.DiceTerm) {
+                hasDie = true;
+                value = term.total;
+            } else if (term instanceof foundry.dice.terms.NumericTerm) {
+                value = term.total;
+            }
+
+            if (value === undefined) continue;
+
+            // If its the first number, add it to groupResult
+            if (groupResult === 0) {
+                groupResult = value;
+                continue;
+            }
+
+            // If its the second number, apply number with stored operator
+            if (operator === '*') {
+                groupResult *= value;
+                math += `* ${value}`;
+            } else if (operator === '/') {
+                groupResult /= value;
+                math += `/ ${value}`;
+            }
+        }
+
+        // Apply original sign (either 1 or -1)
+        groupResult *= sign;
+
+        // Add result to finalNumbers or to finalBonus depending on
+        // whether or not this bonus was tied to a die roll.
+        if (hasDie) {
+            finalNumbers.push({
+                result: groupResult,
+                math,
+            });
+        } else {
+            finalBonus += groupResult;
+        }
+    }
+
+    // Add the finalBonus to the array at the end
+    finalNumbers.push({
+        result: finalBonus,
+        math: finalBonus >= 0 ? `+${finalBonus}` : `${finalBonus}`,
+    });
+
+    return finalNumbers;
 }
 
 /**

--- a/src/system/utils/generic.ts
+++ b/src/system/utils/generic.ts
@@ -177,29 +177,16 @@ export function isFastForward() {
  * @returns The total constant value.
  */
 export function getConstantFromRoll(roll: Roll) {
-    let previous: unknown;
-    let constant = 0;
-
-    for (const term of roll.terms) {
-        if (term instanceof foundry.dice.terms.NumericTerm) {
-            if (
-                previous instanceof foundry.dice.terms.OperatorTerm &&
-                previous.operator === '-'
-            ) {
-                constant -= term.number;
-            } else {
-                constant += term.number;
-            }
-        } else if (term instanceof foundry.dice.terms.FunctionTerm) {
-            if (typeof term.total === 'number') {
-                constant += term.total;
-            }
+    const dieResult = roll.dice.reduce((sum, die) => {
+        if (die.total) {
+            return sum + die.total;
+        } else {
+            return sum;
         }
+    }, 0);
+    const total = roll.total ? roll.total : 0;
 
-        previous = term;
-    }
-
-    return constant;
+    return total - dieResult;
 }
 
 /**


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes several small issues with how we are handling the tooltip calculations and getting constants

**Related Issue**  
Closes #915 

**How Has This Been Tested?**  
1. Create new actor
2. Add new action to actor
3. Set action to skill test
4. Add to roll formula extension: 2*10
5. Add damage to action: 2d4+2*10
6. Use action
7. See the tooltip calculations now match the result.

**Screenshots (if applicable)**  
<img width="280" height="490" alt="image" src="https://github.com/user-attachments/assets/ddf8745f-1764-4e51-9b6d-3d9781d289b7" />

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] No part of this PR was created using generative AI tools.
- [X] I have tested my changes on Foundry VTT version: 13.351.
