### PR TITLE
fix(damage rolls): adds checks to ensure skill and attribute exists

### DIFF
--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -911,7 +911,9 @@ export class CosmereItem<
 
         // Get the attribute id
         const attributeId =
-            options.attribute ??
+            (options.attribute && actor.system.attributes[options.attribute]
+                ? options.attribute
+                : null) ??
             (activatable ? this.system.damage.resolvedAttribute : null);
 
         // Set up data

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -1910,16 +1910,18 @@ export class CosmereItem<
         attributeId: Attribute | null,
         actor: CosmereActor,
     ): DamageRollData {
-        const skill = skillId
-            ? actor.system.skills[skillId]
-            : {
-                  attribute: attributeId ?? Attribute.Strength,
-                  rank: 0,
-                  mod: { bonus: 0 },
-              };
-        const attribute = attributeId
+        // Get skill and ensure skill actually exists, if it doesnt then create an empty skill
+        const skill = (skillId ? actor.system.skills[skillId] : null) ?? {
+            attribute: attributeId ?? Attribute.Strength,
+            rank: 0,
+            mod: { bonus: 0 },
+        };
+
+        // Get attribute and ensure attribute actually exists, if it doesnt then create an empty attribute
+        const attribute = (attributeId
             ? actor.system.attributes[attributeId]
-            : { value: 0, bonus: 0 };
+            : null) ?? { value: 0, bonus: 0 };
+
         const mod =
             skill.rank + skill.mod.bonus + attribute.value + attribute.bonus;
 

--- a/src/system/documents/item.ts
+++ b/src/system/documents/item.ts
@@ -904,11 +904,10 @@ export class CosmereItem<
 
         // Get the skill id
         const skillId =
-            options.skill ??
+            (options.skill && actor.system.skills[options.skill]
+                ? options.skill
+                : null) ??
             (activatable ? this.system.damage.resolvedSkill : null);
-
-        // Get the skill
-        const skill = skillId ? actor.system.skills[skillId] : undefined;
 
         // Get the attribute id
         const attributeId =


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Fixes an issue where getDamageRollData was sometimes given "default" as an attribute and skill id, which it can't resolve correctly.
This fix adds a check in getDamageRollData to ensure if it happens again, it wont break.

This fix also adds a check in the offending part of the code that calls getDamageRollData with the invalid Ids.
I'm not sure if this part of the code works as intended as written as it does not seem to resolve default? I decided to leave it be as I'm uncertain if this is doing what it is supposed to do or not.

**Related Issue**  
Closes #929 

**How Has This Been Tested?**  
1. Open new character
2. Go to actions
3. create new action
4. give action a skill test and set damage to 1d4 impact
5. use action
6. roll
7. see that it no longer produces errors and posts to the chat.

**Screenshots (if applicable)**  
_Add screenshots or GIFs that help illustrate the changes, especially if they affect the UI or user-facing aspects of the system._

**Checklist:**  
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] My changes do not introduce any new warnings or errors.
- [X] My PR does not contain any copyrighted works that I do not have permission to use.
- [X] No part of this PR was created using generative AI tools.
- [X] I have tested my changes on Foundry VTT version: 13.351.

**Additional context**  
_Add any other context or information here that would be useful for reviewers._
As mentioned earlier in the description, the section of code under the method "rollDamage" might not be properly resolving "default" to the default skill. As I'm unfamiliar with how we do default, and I don't want to spend too much time figuring it out, I decided to make a straight forward fix. 